### PR TITLE
Pangctl command to reset a user’s passkeys (WebAuthn credentials)

### DIFF
--- a/cli/commands/resetUserSecurityKeys.ts
+++ b/cli/commands/resetUserSecurityKeys.ts
@@ -1,0 +1,67 @@
+import { CommandModule } from "yargs";
+import { db, users, securityKeys } from "@server/db";
+import { eq } from "drizzle-orm";
+
+type ResetUserSecurityKeysArgs = {
+    email: string;
+};
+
+export const resetUserSecurityKeys: CommandModule<{}, ResetUserSecurityKeysArgs> = {
+    command: "reset-user-security-keys",
+    describe: "Reset a user's security keys (passkeys) by deleting all their webauthn credentials",
+    builder: (yargs) => {
+        return yargs
+            .option("email", {
+                type: "string",
+                demandOption: true,
+                describe: "User email address"
+            });
+    },
+    handler: async (argv: { email: string }) => {
+        try {
+            const { email } = argv;
+
+            console.log(`Looking for user with email: ${email}`);
+
+            // Find the user by email
+            const [user] = await db
+                .select()
+                .from(users)
+                .where(eq(users.email, email))
+                .limit(1);
+
+            if (!user) {
+                console.error(`User with email '${email}' not found`);
+                process.exit(1);
+            }
+
+            console.log(`Found user: ${user.email} (ID: ${user.userId})`);
+
+            // Check if user has any security keys
+            const userSecurityKeys = await db
+                .select()
+                .from(securityKeys)
+                .where(eq(securityKeys.userId, user.userId));
+
+            if (userSecurityKeys.length === 0) {
+                console.log(`User '${email}' has no security keys to reset`);
+                process.exit(0);
+            }
+
+            console.log(`Found ${userSecurityKeys.length} security key(s) for user '${email}'`);
+
+            // Delete all security keys for the user
+            await db
+                .delete(securityKeys)
+                .where(eq(securityKeys.userId, user.userId));
+
+            console.log(`Successfully reset security keys for user '${email}'`);
+            console.log(`Deleted ${userSecurityKeys.length} security key(s)`);
+
+            process.exit(0);
+        } catch (error) {
+            console.error("Error:", error);
+            process.exit(1);
+        }
+    }
+}; 

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -3,9 +3,11 @@
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 import { setAdminCredentials } from "@cli/commands/setAdminCredentials";
+import { resetUserSecurityKeys } from "@cli/commands/resetUserSecurityKeys";
 
 yargs(hideBin(process.argv))
     .scriptName("pangctl")
     .command(setAdminCredentials)
+    .command(resetUserSecurityKeys)
     .demandCommand()
     .help().argv;


### PR DESCRIPTION
## Description
Adds an admin CLI command to remove a user’s passkeys (WebAuthn credentials) by email. This is for recovery/support when a user is locked out or needs to re-enroll passkeys.

- Command: `reset-user-security-keys`
- Input: `--email <user@example.com>`
- Effect: Deletes all WebAuthn credentials for that user
- Output: Clear logs for user lookup, keys found, and keys deleted

## How to test?
Run the command and observe the output.

1) Execute:
   ```bash
   pangctl reset-user-security-keys --email user@example.com
   ```

2) Expected behaviors:
   - If the user exists and has passkeys:
     - Output includes:
       - “Looking for user with email: user@example.com”
       - “Found user: user@example.com (ID: …)”
       - “Found N security key(s) for user ‘user@example.com’”
       - “Successfully reset security keys for user ‘user@example.com’”
       - “Deleted N security key(s)”
   - If the user exists but has no passkeys:
     - Output includes:
       - “User ‘user@example.com’ has no security keys to reset”
   - If the user does not exist:
     - Output includes:
       - “User with email ‘user@example.com’ not found”

## Screenshots
<img width="480" height="73" alt="Screenshot 2025-08-08 at 8 16 06 pm" src="https://github.com/user-attachments/assets/93d91ac6-c182-4ebd-ac86-2611d863c493" />
<img width="560" height="89" alt="Screenshot 2025-08-08 at 8 15 55 pm" src="https://github.com/user-attachments/assets/1d8ab9b4-b089-4671-b653-a294323e9b45" />
<img width="633" height="136" alt="Screenshot 2025-08-08 at 8 15 43 pm" src="https://github.com/user-attachments/assets/bef7b225-b833-403b-972a-3ed2e6914181" />
<img width="819" height="182" alt="Screenshot 2025-08-08 at 8 18 56 pm" src="https://github.com/user-attachments/assets/53933973-7362-42b3-9ecc-c9d25ca5d1c4" />