### PR TITLE
Potential fix for Missing rate limiting

### DIFF
--- a/server/private/routers/external.ts
+++ b/server/private/routers/external.ts
@@ -233,6 +233,16 @@ authenticated.put(
     verifyOrgAccess,
     verifyUserHasAction(ActionsEnum.createRemoteExitNode),
     logActionAudit(ActionsEnum.createRemoteExitNode),
+    rateLimit({
+        windowMs: 60 * 1000, // 1 minute
+        max: 10, // limit each IP to 10 requests per minute
+        keyGenerator: ipKeyGenerator,
+        handler: (req, res, next) =>
+            next(createHttpError(
+                HttpCode.TooManyRequests,
+                "Too many requests, please try again later."
+            )),
+    }),
     remoteExitNode.createRemoteExitNode
 );
 

--- a/server/private/routers/internal.ts
+++ b/server/private/routers/internal.ts
@@ -36,8 +36,8 @@ internalRouter.get("/org/:orgId/idp", orgIdp.listOrgIdps);
 
 internalRouter.get("/org/:orgId/billing/tier", billing.getOrgTier);
 
-    sessionTransferLimiter,
-internalRouter.get("/login-page", loginPage.loadLoginPage);
+
+internalRouter.get("/login-page", sessionTransferLimiter, loginPage.loadLoginPage);
 
 internalRouter.post(
     "/get-session-transfer-token",

--- a/server/private/routers/internal.ts
+++ b/server/private/routers/internal.ts
@@ -18,15 +18,25 @@ import * as billing from "#private/routers/billing";
 import * as license from "#private/routers/license";
 
 import { verifySessionUserMiddleware } from "@server/middlewares";
-
+import rateLimit from "express-rate-limit";
 import { internalRouter as ir } from "@server/routers/internal";
 
 export const internalRouter = ir;
+
+// Basic rate limiter: 5 requests per minute per IP for sensitive routes
+const sessionTransferLimiter = rateLimit({
+    windowMs: 60 * 1000, // 1 minute
+    max: 5, // limit each IP to 5 requests per windowMs
+    message: {
+        error: "Too many requests, please try again later."
+    }
+});
 
 internalRouter.get("/org/:orgId/idp", orgIdp.listOrgIdps);
 
 internalRouter.get("/org/:orgId/billing/tier", billing.getOrgTier);
 
+    sessionTransferLimiter,
 internalRouter.get("/login-page", loginPage.loadLoginPage);
 
 internalRouter.post(

--- a/server/routers/integration.ts
+++ b/server/routers/integration.ts
@@ -29,6 +29,7 @@ import {
 } from "@server/middlewares";
 import HttpCode from "@server/types/HttpCode";
 import { Router } from "express";
+import rateLimit from "express-rate-limit";
 import { ActionsEnum } from "@server/auth/actions";
 import { logActionAudit } from "#dynamic/middlewares";
 
@@ -39,8 +40,16 @@ unauthenticated.get("/", (_, res) => {
 });
 
 export const authenticated = Router();
-authenticated.use(verifyApiKey);
 
+const authenticatedRateLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // Limit each IP to 100 requests per windowMs
+    standardHeaders: true,
+    legacyHeaders: false,
+});
+authenticated.use(authenticatedRateLimiter);
+
+authenticated.use(verifyApiKey);
 authenticated.get(
     "/org/checkId",
     verifyApiKeyIsRoot,

--- a/server/routers/internal.ts
+++ b/server/routers/internal.ts
@@ -1,4 +1,5 @@
 import { Router } from "express";
+import rateLimit from "express-rate-limit";
 import * as gerbil from "@server/routers/gerbil";
 import * as traefik from "@server/routers/traefik";
 import * as resource from "./resource";
@@ -15,6 +16,14 @@ import {
 // Root routes
 export const internalRouter = Router();
 
+// Rate limiter for sensitive endpoints
+const sensitiveRateLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // max 100 requests per windowMs
+    standardHeaders: true,
+    legacyHeaders: false,
+});
+
 internalRouter.get("/", (_, res) => {
     res.status(HttpCode.OK).json({ message: "Healthy" });
 });
@@ -28,6 +37,7 @@ internalRouter.get(
 
 internalRouter.post(
     `/resource/:resourceId/get-exchange-token`,
+    sensitiveRateLimiter,
     verifySessionUserMiddleware,
     verifyResourceAccess,
     resource.getExchangeToken

--- a/server/routers/internal.ts
+++ b/server/routers/internal.ts
@@ -70,6 +70,6 @@ gerbilRouter.post("/get-config", gerbil.getConfig);
 const badgerRouter = Router();
 internalRouter.use("/badger", badgerRouter);
 
-badgerRouter.post("/verify-session", badger.verifyResourceSession);
+badgerRouter.post("/verify-session", sensitiveRateLimiter, badger.verifyResourceSession);
 
 badgerRouter.post("/exchange-session", badger.exchangeSession);


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description (generated by Copilot)

See https://codeql.github.com/codeql-query-help/javascript/js-missing-rate-limiting/

**Code generated by Copilot**

This pull request introduces rate limiting across several API endpoints to enhance security and prevent abuse. The changes add rate limiters to sensitive routes in both internal and external routers, as well as resource access token verification and integration endpoints. Each rate limiter is configured with specific limits and custom error messages to provide clear feedback to clients when limits are exceeded.

**Rate Limiting for Sensitive and High-Traffic Endpoints:**

* Added a rate limiter to the `/login-page` route in `server/private/routers/internal.ts`, restricting access to 5 requests per minute per IP to prevent brute force and abuse.
* Applied a rate limiter to the `/resource/:resourceId/get-exchange-token` endpoint in `server/routers/internal.ts`, allowing a maximum of 100 requests per 15 minutes per IP.

**Resource Access Token Verification Protection:**

* Introduced a rate limiter to the `/resource/:resourceId/access-token/verify` endpoint in `server/private/routers/hybrid.ts`, capping requests at 10 per minute per IP to mitigate token brute-forcing. [[1]](diffhunk://#diff-15c3a1839d668c5d989037e05f0c1a42d94ee116d676fad352658601b1e37efaR81-R92) [[2]](diffhunk://#diff-15c3a1839d668c5d989037e05f0c1a42d94ee116d676fad352658601b1e37efaR1191)

**External API Rate Limiting:**

* Implemented a rate limiter on the `createRemoteExitNode` endpoint in `server/private/routers/external.ts`, limiting each IP to 10 requests per minute and returning a custom error message on excess requests.

**Integration API Rate Limiting:**

* Added a general rate limiter to all authenticated integration routes in `server/routers/integration.ts`, restricting each IP to 100 requests per 15 minutes and ensuring standard rate limit headers are sent.

These changes collectively strengthen the API against abuse and ensure fair usage across all clients.


