### PR TITLE
Fix/hostname field reset port and method

### DIFF
--- a/src/app/[orgId]/settings/resources/[resourceId]/proxy/page.tsx
+++ b/src/app/[orgId]/settings/resources/[resourceId]/proxy/page.tsx
@@ -650,8 +650,8 @@ export default function ReverseProxyTargets(props: {
                     className="min-w-[150px]"
                     onBlur={(e) => {
                         const input = e.target.value.trim();
-                        const hasProtocol = /^https?:\/\//.test(input);
-                        const hasPort = /:\d+/.test(input);
+                        const hasProtocol = /^(https?|h2c):\/\//.test(input);
+                        const hasPort = /:\d+(?:\/|$)/.test(input);
 
                         if (hasProtocol || hasPort) {
                             const parsed = parseHostTarget(input);
@@ -675,9 +675,7 @@ export default function ReverseProxyTargets(props: {
                             });
                         }
                     }}
-
                 />
-
             )
         },
         {
@@ -973,8 +971,8 @@ export default function ReverseProxyTargets(props: {
                                                         {...field}
                                                         onBlur={(e) => {
                                                             const input = e.target.value.trim();
-                                                            const hasProtocol = /^https?:\/\//.test(input);
-                                                            const hasPort = /:\d+/.test(input);
+                                                            const hasProtocol = /^(https?|h2c):\/\//.test(input);
+                                                            const hasPort = /:\d+(?:\/|$)/.test(input);
 
                                                             if (hasProtocol || hasPort) {
                                                                 const parsed = parseHostTarget(input);

--- a/src/app/[orgId]/settings/resources/[resourceId]/proxy/page.tsx
+++ b/src/app/[orgId]/settings/resources/[resourceId]/proxy/page.tsx
@@ -649,18 +649,29 @@ export default function ReverseProxyTargets(props: {
                     defaultValue={row.original.ip}
                     className="min-w-[150px]"
                     onBlur={(e) => {
-                        const parsed = parseHostTarget(e.target.value);
-                        if (parsed) {
-                            updateTarget(row.original.targetId, {
-                                ...row.original,
-                                method: parsed.protocol,
-                                ip: parsed.host,
-                                port: parsed.port
-                            });
+                        const input = e.target.value.trim();
+                        const hasProtocol = /^https?:\/\//.test(input);
+                        const hasPort = /:\d+/.test(input);
+
+                        if (hasProtocol || hasPort) {
+                            const parsed = parseHostTarget(input);
+                            if (parsed) {
+                                updateTarget(row.original.targetId, {
+                                    ...row.original,
+                                    method: hasProtocol ? parsed.protocol : row.original.method,
+                                    ip: parsed.host,
+                                    port: hasPort ? parsed.port : row.original.port
+                                });
+                            } else {
+                                updateTarget(row.original.targetId, {
+                                    ...row.original,
+                                    ip: input
+                                });
+                            }
                         } else {
                             updateTarget(row.original.targetId, {
                                 ...row.original,
-                                ip: e.target.value
+                                ip: input
                             });
                         }
                     }}
@@ -961,11 +972,21 @@ export default function ReverseProxyTargets(props: {
                                                         id="ip"
                                                         {...field}
                                                         onBlur={(e) => {
-                                                            const parsed = parseHostTarget(e.target.value);
-                                                            if (parsed) {
-                                                                addTargetForm.setValue("method", parsed.protocol);
-                                                                addTargetForm.setValue("ip", parsed.host);
-                                                                addTargetForm.setValue("port", parsed.port);
+                                                            const input = e.target.value.trim();
+                                                            const hasProtocol = /^https?:\/\//.test(input);
+                                                            const hasPort = /:\d+/.test(input);
+
+                                                            if (hasProtocol || hasPort) {
+                                                                const parsed = parseHostTarget(input);
+                                                                if (parsed) {
+                                                                    if (hasProtocol || !addTargetForm.getValues("method")) {
+                                                                        addTargetForm.setValue("method", parsed.protocol);
+                                                                    }
+                                                                    addTargetForm.setValue("ip", parsed.host);
+                                                                    if (hasPort || !addTargetForm.getValues("port")) {
+                                                                        addTargetForm.setValue("port", parsed.port);
+                                                                    }
+                                                                }
                                                             } else {
                                                                 field.onBlur();
                                                             }

--- a/src/lib/parseHostTarget.ts
+++ b/src/lib/parseHostTarget.ts
@@ -1,15 +1,29 @@
+
 export function parseHostTarget(input: string) {
   try {
-    const normalized = input.match(/^https?:\/\//) ? input : `http://${input}`;
+    const normalized = input.match(/^(https?|h2c):\/\//) ? input : `http://${input}`;
     const url = new URL(normalized);
 
-    const protocol = url.protocol.replace(":", ""); // http | https
+    const protocol = url.protocol.replace(":", ""); // http | https | h2c
     const host = url.hostname;
-    const port = url.port ? parseInt(url.port, 10) : protocol === "https" ? 443 : 80;
+    
+    let defaultPort: number;
+    switch (protocol) {
+      case "https":
+        defaultPort = 443;
+        break;
+      case "h2c":
+        defaultPort = 80; 
+        break;
+      default: // http
+        defaultPort = 80;
+        break;
+    }
+    
+    const port = url.port ? parseInt(url.port, 10) : defaultPort;
 
     return { protocol, host, port };
   } catch {
     return null;
   }
 }
-


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description
Modified the handlers to only trigger URL parsing when the input actually looks like a URL.

**Conditional updates:**
- Method: Only update if protocol was explicitly provided OR no method currently set
- Port: Only update if port was explicitly provided OR no port currently set
- IP: Always update (this is the primary field)

**Preserve existing values: Plain IP/hostname entries don't trigger parsing at all.
Update the parseHostTarget to support h2c.**

Fixes: #1393 

## How to test?

