### PR TITLE
Use niceId for resource URLs to prevent 307 redirects

### DIFF
--- a/src/components/ResourcesTable.tsx
+++ b/src/components/ResourcesTable.tsx
@@ -462,7 +462,7 @@ export default function ResourcesTable({
                             <DropdownMenuContent align="end">
                                 <Link
                                     className="block w-full"
-                                    href={`/${resourceRow.orgId}/settings/resources/${resourceRow.id}`}
+                                    href={`/${resourceRow.orgId}/settings/resources/${resourceRow.nice}`}
                                 >
                                     <DropdownMenuItem>
                                         {t("viewSettings")}


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description
Update the `ResourcesTable` to use `resourceRow.nice` (niceId) instead of `resourceRow.id` when building resource URLs.
Using .id caused 307 redirects and broken pages.

## How to test?

