### PR TITLE
Fix: Add missing gnupg utility during Docker installation

### DIFF
--- a/install/containers.go
+++ b/install/containers.go
@@ -73,7 +73,7 @@ func installDocker() error {
 	case strings.Contains(osRelease, "ID=ubuntu"):
 		installCmd = exec.Command("bash", "-c", fmt.Sprintf(`
 			apt-get update &&
-			apt-get install -y apt-transport-https ca-certificates curl &&
+			apt-get install -y apt-transport-https ca-certificates curl gpg &&
 			curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg &&
 			echo "deb [arch=%s signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list &&
 			apt-get update &&
@@ -82,7 +82,7 @@ func installDocker() error {
 	case strings.Contains(osRelease, "ID=debian"):
 		installCmd = exec.Command("bash", "-c", fmt.Sprintf(`
 			apt-get update &&
-			apt-get install -y apt-transport-https ca-certificates curl &&
+			apt-get install -y apt-transport-https ca-certificates curl gpg &&
 			curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg &&
 			echo "deb [arch=%s signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list &&
 			apt-get update &&


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description
During setup on a fresh Debian Trixie server, I noticed that Docker was not installed correctly because the Docker APT repository could not be set up due to the missing GPG utility.

Log from failed installation of version 1.13.0:

```

root@test:~# curl -fsSL https://static.pangolin.net/get-installer.sh | bash
[INFO] Installing latest version of installer...
[INFO] Fetching latest version from GitHub...
[INFO] Latest version: v1.13.0
[INFO] Detected platform: linux_amd64
[INFO] Install directory: /root
[INFO] Downloading installer from https://github.com/fosrl/pangolin/releases/download/1.13.0/installer_linux_amd64
[INFO] Installer downloaded to /root/installer
[INFO] Installation successful!
[INFO] Installer is ready to use!
root@test~# sudo ./installer
Welcome to the Pangolin installer!
This installer will help you set up Pangolin on your server.

Please make sure you have the following prerequisites:
- Open TCP ports 80 and 443 and UDP ports 51820 and 21820 on your VPS and firewall.

Lets get started!

=== Basic Configuration ===
Enter your base domain (no subdomain e.g. example.com): issei.space
Enter the domain for the Pangolin dashboard (default: pangolin.issei.space):
Enter email for Let's Encrypt certificates: hello@issei.space
Do you want to use Gerbil to allow tunneled connections (yes/no) (default: yes):

=== Email Configuration ===
Enable email functionality (SMTP) (yes/no) (default: no):

=== Advanced Configuration ===
Is your server IPv6 capable? (yes/no) (default: yes):
Do you want to download the MaxMind GeoLite2 database for geoblocking functionality? (yes/no) (default: yes):

=== Generating Configuration Files ===

Configuration files created successfully!

=== Downloading MaxMind Database ===
Downloading MaxMind GeoLite2 Country database...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 4824k  100 4824k    0     0  5415k      0 --:--:-- --:--:-- --:--:-- 49.5M
MaxMind GeoLite2 Country database downloaded successfully!

=== Starting installation ===
Would you like to install and start the containers? (yes/no) (default: yes):
Would you like to run Pangolin as Docker or Podman containers? (default: docker):
Docker is not installed. Would you like to install it? (yes/no) (default: yes):
[...]
Setting up curl (8.14.1-2+deb13u2) ...
Processing triggers for libc-bin (2.41-12) ...
bash: line 4: gpg: command not found
Failed to enable unit: Unit docker.service does not exist
Error starting Docker service: exit status 1
Waiting for Docker to start...
Docker is not running yet, waiting...
Docker is not running yet, waiting...
Docker is not running yet, waiting...
Docker is not running yet, waiting...
Docker is not running yet, waiting...
Docker is still not running after 10 seconds. Please check the installation.
``` 

This contribution is adding a gpg utility to the install script, which results in a successful installation of docker

## How to test?
* Run the install on Debian/Ubuntu which doesn't already have docker and gpg installed.
