### PR TITLE
feat(fingerprint): add endpoint to reset olm secret based on fingerprint 

### DIFF
--- a/server/routers/external.ts
+++ b/server/routers/external.ts
@@ -861,6 +861,12 @@ authenticated.get(
     olm.getUserOlm
 );
 
+authenticated.post(
+    "/user/:userId/olm/recover",
+    verifyIsLoggedInUser,
+    olm.recoverOlmWithFingerprint
+);
+
 authenticated.put(
     "/idp/oidc",
     verifyUserIsServerAdmin,

--- a/server/routers/olm/index.ts
+++ b/server/routers/olm/index.ts
@@ -9,3 +9,4 @@ export * from "./listUserOlms";
 export * from "./getUserOlm";
 export * from "./handleOlmServerPeerAddMessage";
 export * from "./handleOlmUnRelayMessage";
+export * from "./recoverOlmWithFingerprint";

--- a/server/routers/olm/recoverOlmWithFingerprint.ts
+++ b/server/routers/olm/recoverOlmWithFingerprint.ts
@@ -1,0 +1,120 @@
+import { db, fingerprints, olms } from "@server/db";
+import logger from "@server/logger";
+import HttpCode from "@server/types/HttpCode";
+import { and, eq } from "drizzle-orm";
+import { NextFunction, Request, Response } from "express";
+import response from "@server/lib/response";
+import createHttpError from "http-errors";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
+import { generateId } from "@server/auth/sessions/app";
+import { hashPassword } from "@server/auth/password";
+
+const paramsSchema = z
+    .object({
+        userId: z.string()
+    })
+    .strict();
+
+const bodySchema = z
+    .object({
+        platformFingerprint: z.string()
+    })
+    .strict();
+
+export async function recoverOlmWithFingerprint(
+    req: Request,
+    res: Response,
+    next: NextFunction
+): Promise<any> {
+    try {
+        const parsedParams = paramsSchema.safeParse(req.params);
+        if (!parsedParams.success) {
+            return next(
+                createHttpError(
+                    HttpCode.BAD_REQUEST,
+                    fromError(parsedParams.error).toString()
+                )
+            );
+        }
+
+        const { userId } = parsedParams.data;
+
+        const parsedBody = bodySchema.safeParse(req.body);
+        if (!parsedBody.success) {
+            return next(
+                createHttpError(
+                    HttpCode.BAD_REQUEST,
+                    fromError(parsedBody.error).toString()
+                )
+            );
+        }
+
+        const { platformFingerprint } = parsedBody.data;
+
+        const result = await db
+            .select({
+                olm: olms,
+                fingerprint: fingerprints
+            })
+            .from(olms)
+            .innerJoin(fingerprints, eq(fingerprints.olmId, olms.olmId))
+            .where(
+                and(
+                    eq(olms.userId, userId),
+                    eq(olms.archived, false),
+                    eq(fingerprints.platformFingerprint, platformFingerprint)
+                )
+            )
+            .orderBy(fingerprints.lastSeen);
+
+        if (!result || result.length == 0) {
+            return next(
+                createHttpError(
+                    HttpCode.NOT_FOUND,
+                    "corresponding olm with this fingerprint not found"
+                )
+            );
+        }
+
+        if (result.length > 1) {
+            return next(
+                createHttpError(
+                    HttpCode.CONFLICT,
+                    "multiple matching fingerprints found, not resetting secrets"
+                )
+            );
+        }
+
+        const [{ olm: foundOlm }] = result;
+
+        const newSecret = generateId(48);
+        const newSecretHash = await hashPassword(newSecret);
+
+        await db
+            .update(olms)
+            .set({
+                secretHash: newSecretHash
+            })
+            .where(eq(olms.olmId, foundOlm.olmId));
+
+        return response(res, {
+            data: {
+                olmId: foundOlm.olmId,
+                secret: newSecret
+            },
+            success: true,
+            error: false,
+            message: "Successfully retrieved olm",
+            status: HttpCode.OK
+        });
+    } catch (error) {
+        logger.error(error);
+        return next(
+            createHttpError(
+                HttpCode.INTERNAL_SERVER_ERROR,
+                "Failed to recover olm using provided fingerprint input"
+            )
+        );
+    }
+}


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description

This attempts to reset an olm secret if a corresponding secret is found.

## How to test?

Re-login with a machine after logging out with a client, AND make sure the `olm` credentials are deleted client-side.

Any clients that use this endpoint should be able to reuse the same `olm` with a secret that has been reset (aka not the old secret, this should be removed), and a new device should not pop up in the list.