### PR TITLE
fix: add missing `await` when verifying pincode

### DIFF
--- a/server/routers/resource/authWithPincode.ts
+++ b/server/routers/resource/authWithPincode.ts
@@ -117,7 +117,7 @@ export async function authWithPincode(
             );
         }
 
-        const validPincode = verifyPassword(
+        const validPincode = await verifyPassword(
             pincode,
             definedPincode.pincodeHash
         );


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description
When using a PIN, Pangolin grants access regardless of whether the PIN is correct or not.
This PR fixes that by waiting for the promise (`validPincode` ends up as a `Promise` and evaluates as a thruthy value wether the pin is correct or not).

Closes #74 

## How to test?
Create a PIN code for a resource, then try any password when accessing it.
