### PR TITLE
Potential fix for Server-side request forgery

### DIFF
--- a/server/private/routers/generatedLicense/generateNewLicense.ts
+++ b/server/private/routers/generatedLicense/generateNewLicense.ts
@@ -53,11 +53,21 @@ export async function generateNewLicense(
     try {
         const { orgId } = req.params;
 
+        // Validate orgId - allow only UUIDs or alphanumeric with dash (example pattern)
+        const orgIdPattern = /^[a-zA-Z0-9\-]{1,64}$/; // 64 is arbitrary, change as needed
         if (!orgId) {
             return next(
                 createHttpError(
                     HttpCode.BAD_REQUEST,
                     "Organization ID is required"
+                )
+            );
+        }
+        if (!orgIdPattern.test(orgId)) {
+            return next(
+                createHttpError(
+                    HttpCode.BAD_REQUEST,
+                    "Invalid Organization ID format"
                 )
             );
         }

--- a/server/private/routers/generatedLicense/generateNewLicense.ts
+++ b/server/private/routers/generatedLicense/generateNewLicense.ts
@@ -53,8 +53,8 @@ export async function generateNewLicense(
     try {
         const { orgId } = req.params;
 
-        // Validate orgId - allow only UUIDs or alphanumeric with dash (example pattern)
-        const orgIdPattern = /^[a-zA-Z0-9\-]{1,64}$/; // 64 is arbitrary, change as needed
+        // Validate orgId - allow only UUID v4 format (same as listGeneratedLicenses.ts)
+        const orgIdPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
         if (!orgId) {
             return next(
                 createHttpError(

--- a/server/private/routers/generatedLicense/listGeneratedLicenses.ts
+++ b/server/private/routers/generatedLicense/listGeneratedLicenses.ts
@@ -54,11 +54,13 @@ export async function listSaasLicenseKeys(
     try {
         const { orgId } = req.params;
 
-        if (!orgId) {
+        // Accept orgId if it matches UUID v4 pattern (adjust pattern to fit actual orgId requirements)
+        const orgIdPattern = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$/;
+        if (!orgId || !orgIdPattern.test(orgId)) {
             return next(
                 createHttpError(
                     HttpCode.BAD_REQUEST,
-                    "Organization ID is required"
+                    "Organization ID is required and must be a valid UUID"
                 )
             );
         }


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description (generated by Copilot)

See https://codeql.github.com/codeql-query-help/javascript/js-request-forgery/

**Code generated by Copilot**

This pull request introduces stricter validation for organization and resource identifiers to improve security and consistency across API endpoints. The main changes add UUID format checks for organization IDs in license-related routes and type guard functions for resource and identity provider IDs in server-side actions, with corresponding input validation in proxy functions.

**Validation improvements for organization IDs:**

* Added UUID v4 format validation for `orgId` in `generateNewLicense.ts`, ensuring only valid organization IDs are accepted when generating new licenses. [[1]](diffhunk://#diff-6c08a641d462a22060ae3f4fdfd0ee0889f7f4ac9f3dfa255a4b1c0568065c47R56-R57) [[2]](diffhunk://#diff-6c08a641d462a22060ae3f4fdfd0ee0889f7f4ac9f3dfa255a4b1c0568065c47R66-R73)
* Updated `listGeneratedLicenses.ts` to require `orgId` to match a UUID v4 pattern, rejecting invalid or missing organization IDs with a clear error message.

**Security enhancements in server-side actions:**

* Introduced `isValidResourceId` and `isValidIdpId` type guard functions in `server.ts` to validate resource and identity provider IDs, restricting accepted formats.
* Added input validation using these type guards in proxy functions (`resourcePasswordProxy`, `resourcePincodeProxy`, `resourceWhitelistProxy`, `resourceAccessProxy`, `validateOidcUrlCallbackProxy`, `generateOidcUrlProxy`), throwing errors for invalid IDs to prevent unsafe requests. [[1]](diffhunk://#diff-e10bdddde4c48eed57a2e4ae3149c01574a9ae9fe8f19001704f360a13f579dbR334-R336) [[2]](diffhunk://#diff-e10bdddde4c48eed57a2e4ae3149c01574a9ae9fe8f19001704f360a13f579dbR349-R351) [[3]](diffhunk://#diff-e10bdddde4c48eed57a2e4ae3149c01574a9ae9fe8f19001704f360a13f579dbR364-R366) [[4]](diffhunk://#diff-e10bdddde4c48eed57a2e4ae3149c01574a9ae9fe8f19001704f360a13f579dbR382-R384) [[5]](diffhunk://#diff-e10bdddde4c48eed57a2e4ae3149c01574a9ae9fe8f19001704f360a13f579dbR422-R424) [[6]](diffhunk://#diff-e10bdddde4c48eed57a2e4ae3149c01574a9ae9fe8f19001704f360a13f579dbR442-R447)
* Enforced alphanumeric, dash, and underscore restrictions for `orgId` in `generateOidcUrlProxy` to further strengthen input validation.

## How to test?

