### PR TITLE
Fix resource auth API call to use resourceGuid instead of resourceid

### DIFF
--- a/src/app/[orgId]/settings/resources/[niceId]/layout.tsx
+++ b/src/app/[orgId]/settings/resources/[niceId]/layout.tsx
@@ -46,7 +46,7 @@ export default async function ResourceLayout(props: ResourceLayoutProps) {
     try {
         const res = await internal.get<
             AxiosResponse<GetResourceAuthInfoResponse>
-        >(`/resource/${resource.resourceId}/auth`, await authCookieHeader());
+        >(`/resource/${resource.resourceGuid}/auth`, await authCookieHeader());
         authInfo = res.data.data;
     } catch {
         redirect(`/${params.orgId}/settings/resources`);


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description
Resource Auth API call was incorrectly referencing `resource.resourceid` instead of the correct field `resource.resourceGuid`.

The mismatch (resourceid vs resourceGuid) caused the resource auth lookup to fail, triggering an unnecessary redirect back to
`/resources`

## How to test?

