### PR TITLE
Fix to issues with binding to ports other than 80/443 for web resources

### DIFF
--- a/server/routers/badger/exchangeSession.ts
+++ b/server/routers/badger/exchangeSession.ts
@@ -53,19 +53,26 @@ export async function exchangeSession(
     try {
         const { requestToken, host, requestIp } = parsedBody.data;
 
+        let cleanHost = host;
+        // if the host ends with :port
+        if (cleanHost.match(/:[0-9]{1,5}$/)) {
+            let matched = ''+cleanHost.match(/:[0-9]{1,5}$/);
+            cleanHost = cleanHost.slice(0, -1*matched.length);
+        }
+
         const clientIp = requestIp?.split(":")[0];
 
         const [resource] = await db
             .select()
             .from(resources)
-            .where(eq(resources.fullDomain, host))
+            .where(eq(resources.fullDomain, cleanHost))
             .limit(1);
 
         if (!resource) {
             return next(
                 createHttpError(
                     HttpCode.NOT_FOUND,
-                    `Resource with host ${host} not found`
+                    `Resource with host ${cleanHost} not found`
                 )
             );
         }

--- a/server/routers/badger/verifySession.ts
+++ b/server/routers/badger/verifySession.ts
@@ -121,11 +121,10 @@ export async function verifyResourceSession(
         logger.debug("Client IP:", { clientIp });
 
         let cleanHost = host;
-        // if the host ends with :443 or :80 remove it
-        if (cleanHost.endsWith(":443")) {
-            cleanHost = cleanHost.slice(0, -4);
-        } else if (cleanHost.endsWith(":80")) {
-            cleanHost = cleanHost.slice(0, -3);
+        // if the host ends with :port, remove it
+        if (cleanHost.match(/:[0-9]{1,5}$/)) {
+            let matched = ''+cleanHost.match(/:[0-9]{1,5}$/);
+            cleanHost = cleanHost.slice(0, -1*matched.length);
         }
 
         const resourceCacheKey = `resource:${cleanHost}`;

--- a/src/app/auth/resource/[resourceId]/page.tsx
+++ b/src/app/auth/resource/[resourceId]/page.tsx
@@ -59,9 +59,16 @@ export default async function ResourceAuthPage(props: {
         try {
             const serverResourceHost = new URL(authInfo.url).host;
             const redirectHost = new URL(searchParams.redirect).host;
+            const redirectPort = new URL(searchParams.redirect).port;
+            const serverResourceHostWithPort = `${serverResourceHost}:${redirectPort}`;
 
+            //Compare resource host against redirect host
             if (serverResourceHost === redirectHost) {
                 redirectUrl = searchParams.redirect;
+
+            //Compare resource host:port with redirect host
+            } else if ( serverResourceHostWithPort === redirectHost ) {
+                redirectUrl = `${searchParams.redirect}`;
             }
         } catch (e) {}
     }


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description
Fix to issues with binding to ports other than 80/443 for HTTP/HTTPS web resources

- server/routers/badger/verifySession.ts : verifyResourceSession() updated code behind "cleanHost" var to a regex which strips the trailing :port for any port (rather than a string match for 80/443)
- src/app/auth/resource/[resourceId]/page.tsx : ResourceAuthPage() added a secondary match for serverResourceHost and redirectHost that accounts for ports
- server/routers/badger/exchangeSession.ts :  Updated exchangeSession() to use the same "cleanHost" type var (with port-stripping) as in verifyResourceSession(), replaced references to "host" with "cleanHost"

## How to test?

When running from docker, bind the ports in docker-compose with something other than 443:443 and 80:80
(in my case I also changed the "entrypoints" ports for traefik but this may not be necessary)


