### PR TITLE
Added QR code to wireguard config for easy scanning on mobile phones

### DIFF
--- a/src/app/[orgId]/settings/sites/create/page.tsx
+++ b/src/app/[orgId]/settings/sites/create/page.tsx
@@ -57,6 +57,8 @@ import {
     BreadcrumbSeparator
 } from "@app/components/ui/breadcrumb";
 import Link from "next/link";
+import QRCode from "react-qr-code";
+import QRContainer from "@app/components/QRContainer";
 
 const createSiteFormSchema = z
     .object({
@@ -775,8 +777,16 @@ PersistentKeepalive = 5`;
                                     </SettingsSectionDescription>
                                 </SettingsSectionHeader>
                                 <SettingsSectionBody>
-                                    <CopyTextBox text={wgConfig} />
-
+                                    <div className="flex items-center gap-4">
+                                        <CopyTextBox text={wgConfig} />
+                                        <QRContainer>
+                                            <QRCode
+                                                value={wgConfig}
+                                                size={168}
+                                                className="mx-auto"
+                                            />
+                                        </QRContainer>
+                                    </div>
                                     <Alert variant="neutral">
                                         <InfoIcon className="h-4 w-4" />
                                         <AlertTitle className="font-semibold">

--- a/src/components/QRContainer.tsx
+++ b/src/components/QRContainer.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+export default function QRContainer({
+    children = <div/>,
+    outline = true
+}) {
+
+    return (
+        <div
+            className={`relative w-fit border-2 rounded-md`}
+        >
+            <div className="bg-white p-6 rounded-md">
+                {children}
+            </div>
+        </div>
+    );
+}


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description
Added a QR Code next to the wireguard config on site creation for easy scanning/adding to mobile phones (and other devices)

## How to test?

- Head to Sites
- Add Site
- Click Basic WireGuard
- QR Code should appear on the right as in the image below

![image](https://github.com/user-attachments/assets/851cb347-e2ee-4403-8cc3-e544f66ccb2d)


