### PR TITLE
Fix inconsistent destinationIp validation between create and update APIs

### DIFF
--- a/server/routers/siteResource/updateSiteResource.ts
+++ b/server/routers/siteResource/updateSiteResource.ts
@@ -28,7 +28,7 @@ const updateSiteResourceSchema = z
         protocol: z.enum(["tcp", "udp"]).optional(),
         proxyPort: z.number().int().positive().optional(),
         destinationPort: z.number().int().positive().optional(),
-        destinationIp: z.string().ip().optional(),
+        destinationIp: z.string().optional(),
         enabled: z.boolean().optional()
     })
     .strict();


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description
This PR resolves the inconsistency reported in #1419 and #1426 where the update site resource rejected hostnames (localhost, host.docker.internal, etc.) due to strict .ip() validation, while the create API accepted them.

## How to test?

