### PR TITLE
fix(bandwidth): Record correct megaBytesIn/megaBytesOut

### DIFF
--- a/server/routers/gerbil/receiveBandwidth.ts
+++ b/server/routers/gerbil/receiveBandwidth.ts
@@ -59,8 +59,8 @@ export const receiveBandwidth = async (
                 await trx
                     .update(sites)
                     .set({
-                        megabytesOut: (site.megabytesIn || 0) + bytesIn,
-                        megabytesIn: (site.megabytesOut || 0) + bytesOut,
+                        megabytesIn: (site.megabytesIn || 0) + bytesIn,
+                        megabytesOut: (site.megabytesOut || 0) + bytesOut,
                         lastBandwidthUpdate: new Date().toISOString(),
                         online
                     })

--- a/server/routers/gerbil/receiveBandwidth.ts
+++ b/server/routers/gerbil/receiveBandwidth.ts
@@ -59,8 +59,8 @@ export const receiveBandwidth = async (
                 await trx
                     .update(sites)
                     .set({
-                        megabytesIn: (site.megabytesIn || 0) + bytesIn,
-                        megabytesOut: (site.megabytesOut || 0) + bytesOut,
+                        megabytesOut: (site.megabytesOut || 0) + bytesIn,
+                        megabytesIn: (site.megabytesIn || 0) + bytesOut,
                         lastBandwidthUpdate: new Date().toISOString(),
                         online
                     })


### PR DESCRIPTION
## Description
Bandwidth is switching side every time new bandwidth is received

<img width="440" alt="Screenshot 2025-03-28 at 00 27 53" src="https://github.com/user-attachments/assets/d2ee1090-b331-4fca-a4dc-7683ebb044d1" />
<img width="509" alt="Screenshot 2025-03-28 at 00 27 41" src="https://github.com/user-attachments/assets/3a670516-f073-4e93-9041-8b5cc478d2e6" />



This fixes this issue.