### PR TITLE
Add ability for sticky sessions to backend resource.

### DIFF
--- a/server/db/schemas/schema.ts
+++ b/server/db/schemas/schema.ts
@@ -77,7 +77,10 @@ export const resources = sqliteTable("resources", {
     applyRules: integer("applyRules", { mode: "boolean" })
         .notNull()
         .default(false),
-    enabled: integer("enabled", { mode: "boolean" }).notNull().default(true)
+    enabled: integer("enabled", { mode: "boolean" }).notNull().default(true),
+    stickySession: integer("stickySession", { mode: "boolean" })
+        .notNull()
+        .default(false)
 });
 
 export const targets = sqliteTable("targets", {

--- a/server/routers/resource/updateResource.ts
+++ b/server/routers/resource/updateResource.ts
@@ -42,7 +42,8 @@ const updateHttpResourceBodySchema = z
         isBaseDomain: z.boolean().optional(),
         applyRules: z.boolean().optional(),
         domainId: z.string().optional(),
-        enabled: z.boolean().optional()
+        enabled: z.boolean().optional(),
+        stickySession: z.boolean().optional()
     })
     .strict()
     .refine((data) => Object.keys(data).length > 0, {

--- a/server/routers/traefik/getTraefikConfig.ts
+++ b/server/routers/traefik/getTraefikConfig.ts
@@ -40,7 +40,8 @@ export async function traefikConfigProvider(
                     org: {
                         orgId: orgs.orgId
                     },
-                    enabled: resources.enabled
+                    enabled: resources.enabled,
+                    stickySession: resources.stickySession
                 })
                 .from(resources)
                 .innerJoin(sites, eq(sites.siteId, resources.siteId))
@@ -275,7 +276,18 @@ export async function traefikConfigProvider(
                                         url: `${target.method}://${ip}:${target.internalPort}`
                                     };
                                 }
-                            })
+                            }),
+                        ...(resource.stickySession
+                            ? {
+                                  sticky: {
+                                      cookie: {
+                                          name: "pangolin_sticky",
+                                          secure: resource.ssl,
+                                          httpOnly: true
+                                      }
+                                  }
+                              }
+                            : {})
                     }
                 };
             } else {
@@ -335,7 +347,18 @@ export async function traefikConfigProvider(
                                         address: `${ip}:${target.internalPort}`
                                     };
                                 }
-                            })
+                            }),
+                        ...(resource.stickySession
+                            ? {
+                                  sticky: {
+                                      cookie: {
+                                          name: "pangolin_sticky",
+                                          secure: resource.ssl,
+                                          httpOnly: true
+                                      }
+                                  }
+                              }
+                            : {})
                     }
                 };
             }

--- a/server/routers/traefik/getTraefikConfig.ts
+++ b/server/routers/traefik/getTraefikConfig.ts
@@ -103,7 +103,10 @@ export async function traefikConfigProvider(
                             [badgerMiddlewareName]: {
                                 apiBaseUrl: new URL(
                                     "/api/v1",
-                                    `http://${config.getRawConfig().server.internal_hostname}:${
+                                    `http://${
+                                        config.getRawConfig().server
+                                            .internal_hostname
+                                    }:${
                                         config.getRawConfig().server
                                             .internal_port
                                     }`
@@ -351,10 +354,9 @@ export async function traefikConfigProvider(
                         ...(resource.stickySession
                             ? {
                                   sticky: {
-                                      cookie: {
-                                          name: "pangolin_sticky",
-                                          secure: resource.ssl,
-                                          httpOnly: true
+                                      ipStrategy: {
+                                          depth: 0,
+                                          sourcePort: true
                                       }
                                   }
                               }

--- a/server/setup/migrations.ts
+++ b/server/setup/migrations.ts
@@ -19,7 +19,7 @@ import m15 from "./scripts/1.0.0-beta15";
 import m16 from "./scripts/1.0.0";
 import m17 from "./scripts/1.1.0";
 import m18 from "./scripts/1.2.0";
-
+import m19 from "./scripts/1.3.0";
 // THIS CANNOT IMPORT ANYTHING FROM THE SERVER
 // EXCEPT FOR THE DATABASE AND THE SCHEMA
 
@@ -37,7 +37,8 @@ const migrations = [
     { version: "1.0.0-beta.15", run: m15 },
     { version: "1.0.0", run: m16 },
     { version: "1.1.0", run: m17 },
-    { version: "1.2.0", run: m18 }
+    { version: "1.2.0", run: m18 },
+    { version: "1.3.0", run: m19 }
     // Add new migrations here as they are created
 ] as const;
 

--- a/server/setup/scripts/1.3.0.ts
+++ b/server/setup/scripts/1.3.0.ts
@@ -1,0 +1,23 @@
+import db from "@server/db";
+import { sql } from "drizzle-orm";
+
+const version = "1.3.0";
+
+export default async function migration() {
+    console.log(`Running setup script ${version}...`);
+
+    try {
+        db.transaction((trx) => {
+            trx.run(
+                sql`ALTER TABLE resources ADD stickySession integer DEFAULT false NOT NULL;`
+            );
+        });
+
+        console.log(`Added new column: stickySession`);
+    } catch (e) {
+        console.log("Unable to add new column: stickySession");
+        throw e;
+    }
+
+    console.log(`${version} migration complete`);
+}

--- a/src/app/[orgId]/settings/resources/[resourceId]/connectivity/page.tsx
+++ b/src/app/[orgId]/settings/resources/[resourceId]/connectivity/page.tsx
@@ -493,15 +493,17 @@ export default function ReverseProxyTargets(props: {
                         </SettingsSectionDescription>
                     </SettingsSectionHeader>
                     <SettingsSectionBody>
-                        <SwitchInput
-                            id="sticky-toggle"
-                            label="Enable Sticky Sessions"
-                            description="Keep users on the same backend target for their entire session. Useful for applications like VNC that require persistent connections."
-                            defaultChecked={resource.stickySession}
-                            onCheckedChange={async (val) => {
-                                await saveStickySession(val);
-                            }}
-                        />
+                        {targets.length >= 2 && (
+                            <SwitchInput
+                                id="sticky-toggle"
+                                label="Enable Sticky Sessions"
+                                description="Keep users on the same backend target for their entire session. Useful for applications like VNC that require persistent connections."
+                                defaultChecked={resource.stickySession}
+                                onCheckedChange={async (val) => {
+                                    await saveStickySession(val);
+                                }}
+                            />
+                        )}
                         <SwitchInput
                             id="ssl-toggle"
                             label="Enable SSL (https)"


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description
Allow 'sticky sessions' to backend resources. This is required if there are multiple targets and the targets aren't stateless, like the VNC console sessions to Proxmox. This keep the user pinned to a single target for the duration of their session.

![image](https://github.com/user-attachments/assets/475826e4-95fe-4e79-8596-779ba8a7dc37)


## How to test?
```shell
mkdir -p /tmp/server1 && echo "server1" > /tmp/server1/index.html && \
mkdir -p /tmp/server2 && echo "server2" > /tmp/server2/index.html && \
python3 -m http.server 10000 --bind 0.0.0.0 --directory /tmp/server1 && \
python3 -m http.server 20000 --bind 0.0.0.0 --directory /tmp/server2
```

Add two targets as shown in the screenshot below. Browse to your Resource and hit refresh and notice the webpage rotates from server1 to server 2, etc. Enable Sticky Sessions, hit refresh several more times, and notice that Traefik now keeps your session pinned to a single target.

![image](https://github.com/user-attachments/assets/df681ecd-05e6-4261-aa2c-95ce256cf882)

