### PR TITLE
Preserve subdomain input when selecting a base domain

### DIFF
--- a/server/lib/schemas.ts
+++ b/server/lib/schemas.ts
@@ -1,18 +1,24 @@
 import { z } from "zod";
 
+
 export const subdomainSchema = z
     .string()
     .regex(
-        /^(?!:\/\/)([a-zA-Z0-9-_]+\.)*[a-zA-Z0-9-_]+$/,
+        /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/,
         "Invalid subdomain format"
     )
     .min(1, "Subdomain must be at least 1 character long")
+    .max(63, "Subdomain must not exceed 63 characters")
     .transform((val) => val.toLowerCase());
 
 export const tlsNameSchema = z
     .string()
     .regex(
-        /^(?!:\/\/)([a-zA-Z0-9-_]+\.)*[a-zA-Z0-9-_]+$|^$/,
+        /^([a-z0-9](?:[a-z0-9-]*[a-z0-9])?)(\.[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)*$/,
         "Invalid subdomain format"
-    )
+    ).max(253, "Domain must not exceed 253 characters")
+  .refine((val) => {
+    const labels = val.split('.');
+    return labels.every((label) => label.length <= 63);
+  }, "Each part of the domain must not exceed 63 characters")
     .transform((val) => val.toLowerCase());

--- a/server/lib/schemas.ts
+++ b/server/lib/schemas.ts
@@ -1,24 +1,19 @@
 import { z } from "zod";
 
-
 export const subdomainSchema = z
     .string()
     .regex(
-        /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/,
+        /^(?!:\/\/)([a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?\.)*[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$/,
         "Invalid subdomain format"
     )
     .min(1, "Subdomain must be at least 1 character long")
-    .max(63, "Subdomain must not exceed 63 characters")
     .transform((val) => val.toLowerCase());
 
 export const tlsNameSchema = z
     .string()
     .regex(
-        /^([a-z0-9](?:[a-z0-9-]*[a-z0-9])?)(\.[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)*$/,
+        /^(?!:\/\/)([a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?\.)*[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$|^$/,
         "Invalid subdomain format"
-    ).max(253, "Domain must not exceed 253 characters")
-  .refine((val) => {
-    const labels = val.split('.');
-    return labels.every((label) => label.length <= 63);
-  }, "Each part of the domain must not exceed 63 characters")
+    )
     .transform((val) => val.toLowerCase());
+

--- a/src/app/[orgId]/settings/resources/[resourceId]/general/page.tsx
+++ b/src/app/[orgId]/settings/resources/[resourceId]/general/page.tsx
@@ -86,6 +86,7 @@ export default function GeneralForm() {
         domainId: string;
         subdomain?: string;
         fullDomain: string;
+        baseDomain: string;
     } | null>(null);
 
     const GeneralFormSchema = z
@@ -442,7 +443,8 @@ export default function GeneralForm() {
                                     const selected = {
                                         domainId: res.domainId,
                                         subdomain: res.subdomain,
-                                        fullDomain: res.fullDomain
+                                        fullDomain: res.fullDomain,
+                                        baseDomain: res.baseDomain
                                     };
                                     setSelectedDomain(selected);
                                 }}
@@ -460,11 +462,8 @@ export default function GeneralForm() {
                                             : "";
 
                                         const sanitizedFullDomain = sanitizedSubdomain
-                                            ? `${sanitizedSubdomain}.${selectedDomain.fullDomain
-                                                .split(".")
-                                                .slice(-2)
-                                                .join(".")}`
-                                            : selectedDomain.fullDomain;
+                                            ? `${sanitizedSubdomain}.${selectedDomain.baseDomain}`
+                                            : selectedDomain.baseDomain;
 
                                         setResourceFullDomain(sanitizedFullDomain);
                                         form.setValue("domainId", selectedDomain.domainId);

--- a/src/app/[orgId]/settings/resources/[resourceId]/general/page.tsx
+++ b/src/app/[orgId]/settings/resources/[resourceId]/general/page.tsx
@@ -53,6 +53,7 @@ import {
 import DomainPicker from "@app/components/DomainPicker";
 import { Globe } from "lucide-react";
 import { build } from "@server/build";
+import { finalizeSubdomainSanitize } from "@app/lib/subdomain-utils";
 
 export default function GeneralForm() {
     const [formKey, setFormKey] = useState(0);
@@ -454,18 +455,27 @@ export default function GeneralForm() {
                             <Button
                                 onClick={() => {
                                     if (selectedDomain) {
-                                        setResourceFullDomain(
-                                            selectedDomain.fullDomain
-                                        );
-                                        form.setValue(
-                                            "domainId",
-                                            selectedDomain.domainId
-                                        );
-                                        form.setValue(
-                                            "subdomain",
-                                            selectedDomain.subdomain
-                                        );
+                                        const sanitizedSubdomain = selectedDomain.subdomain
+                                            ? finalizeSubdomainSanitize(selectedDomain.subdomain)
+                                            : "";
+
+                                        const sanitizedFullDomain = sanitizedSubdomain
+                                            ? `${sanitizedSubdomain}.${selectedDomain.fullDomain
+                                                .split(".")
+                                                .slice(-2)
+                                                .join(".")}`
+                                            : selectedDomain.fullDomain;
+
+                                        setResourceFullDomain(sanitizedFullDomain);
+                                        form.setValue("domainId", selectedDomain.domainId);
+                                        form.setValue("subdomain", sanitizedSubdomain);
+
                                         setEditDomainOpen(false);
+
+                                        toast({
+                                            title: "Domain sanitized",
+                                            description: `Final domain: ${sanitizedFullDomain}`,
+                                        });
                                     }
                                 }}
                             >

--- a/src/components/DomainPicker.tsx
+++ b/src/components/DomainPicker.tsx
@@ -263,7 +263,7 @@ export default function DomainPicker2({
 
         if (baseDomain.type === "provided-search") {
             return subdomain === "" || (
-                /^[a-zA-Z0-9.-]+$/.test(subdomain) &&
+                /^[a-zA-Z0-9-]+$/.test(subdomain) &&
                 isValidSubdomainStructure(subdomain)
             );
         }
@@ -274,7 +274,7 @@ export default function DomainPicker2({
             } else if (baseDomain.domainType === "ns" || baseDomain.domainType === "wildcard") {
                 // NS and wildcard domains support multi-level subdomains with dots and hyphens
                 return subdomain === "" || (
-                    /^[a-zA-Z0-9.-]+$/.test(subdomain) &&
+                    /^[a-zA-Z0-9-]+$/.test(subdomain) &&
                     isValidSubdomainStructure(subdomain)
                 );
             }
@@ -287,24 +287,17 @@ export default function DomainPicker2({
         if (!input) return "";
         return input
             .toLowerCase()
-            .replace(/[^a-z0-9.-]/g, "");
+            .replace(/[^a-z0-9-]/g, "");
     };
 
     const isValidSubdomainStructure = (subdomain: string): boolean => {
         if (!subdomain) return true;
 
-        // check for consecutive dots or hyphens
-        if (/\.{2,}|-{2,}/.test(subdomain)) return false;
+        // Check for consecutive hyphens
+        if (/--/.test(subdomain)) return false;
 
-        // check if starts or ends with hyphen or dot
-        if (/^[-.]|[-.]$/.test(subdomain)) return false;
-
-        // check each label >> (part between dots)
-        const parts = subdomain.split(".");
-        for (const part of parts) {
-            if (!part) return false; // Empty label
-            if (/^-|-$/.test(part)) return false; // Label starts/ends with hyphen
-        }
+        // Check if starts or ends with hyphen
+        if (/^-|-$/.test(subdomain)) return false;
 
         return true;
     };
@@ -369,7 +362,7 @@ export default function DomainPicker2({
         if (value !== sanitized) {
             toast({
                 title: "Invalid characters removed",
-                description: `Only letters, numbers, hyphens, and dots are allowed`,
+                description: `Only letters, numbers, and hyphens are allowed`,
             });
         }
 

--- a/src/lib/subdomain-utils.ts
+++ b/src/lib/subdomain-utils.ts
@@ -1,0 +1,59 @@
+
+export type DomainType = "organization" | "provided" | "provided-search";
+
+export const SINGLE_LABEL_RE = /^[a-z0-9-]+$/i; // provided-search (no dots)
+export const MULTI_LABEL_RE = /^[a-z0-9-]+(\.[a-z0-9-]+)*$/i; // ns/wildcard
+export const SINGLE_LABEL_STRICT_RE = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/i; // start/end alnum
+
+
+export function sanitizeInputRaw(input: string): string {
+  if (!input) return "";
+  return input.toLowerCase().replace(/[^a-z0-9.-]/g, "");
+}
+
+export function finalizeSubdomainSanitize(input: string): string {
+  if (!input) return "";
+  return input
+    .toLowerCase()
+    .replace(/[^a-z0-9.-]/g, "")   // allow only valid chars
+    .replace(/\.{2,}/g, ".")       // collapse multiple dots
+    .replace(/^-+|-+$/g, "")       // strip leading/trailing hyphens
+    .replace(/^\.+|\.+$/g, "");    // strip leading/trailing dots
+}
+
+
+
+
+export function validateByDomainType(subdomain: string, domainType: { type: "provided-search" | "organization"; domainType?: "ns" | "cname" | "wildcard" } ): boolean {
+  if (!domainType) return false;
+
+  if (domainType.type === "provided-search") {
+    return SINGLE_LABEL_RE.test(subdomain);
+  }
+
+  if (domainType.type === "organization") {
+    if (domainType.domainType === "cname") {
+      return subdomain === "";
+    } else if (domainType.domainType === "ns" || domainType.domainType === "wildcard") {
+      if (subdomain === "") return true;
+      if (!MULTI_LABEL_RE.test(subdomain)) return false;
+      const labels = subdomain.split(".");
+      return labels.every(l => l.length >= 1 && l.length <= 63 && SINGLE_LABEL_RE.test(l));
+    }
+  }
+  return false;
+}
+
+
+
+export const isValidSubdomainStructure = (input: string): boolean => {
+  const regex = /^(?!-)([a-zA-Z0-9-]{1,63})(?<!-)$/;
+
+  if (!input) return false;
+  if (input.includes("..")) return false;
+
+  return input.split(".").every(label => regex.test(label));
+};
+
+
+


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description
This PR resolves #1373 and #1369 , where a subdomain entered before selecting a base domain was not saved when creating or editing a resource.

**Changes introduced:**

- Users can safely type a subdomain before choosing a base domain without losing input.
- Subdomain change and base domain selection now both trigger validation → ensuring state stays in sync regardless of order of operations.
- Improved subdomain validation to ensure consistency across inputs.
- The subdomain is sanitized (invalid characters removed).
- If compatible, it is preserved and combined with the base domain.

## How to test?

