### PR TITLE
Update page.tsx

### DIFF
--- a/src/app/[orgId]/settings/clients/create/page.tsx
+++ b/src/app/[orgId]/settings/clients/create/page.tsx
@@ -178,7 +178,7 @@ export default function Page() {
             },
             windows: {
                 x64: [
-                    `curl -o olm.exe -L "https://github.com/fosrl/olm/releases/download/${version}/olm_windows_installer.exe"`,
+                    `curl -o olm.exe -L "https://github.com/fosrl/olm/releases/download/${version}/olm_windows_amd64.exe"`,
                     `# Run the installer to install olm and wintun`,
                     `olm.exe --id ${id} --secret ${secret} --endpoint ${endpoint}`
                 ]


### PR DESCRIPTION
Previously pointed towards "https://github.com/fosrl/olm/releases/1.1.1/olm_windows_installer.exe".  The olm_windows_installer.exe binary is not provided in release 1.1.1.  Updated to point to the olm_windows_amd64.exe binary, which is provided in the 1.1.1. assets.

## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description

Pangolin v1.9.4 -> clients -> add client -> windows curl command fails.  The binary olm_windows_installer.exe does not exist under assets in https://github.com/fosrl/olm/releases/download/1.1.1/.  Updated to point at old_windows_amd64.exe binary, which is provided in assets. 


