### PR TITLE
fix: full domain should be updated when the form is saved on resource proxy page

### DIFF
--- a/src/app/[orgId]/settings/resources/proxy/[niceId]/general/page.tsx
+++ b/src/app/[orgId]/settings/resources/proxy/[niceId]/general/page.tsx
@@ -224,7 +224,7 @@ export default function GeneralForm() {
                 name: data.name,
                 niceId: data.niceId,
                 subdomain: data.subdomain,
-                fullDomain: resource.fullDomain,
+                fullDomain: updated.fullDomain,
                 proxyPort: data.proxyPort
                 // ...(!resource.http && {
                 //     enableProxy: data.enableProxy


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description

I noticed a bug where when updating a resource domain, it would not be reflected in the infobox, and when going back and forth to the homepage, the value of the full domain would revert to the previous value. 

The domain is correctly updated on the backend though, since we can see that if we refresh the page, it would reflect the actual value we updated. 

The fix: calling `updateResource()` with the updated value, not the previous value of the resource. 

## screenshots 
<table>
<tr>
 <td align="center">
  video
 </td>
</tr>

<tr>
 <td>
<video src="https://github.com/user-attachments/assets/ae0fff1f-dfe1-4fdb-9325-15f620ca0a7d"></video>
 </td>
</tr>
</table>



