### PR TITLE
fix(database): filter dates evaluated at module load time

### DIFF
--- a/server/private/routers/auditLogs/queryAccessAuditLog.ts
+++ b/server/private/routers/auditLogs/queryAccessAuditLog.ts
@@ -48,7 +48,7 @@ export const queryAccessAuditLogsQuery = z.object({
         })
         .transform((val) => Math.floor(new Date(val).getTime() / 1000))
         .optional()
-        .prefault(new Date().toISOString())
+        .prefault(() => new Date().toISOString())
         .openapi({
             type: "string",
             format: "date-time",

--- a/server/private/routers/auditLogs/queryActionAuditLog.ts
+++ b/server/private/routers/auditLogs/queryActionAuditLog.ts
@@ -48,7 +48,7 @@ export const queryActionAuditLogsQuery = z.object({
         })
         .transform((val) => Math.floor(new Date(val).getTime() / 1000))
         .optional()
-        .prefault(new Date().toISOString())
+        .prefault(() => new Date().toISOString())
         .openapi({
             type: "string",
             format: "date-time",

--- a/server/routers/auditLogs/queryRequestAnalytics.ts
+++ b/server/routers/auditLogs/queryRequestAnalytics.ts
@@ -35,7 +35,7 @@ const queryAccessAuditLogsQuery = z.object({
         })
         .transform((val) => Math.floor(new Date(val).getTime() / 1000))
         .optional()
-        .prefault(new Date().toISOString())
+        .prefault(() => new Date().toISOString())
         .openapi({
             type: "string",
             format: "date-time",

--- a/server/routers/auditLogs/queryRequestAuditLog.ts
+++ b/server/routers/auditLogs/queryRequestAuditLog.ts
@@ -35,7 +35,7 @@ export const queryAccessAuditLogsQuery = z.object({
         })
         .transform((val) => Math.floor(new Date(val).getTime() / 1000))
         .optional()
-        .prefault(new Date().toISOString())
+        .prefault(() => new Date().toISOString())
         .openapi({
             type: "string",
             format: "date-time",


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description

Dates in queries were evaluated at module load time and not at request time which limited the request's default behavior for `timeEnd` to the time the server actually started. Feel free to modify the pull request or ask me for changes. (Or close it if it's totally unrelated)

fixes #2113 

<details>
<summary>Opening a very small PR on a project I love using</summary>

<img height="200" alt="image" src="https://github.com/user-attachments/assets/f983f904-4a08-47b6-9aa8-3db25b8bb971" />

</details>

