### PR TITLE
Revert "fix: change default integration_api to 3004"

### DIFF
--- a/server/lib/readConfigFile.ts
+++ b/server/lib/readConfigFile.ts
@@ -64,7 +64,7 @@ export const configSchema = z
         server: z.object({
             integration_port: portSchema
                 .optional()
-                .default(3004)
+                .default(3003)
                 .transform(stoi)
                 .pipe(portSchema.optional()),
             external_port: portSchema


### PR DESCRIPTION
Reverts fosrl/pangolin#1281. It makes absolutely no sense that Pangolin uses ports 3000-3002, skips 3003, and uses 3004. Gerbil should have been changed instead. This is a particularly annoying inconsistency as it prevents me from elegantly mapping the default pangolin ports in a functional language if I have to arbitrarily skip a number:

https://github.com/NixOS/nixpkgs/blob/da9f816ee7211d180eb1bc28f22358b9668b5fbe/nixos/modules/services/networking/pangolin/default.nix#L375-L395

https://github.com/fosrl/gerbil/pull/28