### PR TITLE
Add minor version tags to Docker build commands in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 .PHONY: build build-pg build-release build-arm build-x86 test clean
 
+minor_tag := $(shell echo $(tag) | cut -d. -f1,2)
 build-release:
 	@if [ -z "$(tag)" ]; then \
 		echo "Error: tag is required. Usage: make build-release tag=<tag>"; \
@@ -7,8 +8,10 @@ build-release:
 	fi
 	docker buildx build --build-arg DATABASE=sqlite --platform linux/arm64,linux/amd64 -t fosrl/pangolin:latest --push .
 	docker buildx build --build-arg DATABASE=sqlite --platform linux/arm64,linux/amd64 -t fosrl/pangolin:$(tag) --push .
+	docker buildx build --build-arg DATABASE=sqlite --platform linux/arm64,linux/amd64 -t fosrl/pangolin:$(minor_tag) --push .
 	docker buildx build --build-arg DATABASE=pg --platform linux/arm64,linux/amd64 -t fosrl/pangolin:postgresql-latest --push .
 	docker buildx build --build-arg DATABASE=pg --platform linux/arm64,linux/amd64 -t fosrl/pangolin:postgresql-$(tag) --push .
+	docker buildx build --build-arg DATABASE=pg --platform linux/arm64,linux/amd64 -t fosrl/pangolin:postgresql-$(minor_tag) --push .
 
 build-arm:
 	docker buildx build --platform linux/arm64 -t fosrl/pangolin:latest .


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description
Add minor image tags to allow automatic patch updates with [watchtower](https://github.com/containrrr/watchtower).

## How to test?
Add test command in Makefile:
`
test:
        @echo "test $(minor_tag)"
`

Run commands:
`
make test
make test tag=1
make test tag=1.22
make test tag=1.22.4
`
