### PR TITLE
ci: parallelize test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,11 +12,12 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
-      - uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
+      - name: Install Node
+        uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
         with:
           node-version: '22'
 
@@ -57,8 +58,26 @@ jobs:
           echo "App failed to start"
           exit 1
 
+  build-sqlite:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Copy config file
+        run: cp config/config.example.yml config/config.yml
+
       - name: Build Docker image sqlite
-        run: make build-sqlite
+        run: make dev-build-sqlite
+
+  build-postgres:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Copy config file
+        run: cp config/config.example.yml config/config.yml
 
       - name: Build Docker image pg
-        run: make build-pg
+        run: make dev-build-pg


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description

To enable a faster feedback loop when pushing up to a pull request, move the Docker image building for both PostgreSQL and SQLite into separate CI jobs.

Additionally, the workflow itself seemed broken. `make build-sqlite` uses `buildx` and requires a `tag` param now, which is causing testing CI workflows to fail when they are not able to build the Docker image.

Older CI workflows used to run `docker build` without the `buildx` driver, and the rule that does this got renamed to `dev-build-${db}`, so I switched the rule name to get this working again.

## How to test?

The `test.yml` workflow should pass and be substantially faster.