### PR TITLE
fix: Remove return in installer which prevents showing token

### DIFF
--- a/install/main.go
+++ b/install/main.go
@@ -238,7 +238,6 @@ func main() {
 				}
 
 				fmt.Println("CrowdSec installed successfully!")
-				return
 			}
 		}
 	}


### PR DESCRIPTION
Remove redundant return statement after success message.

## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description

Should fix #1509 after selecting to install crowdsec unless an error occurs. Its a quick fix, but you may want to move the showing of token before the crowdsec installation.

## How to test?

When installing pangolin and when accepting to use crowdsec should show setup code at the end of the installation.

