### PR TITLE
System wide default language detection via browser language header

### DIFF
--- a/src/services/locale.ts
+++ b/src/services/locale.ts
@@ -1,7 +1,7 @@
 'use server';
 
-import {cookies, headers} from 'next/headers';
-import {Locale, defaultLocale, locales} from '@/i18n/config';
+import { cookies, headers } from 'next/headers';
+import { Locale, defaultLocale, locales } from '@/i18n/config';
 
 // In this example the locale is read from a cookie. You could alternatively
 // also read it from a database, backend service, or any other source.
@@ -14,7 +14,7 @@ export async function getUserLocale(): Promise<Locale> {
     return cookieLocale as Locale;
   }
 
-  const headerList = await headers(); 
+  const headerList = await headers();
   const acceptLang = headerList.get('accept-language');
 
   if (acceptLang) {

--- a/src/services/locale.ts
+++ b/src/services/locale.ts
@@ -1,15 +1,35 @@
 'use server';
 
-import {cookies} from 'next/headers';
-import {Locale, defaultLocale} from '@/i18n/config';
+import {cookies, headers} from 'next/headers';
+import {Locale, defaultLocale, locales} from '@/i18n/config';
 
 // In this example the locale is read from a cookie. You could alternatively
 // also read it from a database, backend service, or any other source.
 const COOKIE_NAME = 'NEXT_LOCALE';
 
-export async function getUserLocale() {
-  return (await cookies()).get(COOKIE_NAME)?.value || defaultLocale;
+export async function getUserLocale(): Promise<Locale> {
+  const cookieLocale = (await cookies()).get(COOKIE_NAME)?.value;
+
+  if (cookieLocale && locales.includes(cookieLocale as Locale)) {
+    return cookieLocale as Locale;
+  }
+
+  const headerList = await headers(); 
+  const acceptLang = headerList.get('accept-language');
+
+  if (acceptLang) {
+    const browserLang = acceptLang.split(',')[0];
+    const matched = locales.find((locale) =>
+      browserLang.toLowerCase().startsWith(locale.split('-')[0].toLowerCase())
+    );
+    if (matched) {
+      return matched;
+    }
+  }
+
+  return defaultLocale;
 }
+
 
 export async function setUserLocale(locale: Locale) {
   (await cookies()).set(COOKIE_NAME, locale);


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description
This PR adds support for detecting a user's preferred language from their browser settings (Accept-Language header) and falling back to a predefined default (en-US) when not available. The flow works as follows:

1. If a cookie exists and its value matches one of the app-supported locales (/i18n/config.ts), it is used.
2. If not, the Accept-Language header from the browser is parsed.
        We extract the base language (e.g., fr from fr-FR).
        We try to match it against available locales by comparing prefixes.

3. If no match is found, the app falls back to the default locale: 'en-US'.

## How to test?
1. Open your browser settings and change the preferred language to something like French.
2. Make sure the NEXT_LOCALE cookie is not set by clearing cookies or using an incognito/private window.
3. Visit the app in a new tab or incognito window.
4. Set your browser to a language not included in the app’s locales. The application should fallback to en-US.
5. Cookie Override Test: If NEXT_LOCALE cookie is set (e.g., via language switcher), it should take priority over browser settings on the next visit.

Fix: #1131

