### PR TITLE
Added checks for port 80 and 443

### DIFF
--- a/install/main.go
+++ b/install/main.go
@@ -18,6 +18,7 @@ import (
 	"syscall"
 	"text/template"
 	"time"
+    "net"
 
 	"golang.org/x/term"
 )
@@ -74,6 +75,17 @@ func main() {
 	fmt.Println("")
 	fmt.Println("Lets get started!")
 	fmt.Println("")
+
+
+    for _, p := range []int{80, 443} {
+        if err := checkPortsAvailable(p); err != nil {
+            fmt.Fprintln(os.Stderr, err)
+
+            fmt.Printf("Please close any services on ports 80/443 in order to run the installation smoothly")
+            os.Exit(1)
+        }
+    }
+
 
 	reader := bufio.NewReader(os.Stdin)
 	inputContainer := readString(reader, "Would you like to run Pangolin as Docker or Podman containers?", "docker")
@@ -775,4 +787,22 @@ func run(name string, args ...string) error {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
+}
+
+func checkPortsAvailable(port int) error {
+    addr := fmt.Sprintf(":%d", port)
+    ln, err := net.Listen("tcp", addr)
+    if err != nil {
+        return fmt.Errorf(
+            "ERROR: port %d is occupied or cannot be bound: %w\n\n",
+            port, err,
+        )
+    }
+    if closeErr := ln.Close(); closeErr != nil {
+        fmt.Fprintf(os.Stderr,
+            "WARNING: failed to close test listener on port %d: %v\n",
+            port, closeErr,
+        )
+    }
+    return nil
 }


### PR DESCRIPTION
In my issue #1203, I noticed there was a problem when ports 80 and 443 were already in use. This caused the docker containers to be created but not running

## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description
Just made the script halt at the beginning if it sees that different ports are occupied

## How to test?
Run the installer 

Fixes #1203 
