### PR TITLE
Add docker dev image creation workflow for PRs

### DIFF
--- a/.github/workflows/dev-image.yml
+++ b/.github/workflows/dev-image.yml
@@ -1,0 +1,70 @@
+name: Create Dev-Image
+
+on:
+  pull_request:
+    branches:
+      - main
+      - dev
+    types: 
+      - opened
+      - synchronize
+      - reopened
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Docker image SQLITE
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64
+          push: true
+          tags: ${{ secrets.DOCKER_HUB_REPO }}:dev-pr${{ github.event.pull_request.number }}
+          cache-from: type=registry,ref=${{ secrets.DOCKER_HUB_REPO }}:buildcache
+          cache-to: type=registry,ref=${{ secrets.DOCKER_HUB_REPO }}:buildcache,mode=max
+          build-args: DATABASE=sqlite
+            
+      - name: Build and push Docker image PG
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64
+          push: true
+          tags: ${{ secrets.DOCKER_HUB_REPO }}:postgresql-dev-pr${{ github.event.pull_request.number }}
+          cache-from: type=registry,ref=${{ secrets.DOCKER_HUB_REPO }}:buildcache-pg
+          cache-to: type=registry,ref=${{ secrets.DOCKER_HUB_REPO }}:buildcache-pg,mode=max
+          build-args: DATABASE=pg
+          
+      - uses: actions/github-script@v8
+        env:
+          REPO: https://hub.docker.com/r/${{ secrets.DOCKER_HUB_REPO }}/tags
+          DEV_PR: ${{ secrets.DOCKER_HUB_REPO }}:dev-pr${{ github.event.pull_request.number }}
+          DEV_PR_PG: ${{ secrets.DOCKER_HUB_REPO }}:postgresql-dev-pr${{ github.event.pull_request.number }}
+        with:
+          script: |
+            const repo = process.env.REPO;
+            const devPr = process.env.DEV_PR;
+            const devPrPg = process.env.DEV_PR_PG;
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `👋 Thanks for your PR!  
+              Dev images for this PR are now available on [docker hub](${repo}):
+              **SQLITE Image**
+              \`\`\`
+              ${devPr}
+              \`\`\`
+              **Postgresql Image**
+              \`\`\`
+              ${devPrPg}
+              \`\`\``
+            })

--- a/.github/workflows/dev-image.yml
+++ b/.github/workflows/dev-image.yml
@@ -13,6 +13,12 @@ on:
 jobs:
   docker:
     runs-on: ubuntu-latest
+
+    env:
+      TAG_URL: https://hub.docker.com/r/${{ vars.DOCKER_HUB_REPO }}/tags
+      TAG: ${{ vars.DOCKER_HUB_REPO }}:dev-pr${{ github.event.pull_request.number }}
+      TAG_PG: ${{ vars.DOCKER_HUB_REPO }}:postgresql-dev-pr${{ github.event.pull_request.number }}
+    
     steps:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -28,9 +34,9 @@ jobs:
         with:
           platforms: linux/amd64
           push: true
-          tags: ${{ secrets.DOCKER_HUB_REPO }}:dev-pr${{ github.event.pull_request.number }}
-          cache-from: type=registry,ref=${{ secrets.DOCKER_HUB_REPO }}:buildcache
-          cache-to: type=registry,ref=${{ secrets.DOCKER_HUB_REPO }}:buildcache,mode=max
+          tags: ${{ env.TAG }}
+          cache-from: type=registry,ref=${{ vars.DOCKER_HUB_REPO }}:buildcache
+          cache-to: type=registry,ref=${{ vars.DOCKER_HUB_REPO }}:buildcache,mode=max
           build-args: DATABASE=sqlite
             
       - name: Build and push Docker image PG
@@ -38,33 +44,32 @@ jobs:
         with:
           platforms: linux/amd64
           push: true
-          tags: ${{ secrets.DOCKER_HUB_REPO }}:postgresql-dev-pr${{ github.event.pull_request.number }}
-          cache-from: type=registry,ref=${{ secrets.DOCKER_HUB_REPO }}:buildcache-pg
-          cache-to: type=registry,ref=${{ secrets.DOCKER_HUB_REPO }}:buildcache-pg,mode=max
+          tags: ${{ env.TAG_PG }}
+          cache-from: type=registry,ref=${{ vars.DOCKER_HUB_REPO }}:buildcache-pg
+          cache-to: type=registry,ref=${{ vars.DOCKER_HUB_REPO }}:buildcache-pg,mode=max
           build-args: DATABASE=pg
           
       - uses: actions/github-script@v8
-        env:
-          REPO: https://hub.docker.com/r/${{ secrets.DOCKER_HUB_REPO }}/tags
-          DEV_PR: ${{ secrets.DOCKER_HUB_REPO }}:dev-pr${{ github.event.pull_request.number }}
-          DEV_PR_PG: ${{ secrets.DOCKER_HUB_REPO }}:postgresql-dev-pr${{ github.event.pull_request.number }}
         with:
           script: |
-            const repo = process.env.REPO;
-            const devPr = process.env.DEV_PR;
-            const devPrPg = process.env.DEV_PR_PG;
+            const repoUrl = process.env.TAG_URL;
+            const tag = process.env.TAG;
+            const tagPg = process.env.TAG_PG;
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
               body: `👋 Thanks for your PR!  
-              Dev images for this PR are now available on [docker hub](${repo}):
-              **SQLITE Image**
+              Dev images for this PR are now available on [docker hub](${repoUrl}):
+              
+              **SQLITE Image:**
               \`\`\`
-              ${devPr}
+              ${tag}
               \`\`\`
-              **Postgresql Image**
+              
+              **Postgresql Image:**
               \`\`\`
-              ${devPrPg}
+              ${tagPg}
               \`\`\``
             })
+            


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description
This workflow creates an amd64 image for sqlite and postgresql version of each PR against `main` and `dev` branch in a docker hub repo specified with github variable `DOCKER_HUB_REPO`. 
This repo can be your original `fosrl/pangolin` or a new dev repo, maybe `fosrl/pangolin-dev`.
I removed the arm64 version because it needs ~40min instead of ~6min to create and maybe the amd64 version is enough for testing.

## Usecase
For faster and easier testing, especially on low power VPS. 
A low power VPS (1CPU,1gb RAM, 10gb DISK) is nearly unable to create the docker image.

<img width="923" height="390" alt="image" src="https://github.com/user-attachments/assets/667e5401-77fa-4705-8e5a-089f2df23178" />


Feel free to reject if you don't see a benefit 😊
