### PR TITLE
traefik log rotation with default values

### DIFF
--- a/install/config/crowdsec/traefik_config.yml
+++ b/install/config/crowdsec/traefik_config.yml
@@ -21,6 +21,10 @@ experimental:
 log:
   level: "INFO"
   format: "json" # Log format changed to json for better parsing
+  maxSize: 100
+  maxBackups: 3
+  maxAge: 3
+  compress: true
 
 accessLog: # We enable access logs as json
   filePath: "/var/log/traefik/access.log"

--- a/install/config/traefik/traefik_config.yml
+++ b/install/config/traefik/traefik_config.yml
@@ -18,6 +18,10 @@ experimental:
 log:
   level: "INFO"
   format: "common"
+  maxSize: 100
+  maxBackups: 3
+  maxAge: 3
+  compress: true
 
 certificatesResolvers:
   letsencrypt:


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description
Enables traefik log rotation with default values that work with a least powerful VM.
The log file will get rotating after reaching 100MB of size and the last 3 backups are being kept and get compressed as well. The logs that are older then three days would get deleted.

This also should fix issues like https://github.com/fosrl/pangolin/issues/693

## How to test?

