### PR TITLE
fix(analytics): query latest 7 days 

### DIFF
--- a/server/routers/auditLogs/queryRequestAnalytics.ts
+++ b/server/routers/auditLogs/queryRequestAnalytics.ts
@@ -20,7 +20,6 @@ const queryAccessAuditLogsQuery = z.object({
             error: "timeStart must be a valid ISO date string"
         })
         .transform((val) => Math.floor(new Date(val).getTime() / 1000))
-        .optional()
         .prefault(() => getSevenDaysAgo().toISOString())
         .openapi({
             type: "string",
@@ -34,7 +33,6 @@ const queryAccessAuditLogsQuery = z.object({
             error: "timeEnd must be a valid ISO date string"
         })
         .transform((val) => Math.floor(new Date(val).getTime() / 1000))
-        .optional()
         .prefault(new Date().toISOString())
         .openapi({
             type: "string",


### PR DESCRIPTION
## Community Contribution License Agreement

By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description

Possible fix for default analytics endpoint not returning the correct data as shown in #2113 

`.optional()` being placed before `.prefault()` in the Zod schema is causing it to short-circuit and return `undefined` instead of applying default values (or at least that's my understanding if it)

I'm not sure this fix actually solves the issue and I don't have enough data locally to test this. Feel free to discard my pull request if I went in the wrong direction or request changes if needed. 
Also this issue might be present in other files but I focused on the analytics one, let me know if you want me to fix the other files in the same PR.

Also thanks for the great product!

fixes #2113 