### PR TITLE
Bug: fixed typo in exitNodes table

### DIFF
--- a/server/db/schemas/schema.ts
+++ b/server/db/schemas/schema.ts
@@ -99,7 +99,7 @@ export const exitNodes = sqliteTable("exitNodes", {
     name: text("name").notNull(),
     address: text("address").notNull(), // this is the address of the wireguard interface in gerbil
     endpoint: text("endpoint").notNull(), // this is how to reach gerbil externally - gets put into the wireguard config
-    publicKey: text("pubicKey").notNull(),
+    publicKey: text("publicKey").notNull(),
     listenPort: integer("listenPort").notNull(),
     reachableAt: text("reachableAt") // this is the internal address of the gerbil http server for command control
 });


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description
The field publicKey is spelled wrongly in the exitNodes table

## How to test?

- Confirm spelling is correct in the database (exitNodes table)
