### PR TITLE
add IPv6 support for docker network

### DIFF
--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -52,3 +52,4 @@ networks:
   default:
     driver: bridge
     name: pangolin
+    enable_ipv6: true

--- a/install/config/docker-compose.yml
+++ b/install/config/docker-compose.yml
@@ -59,3 +59,4 @@ networks:
   default:
     driver: bridge
     name: pangolin
+    enable_ipv6: true


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description
Adding IPv6 support to the docker network to ensure no NATing takes place and the IP addresses are logged correctly. This ensures correct behavior of middlewares, for example Crowdsec or GeoBlock.
Successfully tested on Debian based systems with different IP configurations (IPv4 only/IPv6 only/both). Also successfully tested on an existing install (IPv4/6 dual, Debian 12).
I did however only test on Hetzner VPS. There might be some differences in the server setup across providers, but i doubt they would impact this change.

Some follow up thoughts regarding #110:
Upon further thinking I came to the conclusion that step 1 might be disruptive - blocking IPv6 completely might break some installs if users are using an IPv6 only server (unlikely, as GitHub doesn't have IPv6 support yet, but not completely ruled out).

I also put some thoughts again into enabling IPv6 by default on all new installations, and can't think of any reason not to. My initial hesitation was due to increased complexity, especially with dockers tendency to punch through existing firewall policies. After giving this some thought, i came to the conclusion that some basic tech knowledge can be expected from the user, and I think it is a reasonable expectation that someone provisioning an IPv6 capable server is aware of the implications. So, as of now, I don't see any downside to enable IPv6 on all new installations.

In the end, this was basically just adding one line and running a lot of tests. So @oschwartz10612... https://github.com/fosrl/pangolin/issues/110#issuecomment-2994275283 you were completely correct :)

Changing this to ask the user during installation would be trivial now that the tests are done, just let me know if you prefer this. TBH tho, after my tests, I don't see a reason anymore.

I am unsure about how to handle existing installations, if at all. A note in the release notes might be sufficient.

## How to test?
Provision a fresh install or change the docker-compose.yml on an existing install
Ensure connection works from both IPv4 and IPv6 clients
Ensure the IP forwarding works as expected, for example by checking the traefik access.log. IPv6 addresses should now show correctly.
