### PR TITLE
add missing hostmeta export for PG schema

### DIFF
--- a/server/db/pg/schema.ts
+++ b/server/db/pg/schema.ts
@@ -648,3 +648,4 @@ export type UserClient = InferSelectModel<typeof userClients>;
 export type RoleClient = InferSelectModel<typeof roleClients>;
 export type OrgDomains = InferSelectModel<typeof orgDomains>;
 export type SetupToken = InferSelectModel<typeof setupTokens>;
+export type HostMeta = InferSelectModel<typeof hostMeta>;


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description

This PR fixes an issue where the HostMeta export was missing for the Postgres (PG) schema.
The missing export caused runtime errors when attempting to resolve host metadata in PG builds.

## How to test?

