### PR TITLE
Fix: responsive layout for CardHeader (small/medium/large screens)  inside manage resources page.

### DIFF
--- a/src/app/[orgId]/settings/resources/ResourcesTable.tsx
+++ b/src/app/[orgId]/settings/resources/ResourcesTable.tsx
@@ -665,22 +665,21 @@ export default function SitesTable({
                         className="w-full"
                         onValueChange={handleTabChange}
                     >
-                        <CardHeader className="flex flex-col space-y-4 sm:flex-row sm:items-center sm:justify-between sm:space-y-0 pb-0">
-                            <div className="flex flex-row space-y-3 w-full sm:mr-2 gap-2">
-                                {getSearchInput()}
-
+                        <CardHeader className="flex flex-col items-center gap-4 md:items-stretch lg:flex-row lg:items-center lg:justify-between pb-0">
+                            <div className="flex flex-col items-center gap-3 w-full md:flex-row md:justify-center lg:justify-start lg:w-auto lg:mr-2">
+                                <div className="w-full md:w-auto lg:w-auto">{getSearchInput()}</div>
                                 {env.flags.enableClients && (
-                                    <TabsList className="grid grid-cols-2">
-                                        <TabsTrigger value="proxy">
+                                    <TabsList className="grid grid-cols-2 w-full md:w-auto">
+                                        <TabsTrigger value="proxy" className="w-full">
                                             {t("resourcesTableProxyResources")}
                                         </TabsTrigger>
-                                        <TabsTrigger value="internal">
+                                        <TabsTrigger value="internal" className="w-full">
                                             {t("resourcesTableClientResources")}
                                         </TabsTrigger>
                                     </TabsList>
                                 )}
                             </div>
-                            <div className="flex items-center gap-2 sm:justify-end">
+                            <div className="flex justify-center w-full md:justify-center lg:justify-end lg:w-auto">
                                 {getActionButton()}
                             </div>
                         </CardHeader>
@@ -700,12 +699,12 @@ export default function SitesTable({
                                                                 {header.isPlaceholder
                                                                     ? null
                                                                     : flexRender(
-                                                                          header
-                                                                              .column
-                                                                              .columnDef
-                                                                              .header,
-                                                                          header.getContext()
-                                                                      )}
+                                                                        header
+                                                                            .column
+                                                                            .columnDef
+                                                                            .header,
+                                                                        header.getContext()
+                                                                    )}
                                                             </TableHead>
                                                         )
                                                     )}
@@ -798,12 +797,12 @@ export default function SitesTable({
                                                                 {header.isPlaceholder
                                                                     ? null
                                                                     : flexRender(
-                                                                          header
-                                                                              .column
-                                                                              .columnDef
-                                                                              .header,
-                                                                          header.getContext()
-                                                                      )}
+                                                                        header
+                                                                            .column
+                                                                            .columnDef
+                                                                            .header,
+                                                                        header.getContext()
+                                                                    )}
                                                             </TableHead>
                                                         )
                                                     )}


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description
This PR fixes the responsive layout of `CardHeader` inside manage resources.

- Small: stacked vertically & centered
- Medium: search + tabs in one row, action button below centered
- Large: all in one row

Original:
<img width="685" height="618" alt="image" src="https://github.com/user-attachments/assets/c81cbd6f-06cc-4290-ac00-ae2badf47d6e" />

Fixed:
<img width="872" height="607" alt="image" src="https://github.com/user-attachments/assets/548a8df9-5927-4c4b-8d5a-250104c1394e" />

<img width="552" height="642" alt="image" src="https://github.com/user-attachments/assets/e9cda7f9-3dc0-4141-8984-c1b41ac35da6" />


## How to test?

