### PR TITLE
feat(sites): adding official kubernetes helm install command for newt

### DIFF
--- a/src/app/[orgId]/settings/clients/create/page.tsx
+++ b/src/app/[orgId]/settings/clients/create/page.tsx
@@ -42,6 +42,10 @@ import {
     FaFreebsd,
     FaWindows
 } from "react-icons/fa";
+import { 
+    SiNixos,
+    SiKubernetes
+} from "react-icons/si";
 import { Alert, AlertDescription, AlertTitle } from "@app/components/ui/alert";
 import { createApiClient, formatAxiosError } from "@app/lib/api";
 import { useEnvContext } from "@app/hooks/useEnvContext";
@@ -248,10 +252,14 @@ export default function Page() {
                 return <FaApple className="h-4 w-4 mr-2" />;
             case "docker":
                 return <FaDocker className="h-4 w-4 mr-2" />;
+            case "kubernetes":
+                return <SiKubernetes className="h-4 w-4 mr-2" />;
             case "podman":
                 return <FaCubes className="h-4 w-4 mr-2" />;
             case "freebsd":
                 return <FaFreebsd className="h-4 w-4 mr-2" />;
+            case "nixos":
+                return <SiNixos className="h-4 w-4 mr-2" />;
             default:
                 return <Terminal className="h-4 w-4 mr-2" />;
         }

--- a/src/app/[orgId]/settings/sites/create/page.tsx
+++ b/src/app/[orgId]/settings/sites/create/page.tsx
@@ -42,7 +42,10 @@ import {
     FaFreebsd,
     FaWindows
 } from "react-icons/fa";
-import { SiNixos } from "react-icons/si";
+import { 
+    SiNixos,
+    SiKubernetes
+} from "react-icons/si";
 import { Checkbox, CheckboxWithLabel } from "@app/components/ui/checkbox";
 import { Alert, AlertDescription, AlertTitle } from "@app/components/ui/alert";
 import { generateKeypair } from "../[niceId]/wireguardConfig";
@@ -76,6 +79,7 @@ type Commands = {
     freebsd: Record<string, string[]>;
     windows: Record<string, string[]>;
     docker: Record<string, string[]>;
+    kubernetes: Record<string, string[]>;
     podman: Record<string, string[]>;
     nixos: Record<string, string[]>;
 };
@@ -83,6 +87,7 @@ type Commands = {
 const platforms = [
     "linux",
     "docker",
+    "kubernetes",
     "podman",
     "mac",
     "windows",
@@ -277,6 +282,18 @@ PersistentKeepalive = 5`;
                     `docker run -dit fosrl/newt --id ${id} --secret ${secret} --endpoint ${endpoint}${acceptClientsFlag}`
                 ]
             },
+            kubernetes: {
+                "Helm Chart": [
+                    `helm repo add fossorial https://charts.fossorial.io`,
+                    `helm repo update fossorial`,
+                    `helm install newt fossorial/newt \\
+    --create-namespace \\
+    --set newtInstances[0].name="main-tunnel" \\
+    --set-string newtInstances[0].auth.keys.endpointKey="${endpoint}" \\
+    --set-string newtInstances[0].auth.keys.idKey="${id}" \\
+    --set-string newtInstances[0].auth.keys.secretKey="${secret}"`
+                ]
+            },
             podman: {
                 "Podman Quadlet": [
                     `[Unit]
@@ -324,6 +341,8 @@ WantedBy=default.target`
                 return ["x64"];
             case "docker":
                 return ["Docker Compose", "Docker Run"];
+            case "kubernetes":
+                return ["Helm Chart"];
             case "podman":
                 return ["Podman Quadlet", "Podman Run"];
             case "freebsd":
@@ -345,6 +364,8 @@ WantedBy=default.target`
                 return "macOS";
             case "docker":
                 return "Docker";
+            case "kubernetes":
+                return "Kubernetes";
             case "podman":
                 return "Podman";
             case "freebsd":
@@ -391,6 +412,8 @@ WantedBy=default.target`
                 return <FaApple className="h-4 w-4 mr-2" />;
             case "docker":
                 return <FaDocker className="h-4 w-4 mr-2" />;
+            case "kubernetes":
+                return <SiKubernetes className="h-4 w-4 mr-2" />;
             case "podman":
                 return <FaCubes className="h-4 w-4 mr-2" />;
             case "freebsd":


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description by Copilot

This pull request adds support for the Kubernetes platform to both the client and site creation pages, ensuring that Kubernetes is now available as an option alongside existing platforms. The changes include updates to the UI, platform selection logic, and command generation for Kubernetes deployments.

Kubernetes platform support:

- Added SiKubernetes icon import and usage for Kubernetes in both src/app/[orgId]/settings/clients/create/page.tsx and src/app/[orgId]/settings/sites/create/page.tsx, enabling visual identification of the platform. ([src/app/[orgId]/settings/clients/create/page.tsxR45-R48](https://github.com/fosrl/pangolin/pull/1462/files#diff-e59d0a6a1f08cd93a1afbbe17cb31aee16a0d00236b253bf2a6b4060ff594615R45-R48), [src/app/[orgId]/settings/sites/create/page.tsxL45-R48](https://github.com/fosrl/pangolin/pull/1462/files#diff-9a4504bba61ccdd29185e266cfc61b36c979b55a6fffe15c1741d456d8dbfe34L45-R48), [src/app/[orgId]/settings/clients/create/page.tsxR255-R262](https://github.com/fosrl/pangolin/pull/1462/files#diff-e59d0a6a1f08cd93a1afbbe17cb31aee16a0d00236b253bf2a6b4060ff594615R255-R262), [src/app/[orgId]/settings/sites/create/page.tsxR417-R418](https://github.com/fosrl/pangolin/pull/1462/files#diff-9a4504bba61ccdd29185e266cfc61b36c979b55a6fffe15c1741d456d8dbfe34R417-R418))

- Included "kubernetes" in the list of supported platforms and in the Commands type definition, allowing it to be selected and handled like other platforms. ([src/app/[orgId]/settings/sites/create/page.tsxR82-R90](https://github.com/fosrl/pangolin/pull/1462/files#diff-9a4504bba61ccdd29185e266cfc61b36c979b55a6fffe15c1741d456d8dbfe34R82-R90))

- Added Kubernetes-specific deployment commands (Helm Chart instructions) to the command generation logic for sites. ([src/app/[orgId]/settings/sites/create/page.tsxR285-R298](https://github.com/fosrl/pangolin/pull/1462/files#diff-9a4504bba61ccdd29185e266cfc61b36c979b55a6fffe15c1741d456d8dbfe34R285-R298))

- Updated platform label and option logic to display "Kubernetes" as a selectable and recognizable option in the UI. ([src/app/[orgId]/settings/sites/create/page.tsxR346-R347](https://github.com/fosrl/pangolin/pull/1462/files#diff-9a4504bba61ccdd29185e266cfc61b36c979b55a6fffe15c1741d456d8dbfe34R346-R347), [src/app/[orgId]/settings/sites/create/page.tsxR369-R370](https://github.com/fosrl/pangolin/pull/1462/files#diff-9a4504bba61ccdd29185e266cfc61b36c979b55a6fffe15c1741d456d8dbfe34R369-R370))

<img width="1857" height="856" alt="grafik" src="https://github.com/user-attachments/assets/a100701f-0aad-48ea-8672-2f5a7fda528f" />

