### PR TITLE
More relaxed healthcheck for low end systems

### DIFF
--- a/install/config/docker-compose.yml
+++ b/install/config/docker-compose.yml
@@ -8,9 +8,9 @@ services:
       - ./config:/app/config
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3001/api/v1/"]
-      interval: "3s"
-      timeout: "3s"
-      retries: 5
+      interval: "10s"
+      timeout: "10s"
+      retries: 15
 {{if .InstallGerbil}}
   gerbil:
     image: fosrl/gerbil:{{.GerbilVersion}}


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description
If I include crowdsec on the stack, the containers fail the healthcheck on a, let's say oracle free tier, 1/8 CPU core and 1GB RAM.
With these eased up healthcheck it starts and works fine.

## How to test?
Just limit the resources of the VM/VPS to (1 CPU core (1/8 vCPU) and 1GB RAM) and start the stack.
