### PR TITLE
Fix: Include "region" field in ExitNode query to match schema

### DIFF
--- a/server/lib/exitNodes/exitNodes.ts
+++ b/server/lib/exitNodes/exitNodes.ts
@@ -30,7 +30,8 @@ export async function listExitNodes(orgId: string, filterOnline = false) {
             maxConnections: exitNodes.maxConnections,
             online: exitNodes.online,
             lastPing: exitNodes.lastPing,
-            type: exitNodes.type
+            type: exitNodes.type,
+            region: exitNodes.region
         })
         .from(exitNodes);
 


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description
This PR fixes a type mismatch issue in `listExitNodes`. The `ExitNode` type expects a `region: string | null` field, but the query did not select it, causing errors.

## How to test?

