### PR TITLE
feat(setup): allow declaring a server setup token through env variable

### DIFF
--- a/server/setup/ensureSetupToken.ts
+++ b/server/setup/ensureSetupToken.ts
@@ -16,9 +16,21 @@ function generateToken(): string {
     return generateRandomString(random, alphabet, 32);
 }
 
+function validateToken(token: string): boolean {
+    const tokenRegex = /^[a-z0-9]{32}$/;
+    return tokenRegex.test(token);
+}
+
 function generateId(length: number): string {
     const alphabet = "abcdefghijklmnopqrstuvwxyz0123456789";
     return generateRandomString(random, alphabet, length);
+}
+
+function showSetupToken(token: string, source: string): void {
+    console.log(`=== SETUP TOKEN ${source} ===`);
+    console.log("Token:", token);
+    console.log("Use this token on the initial setup page");
+    console.log("================================");
 }
 
 export async function ensureSetupToken() {
@@ -38,17 +50,48 @@ export async function ensureSetupToken() {
         }
 
         // Check if a setup token already exists
-        const existingTokens = await db
+        const [existingToken] = await db
             .select()
             .from(setupTokens)
             .where(eq(setupTokens.used, false));
 
+        const envSetupToken = process.env.PANGOLIN_SETUP_TOKEN;
+        console.debug("PANGOLIN_SETUP_TOKEN:", envSetupToken);
+        if (envSetupToken) {
+            if (!validateToken(envSetupToken)) {
+                throw new Error(
+                    "invalid token format for PANGOLIN_SETUP_TOKEN"
+                );
+            }
+
+            if (existingToken?.token !== envSetupToken) {
+                console.warn(
+                    "Overwriting existing token in DB since PANGOLIN_SETUP_TOKEN is set"
+                );
+
+                await db
+                    .update(setupTokens)
+                    .set({ token: envSetupToken })
+                    .where(eq(setupTokens.tokenId, existingToken.tokenId));
+            } else {
+                const tokenId = generateId(15);
+
+                await db.insert(setupTokens).values({
+                    tokenId: tokenId,
+                    token: envSetupToken,
+                    used: false,
+                    dateCreated: moment().toISOString(),
+                    dateUsed: null
+                });
+            }
+
+            showSetupToken(envSetupToken, "FROM ENVIRONMENT");
+            return;
+        }
+
         // If unused token exists, display it instead of creating a new one
-        if (existingTokens.length > 0) {
-            console.log("=== SETUP TOKEN EXISTS ===");
-            console.log("Token:", existingTokens[0].token);
-            console.log("Use this token on the initial setup page");
-            console.log("================================");
+        if (existingToken) {
+            showSetupToken(existingToken.token, "EXISTS");
             return;
         }
 
@@ -64,10 +107,7 @@ export async function ensureSetupToken() {
             dateUsed: null
         });
 
-        console.log("=== SETUP TOKEN GENERATED ===");
-        console.log("Token:", token);
-        console.log("Use this token on the initial setup page");
-        console.log("================================");
+        showSetupToken(token, "GENERATED");
     } catch (error) {
         console.error("Failed to ensure setup token:", error);
         throw error;


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description

To facilitate integration testing/a more declarative configuration for Pangolin setups, this PR introduces the ability to manually specify a server setup token through an environment variable, `PANGOLIN_SETUP_TOKEN`.

## How to test?

A few test cases exist:

- If PANGOLIN_SETUP_TOKEN is unset, this should preserve previous token generation behavior.
- Set PANGOLIN_SETUP_TOKEN on a fresh instance. This should insert a token into the DB with this provided value.
- Set PANGOLIN_SETUP_TOKEN to an invalid value. This should cause the server to fail to start up. 
- Set PANGOLIN_SETUP_TOKEN when the a token has been generated already, but not used yet. The value, if valid, should replace the previously generated one.