### PR TITLE
add shebangs to migration and server scripts

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -1,3 +1,4 @@
+#! /usr/bin/env node
 import "./extendZod.ts";
 
 import { runSetupFunctions } from "./setup";

--- a/server/setup/migrationsPg.ts
+++ b/server/setup/migrationsPg.ts
@@ -1,3 +1,4 @@
+#! /usr/bin/env node
 import { migrate } from "drizzle-orm/node-postgres/migrator";
 import { db } from "../db/pg";
 import semver from "semver";

--- a/server/setup/migrationsSqlite.ts
+++ b/server/setup/migrationsSqlite.ts
@@ -1,3 +1,4 @@
+#! /usr/bin/env node
 import { migrate } from "drizzle-orm/better-sqlite3/migrator";
 import { db, exists } from "../db/sqlite";
 import path from "path";


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description
In NixOS, we wrap these files in a bash script to allow users to just run them as normal executables, instead of calling them as arguments to Node.JS. In our build scripts, we just [add the shebang](https://github.com/NixOS/nixpkgs/blob/d299df66b63ba4e6f2f98f5b1e13bedd7b748d8b/pkgs/by-name/fo/fosrl-pangolin/package.nix#L100) after the files have been compiled, but adding it upstream will allow all Pangolin users to just run ./server.mjs to start their Pangolin instances.

## How to test?

Build Pangolin, and check if all `*.mjs` files have shebangs. (and not just `cli.mjs`)