### PR TITLE
Fix - Sort Data In/Out correctly in Sites Management page in the Pangolin Dashboard

### DIFF
--- a/src/app/[orgId]/settings/sites/SitesTable.tsx
+++ b/src/app/[orgId]/settings/sites/SitesTable.tsx
@@ -27,6 +27,7 @@ import { formatAxiosError } from "@app/lib/api";
 import { createApiClient } from "@app/lib/api";
 import { useEnvContext } from "@app/hooks/useEnvContext";
 import CreateSiteFormModal from "./CreateSiteModal";
+import { parseDataSize } from '@app/lib/dataSize';
 
 export type SiteRow = {
     id: number;
@@ -197,7 +198,12 @@ export default function SitesTable({ sites, orgId }: SitesTableProps) {
                         <ArrowUpDown className="ml-2 h-4 w-4" />
                     </Button>
                 );
-            }
+            },
+            sortingFn: (rowA, rowB) => {
+                const a = parseDataSize(rowA.original.mbIn);
+                const b = parseDataSize(rowB.original.mbIn);
+                return a > b ? 1 : a < b ? -1 : 0;
+            },
         },
         {
             accessorKey: "mbOut",
@@ -213,7 +219,12 @@ export default function SitesTable({ sites, orgId }: SitesTableProps) {
                         <ArrowUpDown className="ml-2 h-4 w-4" />
                     </Button>
                 );
-            }
+            },
+            sortingFn: (rowA, rowB) => {
+                const a = parseDataSize(rowA.original.mbOut);
+                const b = parseDataSize(rowB.original.mbOut);
+                return a > b ? 1 : a < b ? -1 : 0;
+            },
         },
         {
             accessorKey: "type",

--- a/src/lib/dataSize.ts
+++ b/src/lib/dataSize.ts
@@ -1,0 +1,11 @@
+export function parseDataSize(sizeStr: string): number {
+  if (!sizeStr) return 0;
+  const match = sizeStr.trim().toUpperCase().match(/^([\d.]+)\s*([KMGT]?B)$/);
+  if (!match) return 0;
+  const [, numStr, unit] = match;
+  const num = parseFloat(numStr) || 0;
+  const multipliers: Record<string, number> = {
+    B: 1, KB: 1024, MB: 1024**2, GB: 1024**3, TB: 1024**4,
+  };
+  return num * (multipliers[unit] || 1);
+}


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description
Data Out and Data In sorting option in the "Manage Sites" tab does not actually seem to be sorting on most data in/out based on total number of bytes, but it will try to sort it as text (Str). 

The solution is to parse each size string to a numeric value (in bytes) and compare those numbers:

- Added a `parseDataSize` helper that splits off the numeric part and unit from the string and converts it to a consistent number (bytes)
- Added `sortingFn` to the `SitesTable.tsx` to correctly sort the data in/out.

As you can see the table now sorts correctly! 

![image](https://github.com/user-attachments/assets/f9a69d72-9917-4540-b0c4-35af2bfca1f1)

## Fix Considerations
I've decided to put the `parseDataSize` function as a shared module, this makes it more reusable if the maintainers of this project decide to use any other table or component that needs to sort or compare data-size strings.
Adding it to only the `SitesTable.tsx` seemed a fine fix for now, but could lead to duplicate code if it is needed elsewhere in the project.

## How to test?
1. Clone the branch
2. Create a dev instance by following the https://docs.fossorial.io/development#pangolin docs.
3. Go to the sites overview in the pangolin dashboard.
4. Click on the sorting button above Data In or Data Out
5. Check if the Data In/Out is sorted on total number of bytes instead of as a string.


I'm not super used to Typescript, so please let me know if you would like things changed :)
