### PR TITLE
test if smtp user/pass config is set and if not set auth: null

### DIFF
--- a/server/emails/index.ts
+++ b/server/emails/index.ts
@@ -18,10 +18,10 @@ function createEmailClient() {
         host: emailConfig.smtp_host,
         port: emailConfig.smtp_port,
         secure: emailConfig.smtp_secure || false,
-        auth: {
+        auth: (emailConfig.smtp_user && emailConfig.smtp_pass) ? {
             user: emailConfig.smtp_user,
             pass: emailConfig.smtp_pass
-        }
+        } : null
     } as SMTPTransport.Options;
 
     if (emailConfig.smtp_tls_reject_unauthorized !== undefined) {


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description
For smtp servers that require no authentication (Google Workspace has this option for whitelisted IP addresses for example), the `auth:` option for nodemailer must be set to null. This code checks if a username and password are defined. If they are, there is no change to previous behaviour. But if they aren't, `auth:` is set to null.

As discussed on discord: https://discord.com/channels/1325658630518865980/1395139357312028672

## How to test?
Don't set smtp user/pass values in the config, and configure an open relay as smtp host, and see if it mails.
