### PR TITLE
Fix issue 2251: conditionally render advanced settings button only for newt method

### DIFF
--- a/src/app/[orgId]/settings/sites/create/page.tsx
+++ b/src/app/[orgId]/settings/sites/create/page.tsx
@@ -728,70 +728,73 @@ WantedBy=default.target`
                                                 </FormItem>
                                             )}
                                         />
-                                        <div className="flex items-center justify-end md:col-start-2">
-                                            <Button
-                                                type="button"
-                                                variant="ghost"
-                                                size="sm"
-                                                onClick={() =>
-                                                    setShowAdvancedSettings(
-                                                        !showAdvancedSettings
-                                                    )
-                                                }
-                                                className="flex items-center gap-2"
-                                            >
-                                                {showAdvancedSettings ? (
-                                                    <ChevronUp className="h-4 w-4" />
-                                                ) : (
-                                                    <ChevronDown className="h-4 w-4" />
+                                        {form.watch("method") === "newt" && (
+                                            <>
+                                                <div className="flex items-center justify-end md:col-start-2">
+                                                    <Button
+                                                        type="button"
+                                                        variant="ghost"
+                                                        size="sm"
+                                                        onClick={() =>
+                                                            setShowAdvancedSettings(
+                                                                !showAdvancedSettings
+                                                            )
+                                                        }
+                                                        className="flex items-center gap-2"
+                                                    >
+                                                        {showAdvancedSettings ? (
+                                                            <ChevronUp className="h-4 w-4" />
+                                                        ) : (
+                                                            <ChevronDown className="h-4 w-4" />
+                                                        )}
+                                                        {t("advancedSettings")}
+                                                    </Button>
+                                                </div>
+                                                {showAdvancedSettings && (
+                                                    <FormField
+                                                        control={form.control}
+                                                        name="clientAddress"
+                                                        render={({ field }) => (
+                                                            <FormItem className="md:col-start-1 md:col-span-2">
+                                                                <FormLabel>
+                                                                    {t(
+                                                                        "siteAddress"
+                                                                    )}
+                                                                </FormLabel>
+                                                                <FormControl>
+                                                                    <Input
+                                                                        autoComplete="off"
+                                                                        value={
+                                                                            clientAddress
+                                                                        }
+                                                                        onChange={(
+                                                                            e
+                                                                        ) => {
+                                                                            setClientAddress(
+                                                                                e
+                                                                                    .target
+                                                                                    .value
+                                                                            );
+                                                                            field.onChange(
+                                                                                e
+                                                                                    .target
+                                                                                    .value
+                                                                            );
+                                                                        }}
+                                                                    />
+                                                                </FormControl>
+                                                                <FormMessage />
+                                                                <FormDescription>
+                                                                    {t(
+                                                                        "siteAddressDescription"
+                                                                    )}
+                                                                </FormDescription>
+                                                            </FormItem>
+                                                        )}
+                                                    />
                                                 )}
-                                                {t("advancedSettings")}
-                                            </Button>
-                                        </div>
-                                        {form.watch("method") === "newt" &&
-                                            showAdvancedSettings && (
-                                                <FormField
-                                                    control={form.control}
-                                                    name="clientAddress"
-                                                    render={({ field }) => (
-                                                        <FormItem className="md:col-start-1 md:col-span-2">
-                                                            <FormLabel>
-                                                                {t(
-                                                                    "siteAddress"
-                                                                )}
-                                                            </FormLabel>
-                                                            <FormControl>
-                                                                <Input
-                                                                    autoComplete="off"
-                                                                    value={
-                                                                        clientAddress
-                                                                    }
-                                                                    onChange={(
-                                                                        e
-                                                                    ) => {
-                                                                        setClientAddress(
-                                                                            e
-                                                                                .target
-                                                                                .value
-                                                                        );
-                                                                        field.onChange(
-                                                                            e
-                                                                                .target
-                                                                                .value
-                                                                        );
-                                                                    }}
-                                                                />
-                                                            </FormControl>
-                                                            <FormMessage />
-                                                            <FormDescription>
-                                                                {t(
-                                                                    "siteAddressDescription"
-                                                                )}
-                                                            </FormDescription>
-                                                        </FormItem>
-                                                    )}
-                                                />
-                                            )}
+                                            </>
+                                        )}
                                     </form>
                                 </Form>
                             </SettingsSectionBody>


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description

This PR addresses issue #2251 by modifying the conditional rendering of the advanced settings button and associated form field in the site creation page (`src/app/[orgId]/settings/sites/create/page.tsx`).

**Changes Made:**

- Wrapped the advanced settings button and client address form field in a conditional block that only renders when `form.watch("method") === "newt"`.
- The button is now inside a `<>` React Fragment, along with the conditional form field.
- This ensures the UI elements are only displayed when the site method is "newt", eliminating the previous behavior where the button was always rendered.

**Analysis of Change:**

- **Before:** The button and form field were always rendered in the DOM, but hidden when `form.watch("method") !== "newt"`. 
- **After:** The entire block is conditionally rendered only when the method is "newt", ensuring the UI accurately reflects the current state.

## How to test?

1. Navigate to the site creation page in the application.
2. Select different site methods using the strategy select (newt, wireguard, local).
3. Verify that the "Advanced Settings" button (with chevron icon) only appears when "newt" is selected.