### PR TITLE
fix: Avoid rendering two children with the same key

### DIFF
--- a/src/components/PermissionsSelectBox.tsx
+++ b/src/components/PermissionsSelectBox.tsx
@@ -95,7 +95,7 @@ function getActionsCategories(root: boolean) {
     if (root) {
         actionsByCategory["Organization"] = {
             "List Organizations": "listOrgs",
-            "Check ID": "checkOrgId",
+            "Check ID": "checkId",
             "Create Organization": "createOrg",
             "Delete Organization": "deleteOrg",
             "List API Keys": "listApiKeys",


### PR DESCRIPTION
This change updates the value of the key 'Check ID' to 'checkId' to avoid duplicates. It ensures proper naming conventions in the permissions select box. Avoid rendering two children with the same key in the component.

## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.