### PR TITLE
Fix: confirm delete button working without confirm text

### DIFF
--- a/src/components/ConfirmDeleteDialog.tsx
+++ b/src/components/ConfirmDeleteDialog.tsx
@@ -63,8 +63,7 @@ export default function ConfirmDeleteDialog({
         }
     });
 
-    const confirmText = form.watch("string");
-    const isConfirmed = confirmText === string;
+    const isConfirmed = form.watch("string") === string;
 
     async function onSubmit() {
         try {
@@ -143,7 +142,7 @@ export default function ConfirmDeleteDialog({
                             form="confirm-delete-form"
                             loading={loading}
                             disabled={loading || !isConfirmed}
-                            className={!isConfirmed && !loading ? "opacity-50 cursor-not-allowed" : ""}
+                            className={!isConfirmed && !loading ? "opacity-50" : ""}
                         >
                             {buttonText}
                         </Button>


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description
This PR prevents deletions unless the required confirmation text has been entered. (this has been tested on chrome and Firefox browser)

## How to test?
1. add anything deletable that would trigger the `\src\components\ConfirmDeleteDialog.tsx`
2. attempt to delete it without the confirm text (should not work anymore)
3. attempt it with wrong text (should not work)
4. attempt it with correct text (should work)


## ui changes

### ui changes [before]
<img width="779" height="637" alt="image" src="https://github.com/user-attachments/assets/249f817c-cd04-44a8-9b9c-5053809574e9" />

### ui changes [after]
<img width="777" height="635" alt="image" src="https://github.com/user-attachments/assets/0c94f9a2-b381-4487-94bb-88bcf97488d5" />
<img width="788" height="648" alt="image" src="https://github.com/user-attachments/assets/f1e595b5-762d-4164-b2c3-9572c3f7682a" />

