### PR TITLE
fix: Adding the blueprints list/get access via API 

### DIFF
--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -1045,6 +1045,8 @@
     "actionGetSite": "Get Site",
     "actionListSites": "List Sites",
     "actionApplyBlueprint": "Apply Blueprint",
+    "actionListBlueprints": "List Blueprints",
+    "actionGetBlueprint": "Get Blueprint",
     "setupToken": "Setup Token",
     "setupTokenDescription": "Enter the setup token from the server console.",
     "setupTokenRequired": "Setup token is required",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -1022,6 +1022,8 @@
     "actionGetSite": "獲取站點",
     "actionListSites": "站點列表",
     "actionApplyBlueprint": "應用藍圖",
+    "actionListBlueprints": "藍圖列表",
+    "actionGetBlueprint": "獲取藍圖",
     "setupToken": "設置令牌",
     "setupTokenDescription": "從伺服器控制台輸入設定令牌。",
     "setupTokenRequired": "需要設置令牌",

--- a/server/routers/integration.ts
+++ b/server/routers/integration.ts
@@ -865,6 +865,22 @@ authenticated.put(
     blueprints.applyJSONBlueprint
 );
 
+
+authenticated.get(
+    "/org/:orgId/blueprint/:blueprintId",
+    verifyApiKeyOrgAccess,
+    verifyApiKeyHasAction(ActionsEnum.getBlueprint),
+    blueprints.getBlueprint
+);
+
+
+authenticated.get(
+    "/org/:orgId/blueprints",
+    verifyApiKeyOrgAccess,
+    verifyApiKeyHasAction(ActionsEnum.listBlueprints),
+    blueprints.listBlueprints
+);
+
 authenticated.get(
     "/org/:orgId/logs/request",
     verifyApiKeyOrgAccess,

--- a/src/components/PermissionsSelectBox.tsx
+++ b/src/components/PermissionsSelectBox.tsx
@@ -34,7 +34,9 @@ function getActionsCategories(root: boolean) {
             [t("actionListOrgDomains")]: "listOrgDomains",
             [t("updateOrgUser")]: "updateOrgUser",
             [t("createOrgUser")]: "createOrgUser",
-            [t("actionApplyBlueprint")]: "applyBlueprint"
+            [t("actionApplyBlueprint")]: "applyBlueprint",
+            [t("actionListBlueprints")]: "listBlueprints",
+            [t("actionGetBlueprint")]: "getBlueprint"
         },
 
         Site: {


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description
The current Swagger document have the `GET /org/:orgId/blueprints` and `GET /org/:orgId/blueprint/blueprintId` available
<img width="486" height="226" alt="screenshot" src="https://github.com/user-attachments/assets/d5a0d286-460b-4493-85ec-dd7bea3936dd" />

but I can't access the two endpoints via API

## How to test?
Spin up a testing environment and access the following API with API keys set
`GET http://my-local-machine:3003/v1/org/:orgId/blueprints`
`GET http://my-local-machine:3003/v1/org/:orgId/blueprint/:blueprintId`

I will get `Cannot GET /v1/org/:orgId/blueprints` response

## What have been added
1. Adding these endpoints to API
2. Adding corresponding permission checkbox on the UI
3. Added ZH-TW and English Mapping on the checkbox text

## What should be added later, can't handle by me
1. Other language mapping on the checkbox text