### PR TITLE
updated the traefik image and crowdsec-bouncer-traefik-plugin for bigger files

### DIFF
--- a/install/config/crowdsec/dynamic_config.yml
+++ b/install/config/crowdsec/dynamic_config.yml
@@ -42,6 +42,7 @@ http:
           crowdsecAppsecHost: crowdsec:7422 # CrowdSec IP address which you noted down later
           crowdsecAppsecFailureBlock: true # Block on failure
           crowdsecAppsecUnreachableBlock: true # Block on unreachable
+          crowdsecAppsecBodyLimit: 10485760
           crowdsecLapiKey: "PUT_YOUR_BOUNCER_KEY_HERE_OR_IT_WILL_NOT_WORK" # CrowdSec API key which you noted down later
           crowdsecLapiHost: crowdsec:8080 # CrowdSec  
           crowdsecLapiScheme: http # CrowdSec API scheme

--- a/install/config/crowdsec/traefik_config.yml
+++ b/install/config/crowdsec/traefik_config.yml
@@ -16,7 +16,7 @@ experimental:
       version: "{{.BadgerVersion}}"
     crowdsec: # CrowdSec plugin configuration added
       moduleName: "github.com/maxlerebourg/crowdsec-bouncer-traefik-plugin"
-      version: "v1.3.5"
+      version: "v1.4.2"
 
 log:
   level: "INFO"

--- a/install/config/docker-compose.yml
+++ b/install/config/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       - 80:80 # Port for traefik because of the network_mode
 {{end}}
   traefik:
-    image: traefik:v3.3.3
+    image: traefik:v3.3.5
     container_name: traefik
     restart: unless-stopped
 {{if .InstallGerbil}}


### PR DESCRIPTION
updated the traefik image to v3.3.5
updated the crowdsec-bouncer-traefik-plugin to v1.4.2
added default crowdsecAppsecBodyLimit value of 10MB for bigger files

## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description
See the issue https://github.com/fosrl/pangolin/issues/436#top
and my latest comment https://github.com/fosrl/pangolin/issues/436#issuecomment-2797924344

With a setup pangolin and crowdsec the traefik process gets oom'ed with bigger file uploads (minio, nextcloud, immich, etc.).
There is an attribute `crowdsecAppsecBodyLimit` for the [crowdsec-bouncer-traefik-plugin](https://plugins.traefik.io/plugins/6335346ca4caa9ddeffda116/crowdsec-bouncer-traefik-plugin), that adjust the body size of the uploaded files, but it was first implemented in the version v1.4.0.

## How to test?
Just setup pangolin with crowdsec and use a service like Minio and try to upload some bigger files, like 1GB. It crashes the traefik process with a VM/VPS with 1 CPU core and 1GB memory.
With the adjustment in this PR there is no need to upgrade the memory of the VPSs.
