### PR TITLE
Fix resources card table header mobile responsiveness

### DIFF
--- a/src/components/ResourcesTable.tsx
+++ b/src/components/ResourcesTable.tsx
@@ -314,7 +314,7 @@ export default function ResourcesTable({
     const getSearchInput = () => {
         if (currentView === "internal") {
             return (
-                <div className="relative w-full w-full">
+                <div className="relative w-full">
                     <Input
                         placeholder={t("resourcesSearch")}
                         value={internalGlobalFilter ?? ""}
@@ -330,7 +330,7 @@ export default function ResourcesTable({
             );
         }
         return (
-            <div className="relative w-full w-full">
+            <div className="relative w-full">
                 <Input
                     placeholder={t("resourcesSearch")}
                     value={proxyGlobalFilter ?? ""}
@@ -964,7 +964,7 @@ export default function ResourcesTable({
                         onValueChange={handleTabChange}
                     >
                         <CardHeader
-                            className={`grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 space-y-4 sm:flex-row sm:justify-between md:space-y-0  pb-0`}
+                            className={`grid grid-cols-1 lg:grid-cols-2  ${env.flags.enableClients ? " xl:grid-cols-3" : ""} space-y-4 lg:space-y-0 pb-0`}
                         >
                             <div
                                 className={`flex ${env.flags.enableClients ? "flex-col xl:flex-row xl:col-span-2" : "flex-row"} space-y-3 w-full sm:mr-2 gap-2`}
@@ -982,7 +982,7 @@ export default function ResourcesTable({
                                     </TabsList>
                                 )}
                             </div>
-                            <div className="flex gap-2 md:justify-end ">
+                            <div className={`flex gap-2 lg:justify-end`}>
                                 <div>
                                     <Button
                                         variant="outline"


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description

When viewing the "Manage Resources" page on mobile and when they are available clients, i.e. `enableClients` flag is true - the `Proxy` and `Client` resources tab list buttons would end up overlapping itself.

I took the opportunity to use CSS Grid instead of flex box since I wanted to have more granular control over both axis - and at different breakpoints.

I did a local docker build in my own VPS environment to showcase this:

Before the fix - I have tested it with Chrome  on Iphone 13 Pro:
![manage-resource-mobile-in-chrome](https://github.com/user-attachments/assets/416a4642-b8f3-45fb-b52d-d149bbf08234)

After the fix  - I have tested it with Chrome on Iphone 13 Pro:

![manage-resource-fix-mobile-in-chrome](https://github.com/user-attachments/assets/9552bb80-bee0-496f-8513-d84431fbf480)

I have also tested in the following mobile browsers:
- Firefox
- Safari

## How to test?
- In `src/lib/pullEnv.ts`, and set the key `enableClients` to be `true`.
- Use different browsers on Desktop using the Responsive Design Mode at different breakpoints.

