### PR TITLE
add an environment variable for the smtp_pass config option

### DIFF
--- a/server/lib/readConfigFile.ts
+++ b/server/lib/readConfigFile.ts
@@ -213,7 +213,7 @@ export const configSchema = z
                 smtp_host: z.string().optional(),
                 smtp_port: portSchema.optional(),
                 smtp_user: z.string().optional(),
-                smtp_pass: z.string().optional(),
+                smtp_pass: z.string().optional().transform(getEnvOrYaml("EMAIL_SMTP_PASS")),
                 smtp_secure: z.boolean().optional(),
                 smtp_tls_reject_unauthorized: z.boolean().optional(),
                 no_reply: z.string().email().optional()


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description
The password for secure authentication may be sensitive, so it is best to not leave it lying around in a config file. This commit introduces the `EMAIL_SMTP_PASS` environment variable, which can be set to configure the SMTP password without writing it to the configuration file.

## How to test?
Start a Pangolin server as normal, but use `EMAIL_SMTP_PASS` instead of the config file to set up the mail server.