### PR TITLE
make IPv6 optional during install

### DIFF
--- a/install/config/docker-compose.yml
+++ b/install/config/docker-compose.yml
@@ -60,4 +60,4 @@ networks:
   default:
     driver: bridge
     name: pangolin
-    enable_ipv6: true
+{{if .EnableIPv6}}    enable_ipv6: true{{end}}

--- a/install/input.txt
+++ b/install/input.txt
@@ -1,6 +1,7 @@
 docker
 example.com
 pangolin.example.com
+yes
 admin@example.com
 yes
 admin@example.com

--- a/install/main.go
+++ b/install/main.go
@@ -39,6 +39,7 @@ type Config struct {
 	BadgerVersion             string
 	BaseDomain                string
 	DashboardDomain           string
+	EnableIPv6                bool
 	LetsEncryptEmail          string
 	EnableEmail               bool
 	EmailSMTPHost             string
@@ -303,6 +304,7 @@ func collectUserInput(reader *bufio.Reader) Config {
 	fmt.Println("\n=== Basic Configuration ===")
 	config.BaseDomain = readString(reader, "Enter your base domain (no subdomain e.g. example.com)", "")
 	config.DashboardDomain = readString(reader, "Enter the domain for the Pangolin dashboard", "pangolin."+config.BaseDomain)
+	config.EnableIPv6 = readBool(reader, "Is your server IPv6 capable?", true)
 	config.LetsEncryptEmail = readString(reader, "Enter email for Let's Encrypt certificates", "")
 	config.InstallGerbil = readBool(reader, "Do you want to use Gerbil to allow tunneled connections", true)
 

--- a/server/routers/client/getClient.ts
+++ b/server/routers/client/getClient.ts
@@ -14,7 +14,7 @@ import { OpenAPITags, registry } from "@server/openApi";
 const getClientSchema = z
     .object({
         clientId: z.string().transform(stoi).pipe(z.number().int().positive()),
-        orgId: z.string().optional()
+        orgId: z.string()
     })
     .strict();
 


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description
Following #1111 and #1184.
Installer now asks whether the server is IPv6 capable. Does not disable IPv6 if user choses no, just doesn't enable the IPv6 network for docker. IPv6 connections will still succeed, but will get NATed to the Docker internal IPv4 address.
If needed, this can be changed to actually disable IPv6, for example by changing the Gerbil ports from 443:443 to 0.0.0.0:443:443 conditionally.

## How to test?
Test the install with both "yes" and "no".
"enable_ipv6 = true" should be included respectively not included in the docker-compose.yml
