### PR TITLE
fix blueprint country issue - fix #1705

### DIFF
--- a/server/lib/blueprints/types.ts
+++ b/server/lib/blueprints/types.ts
@@ -60,7 +60,7 @@ export const AuthSchema = z.object({
 
 export const RuleSchema = z.object({
     action: z.enum(["allow", "deny", "pass"]),
-    match: z.enum(["cidr", "path", "ip", "country"]),
+    match: z.enum(["cidr", "path", "ip", "geoip"]),
     value: z.string()
 });
 


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description
The rules section in resources is handling geoblocking as match type `geoip` and not as `country`.

Do you want to stay with `geoip` or switch completely to `country`?
Will also update the docs accordingly.

Staying with geoip will cause a rewrite of all users blueprints and since you are selecting a country will maybe cause some confusions.
A rewrite of the rules section and a database migration from geoip to country would be more user friendly.

Fixes https://github.com/fosrl/pangolin/issues/1705#issuecomment-3429812564


