### PR TITLE
fix: change default integration_api to 3004

### DIFF
--- a/server/lib/readConfigFile.ts
+++ b/server/lib/readConfigFile.ts
@@ -43,7 +43,7 @@ export const configSchema = z
         server: z.object({
             integration_port: portSchema
                 .optional()
-                .default(3003)
+                .default(3004)
                 .transform(stoi)
                 .pipe(portSchema.optional()),
             external_port: portSchema


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description

Currently both gerbil and the integration api server listen on port 3003. This causes site connectivity to break, since gerbil is not reachable. I would propose changing the API server default port to 3004.
closes https://github.com/fosrl/gerbil/issues/18


## How to test?

