### PR TITLE
Enhancement #906/Persist User Preference for Entries Amount

### DIFF
--- a/src/app/[orgId]/settings/access/invitations/InvitationsDataTable.tsx
+++ b/src/app/[orgId]/settings/access/invitations/InvitationsDataTable.tsx
@@ -22,6 +22,7 @@ export function InvitationsDataTable<TData, TValue>({
         <DataTable
             columns={columns}
             data={data}
+            persistPageSize="invitations-table"
             title={t('invite')}
             searchPlaceholder={t('inviteSearch')}
             searchColumn="email"

--- a/src/app/[orgId]/settings/access/roles/RolesDataTable.tsx
+++ b/src/app/[orgId]/settings/access/roles/RolesDataTable.tsx
@@ -24,6 +24,7 @@ export function RolesDataTable<TData, TValue>({
         <DataTable
             columns={columns}
             data={data}
+            persistPageSize="roles-table"
             title={t('roles')}
             searchPlaceholder={t('accessRolesSearch')}
             searchColumn="name"

--- a/src/app/[orgId]/settings/access/users/UsersDataTable.tsx
+++ b/src/app/[orgId]/settings/access/users/UsersDataTable.tsx
@@ -24,6 +24,7 @@ export function UsersDataTable<TData, TValue>({
         <DataTable
             columns={columns}
             data={data}
+            persistPageSize="users-table"
             title={t('users')}
             searchPlaceholder={t('accessUsersSearch')}
             searchColumn="email"

--- a/src/app/[orgId]/settings/api-keys/OrgApiKeysDataTable.tsx
+++ b/src/app/[orgId]/settings/api-keys/OrgApiKeysDataTable.tsx
@@ -22,6 +22,7 @@ export function OrgApiKeysDataTable<TData, TValue>({
         <DataTable
             columns={columns}
             data={data}
+            persistPageSize="Org-apikeys-table"
             title={t('apiKeys')}
             searchPlaceholder={t('searchApiKeys')}
             searchColumn="name"

--- a/src/app/[orgId]/settings/clients/ClientsDataTable.tsx
+++ b/src/app/[orgId]/settings/clients/ClientsDataTable.tsx
@@ -20,6 +20,7 @@ export function ClientsDataTable<TData, TValue>({
         <DataTable
             columns={columns}
             data={data}
+            persistPageSize="clients-table"
             title="Clients"
             searchPlaceholder="Search clients..."
             searchColumn="name"

--- a/src/app/[orgId]/settings/domains/DomainsDataTable.tsx
+++ b/src/app/[orgId]/settings/domains/DomainsDataTable.tsx
@@ -25,6 +25,7 @@ export function DomainsDataTable<TData, TValue>({
         <DataTable
             columns={columns}
             data={data}
+            persistPageSize="domains-table"
             title={t("domains")}
             searchPlaceholder={t("domainsSearch")}
             searchColumn="baseDomain"

--- a/src/app/[orgId]/settings/resources/ResourcesTable.tsx
+++ b/src/app/[orgId]/settings/resources/ResourcesTable.tsx
@@ -626,7 +626,7 @@ export default function ResourcesTable({
         onGlobalFilterChange: setInternalGlobalFilter,
         initialState: {
             pagination: {
-                pageSize: proxyPageSize,
+                pageSize: internalPageSize,
                 pageIndex: 0
             }
         },

--- a/src/app/[orgId]/settings/share-links/ShareLinksDataTable.tsx
+++ b/src/app/[orgId]/settings/share-links/ShareLinksDataTable.tsx
@@ -24,6 +24,7 @@ export function ShareLinksDataTable<TData, TValue>({
         <DataTable
             columns={columns}
             data={data}
+            persistPageSize="shareLinks-table"
             title={t('shareLinks')}
             searchPlaceholder={t('shareSearch')}
             searchColumn="name"

--- a/src/app/[orgId]/settings/sites/SitesDataTable.tsx
+++ b/src/app/[orgId]/settings/sites/SitesDataTable.tsx
@@ -26,6 +26,7 @@ export function SitesDataTable<TData, TValue>({
         <DataTable
             columns={columns}
             data={data}
+            persistPageSize="sites-table"
             title={t('sites')}
             searchPlaceholder={t('searchSitesProgress')}
             searchColumn="name"

--- a/src/app/admin/api-keys/ApiKeysDataTable.tsx
+++ b/src/app/admin/api-keys/ApiKeysDataTable.tsx
@@ -47,6 +47,7 @@ export function ApiKeysDataTable<TData, TValue>({
         <DataTable
             columns={columns}
             data={data}
+            persistPageSize="apiKeys-table"
             title={t('apiKeys')}
             searchPlaceholder={t('searchApiKeys')}
             searchColumn="name"

--- a/src/app/admin/idp/AdminIdpDataTable.tsx
+++ b/src/app/admin/idp/AdminIdpDataTable.tsx
@@ -21,6 +21,7 @@ export function IdpDataTable<TData, TValue>({
         <DataTable
             columns={columns}
             data={data}
+            persistPageSize="idp-table"
             title={t('idp')}
             searchPlaceholder={t('idpSearch')}
             searchColumn="name"

--- a/src/app/admin/idp/[idpId]/policies/PolicyDataTable.tsx
+++ b/src/app/admin/idp/[idpId]/policies/PolicyDataTable.tsx
@@ -22,6 +22,7 @@ export function PolicyDataTable<TData, TValue>({
         <DataTable
             columns={columns}
             data={data}
+            persistPageSize="orgPolicies-table"
             title={t('orgPolicies')}
             searchPlaceholder={t('orgPoliciesSearch')}
             searchColumn="orgId"

--- a/src/app/admin/license/LicenseKeysDataTable.tsx
+++ b/src/app/admin/license/LicenseKeysDataTable.tsx
@@ -136,6 +136,7 @@ export function LicenseKeysDataTable({
         <DataTable
             columns={columns}
             data={licenseKeys}
+            persistPageSize="licenseKeys-table"
             title={t('licenseKeys')}
             searchPlaceholder={t('licenseKeySearch')}
             searchColumn="licenseKey"

--- a/src/app/admin/users/AdminUsersDataTable.tsx
+++ b/src/app/admin/users/AdminUsersDataTable.tsx
@@ -22,6 +22,7 @@ export function UsersDataTable<TData, TValue>({
         <DataTable
             columns={columns}
             data={data}
+            persistPageSize="userServer-table"
             title={t('userServer')}
             searchPlaceholder={t('userSearch')}
             searchColumn="email"

--- a/src/components/DataTablePagination.tsx
+++ b/src/components/DataTablePagination.tsx
@@ -18,28 +18,38 @@ import { useTranslations } from "next-intl";
 
 interface DataTablePaginationProps<TData> {
     table: Table<TData>;
+    onPageSizeChange?: (pageSize: number) => void;
 }
 
 export function DataTablePagination<TData>({
-    table
+    table,
+    onPageSizeChange
 }: DataTablePaginationProps<TData>) {
     const t = useTranslations();
+
+    const handlePageSizeChange = (value: string) => {
+        const newPageSize = Number(value);
+        table.setPageSize(newPageSize);
+        
+        // Call the callback if provided (for persistence)
+        if (onPageSizeChange) {
+            onPageSizeChange(newPageSize);
+        }
+    };
 
     return (
         <div className="flex items-center justify-between text-muted-foreground">
             <div className="flex items-center space-x-2">
                 <Select
                     value={`${table.getState().pagination.pageSize}`}
-                    onValueChange={(value) => {
-                        table.setPageSize(Number(value));
-                    }}
+                    onValueChange={handlePageSizeChange}
                 >
                     <SelectTrigger className="h-8 w-[70px]">
                         <SelectValue
                             placeholder={table.getState().pagination.pageSize}
                         />
                     </SelectTrigger>
-                    <SelectContent side="top">
+                    <SelectContent side="bottom">
                         {[10, 20, 30, 40, 50, 100].map((pageSize) => (
                             <SelectItem key={pageSize} value={`${pageSize}`}>
                                 {pageSize}


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description
This PR addresses usability issues highlighted in #906 .

**4.4 — Does Not Save Amount of Entries**
The “entries per page” setting is not remembered and resets after every page refresh.

**Fix**
- Persist user preference for the number of entries displayed.
- Ensure the setting is retained across sessions.

Extracted from PR : #1283 

## How to test?

