### PR TITLE
Enter key handling & hostname field reset in resource create

### DIFF
--- a/src/app/[orgId]/settings/api-keys/create/page.tsx
+++ b/src/app/[orgId]/settings/api-keys/create/page.tsx
@@ -210,6 +210,11 @@ export default function Page() {
                                         <SettingsSectionForm>
                                             <Form {...form}>
                                                 <form
+                                                    onKeyDown={(e) => {
+                                                        if (e.key === "Enter") {
+                                                            e.preventDefault(); // block default enter refresh
+                                                        }
+                                                    }}
                                                     className="space-y-4"
                                                     id="create-site-form"
                                                 >

--- a/src/app/[orgId]/settings/clients/create/page.tsx
+++ b/src/app/[orgId]/settings/clients/create/page.tsx
@@ -440,6 +440,11 @@ export default function Page() {
                                 <SettingsSectionForm>
                                     <Form {...form}>
                                         <form
+                                            onKeyDown={(e) => {
+                                                if (e.key === "Enter") {
+                                                    e.preventDefault(); // block default enter refresh
+                                                }
+                                            }}
                                             className="space-y-4"
                                             id="create-client-form"
                                         >

--- a/src/app/[orgId]/settings/sites/create/page.tsx
+++ b/src/app/[orgId]/settings/sites/create/page.tsx
@@ -620,6 +620,11 @@ WantedBy=default.target`
                                 <SettingsSectionForm>
                                     <Form {...form}>
                                         <form
+                                            onKeyDown={(e) => {
+                                                if (e.key === "Enter") {
+                                                    e.preventDefault(); // block default enter refresh
+                                                }
+                                            }}
                                             className="space-y-4"
                                             id="create-site-form"
                                         >

--- a/src/app/admin/api-keys/create/page.tsx
+++ b/src/app/admin/api-keys/create/page.tsx
@@ -200,6 +200,11 @@ export default function Page() {
                                         <SettingsSectionForm>
                                             <Form {...form}>
                                                 <form
+                                                    onKeyDown={(e) => {
+                                                        if (e.key === "Enter") {
+                                                            e.preventDefault(); // block default enter refresh
+                                                        }
+                                                    }}
                                                     className="space-y-4"
                                                     id="create-site-form"
                                                 >


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description
**1. Weird "Enter" Behaviors (Page reload on Enter) (4.5)  : #906**
Prevented unintended page refresh on Enter that could cause unsaved data loss.

**2. Hostname Field Resetting Port/Method inside "Create Resource Page"**  
(Similar to fix : #1394)
Fixed hostname resetting method and port values.

## How to test?

