### PR TITLE
Feature #1318/Make version numbers link to GitHub releases and add Discord community link

### DIFF
--- a/src/components/LayoutMobileMenu.tsx
+++ b/src/components/LayoutMobileMenu.tsx
@@ -7,7 +7,7 @@ import { cn } from "@app/lib/cn";
 import { ListUserOrgsResponse } from "@server/routers/org";
 import SupporterStatus from "@app/components/SupporterStatus";
 import { Button } from "@app/components/ui/button";
-import { Menu, Server } from "lucide-react";
+import { ExternalLink, Menu, Server } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useUserContext } from "@app/hooks/useUserContext";
@@ -117,7 +117,15 @@ export function LayoutMobileMenu({
                                         <SupporterStatus />
                                         {env?.app?.version && (
                                             <div className="text-xs text-muted-foreground text-center">
-                                                v{env.app.version}
+                                                <Link
+                                                    href={`https://github.com/fosrl/pangolin/releases/tag/${env.app.version}`}
+                                                    target="_blank"
+                                                    rel="noopener noreferrer"
+                                                    className="flex items-center justify-center gap-1"
+                                                >
+                                                    v{env.app.version}
+                                                    <ExternalLink size={12} />
+                                                </Link>
                                             </div>
                                         )}
                                     </div>

--- a/src/components/LayoutSidebar.tsx
+++ b/src/components/LayoutSidebar.tsx
@@ -7,6 +7,7 @@ import { cn } from "@app/lib/cn";
 import { ListUserOrgsResponse } from "@server/routers/org";
 import SupporterStatus from "@app/components/SupporterStatus";
 import { ExternalLink, Server, BookOpenText, Zap } from "lucide-react";
+import { FaDiscord, FaGithub } from "react-icons/fa";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useUserContext } from "@app/hooks/useUserContext";
@@ -151,7 +152,7 @@ export function LayoutSidebar({
                                 {!isUnlocked()
                                     ? t("communityEdition")
                                     : t("commercialEdition")}
-                                <ExternalLink size={12} />
+                                <FaGithub size={12} />
                             </Link>
                         </div>
                         <div className="text-xs text-muted-foreground ">
@@ -165,9 +166,28 @@ export function LayoutSidebar({
                                 <BookOpenText size={12} />
                             </Link>
                         </div>
+                        <div className="text-xs text-muted-foreground text-center">
+                            <Link
+                                href="https://discord.gg/HCJR8Xhme4"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="flex items-center justify-center gap-1"
+                            >
+                                Discord
+                                <FaDiscord size={12} />
+                            </Link>
+                        </div>
                         {env?.app?.version && (
                             <div className="text-xs text-muted-foreground text-center">
-                                v{env.app.version}
+                                <Link
+                                    href={`https://github.com/fosrl/pangolin/releases/tag/${env.app.version}`}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="flex items-center justify-center gap-1"
+                                >
+                                    v{env.app.version}
+                                    <ExternalLink size={12} />
+                                </Link>
                             </div>
                         )}
                     </div>


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description
This PR links the version numbers to GitHub releases and adds a Discord community link to the sidebar, addressing issue #1318.

## Screenshots
### Desktop View
<img width="248" height="171" alt="image" src="https://github.com/user-attachments/assets/4f87b2ee-e0c6-4e65-9bf6-09de44f4f244" />
<img width="255" height="174" alt="image" src="https://github.com/user-attachments/assets/e7054ccb-8a37-4e47-934f-a2e2eda9f787" />

### Mobile View
<img width="257" height="98" alt="image" src="https://github.com/user-attachments/assets/c9092b3d-1543-4525-9254-51084fed236a" />
<img width="251" height="94" alt="image" src="https://github.com/user-attachments/assets/c3a48733-04a1-4598-802a-eca8a26d5b3c" />

## How to test?

