### PR TITLE
feat(resources): add redirect domain management in settings

### DIFF
--- a/server/db/pg/schema/schema.ts
+++ b/server/db/pg/schema/schema.ts
@@ -141,7 +141,8 @@ export const resources = pgTable("resources", {
     maintenanceTitle: text("maintenanceTitle"),
     maintenanceMessage: text("maintenanceMessage"),
     maintenanceEstimatedTime: text("maintenanceEstimatedTime"),
-    postAuthPath: text("postAuthPath")
+    postAuthPath: text("postAuthPath"),
+    redirectDomains: text("redirectDomains")
 });
 
 export const targets = pgTable("targets", {

--- a/server/db/sqlite/schema/schema.ts
+++ b/server/db/sqlite/schema/schema.ts
@@ -156,7 +156,8 @@ export const resources = sqliteTable("resources", {
     maintenanceTitle: text("maintenanceTitle"),
     maintenanceMessage: text("maintenanceMessage"),
     maintenanceEstimatedTime: text("maintenanceEstimatedTime"),
-    postAuthPath: text("postAuthPath")
+    postAuthPath: text("postAuthPath"),
+    redirectDomains: text("redirectDomains")
 });
 
 export const targets = sqliteTable("targets", {

--- a/server/lib/traefik/getTraefikConfig.ts
+++ b/server/lib/traefik/getTraefikConfig.ts
@@ -66,6 +66,7 @@ export async function getTraefikConfig(
             setHostHeader: resources.setHostHeader,
             enableProxy: resources.enableProxy,
             headers: resources.headers,
+            redirectDomains: resources.redirectDomains,
             proxyProtocol: resources.proxyProtocol,
             proxyProtocolVersion: resources.proxyProtocolVersion,
 
@@ -177,6 +178,18 @@ export async function getTraefikConfig(
                 enableProxy: row.enableProxy,
                 targets: [],
                 headers: row.headers,
+                redirectDomains: (() => {
+                    if (!row.redirectDomains) {
+                        return [] as string[];
+                    }
+
+                    try {
+                        const parsed = JSON.parse(row.redirectDomains);
+                        return Array.isArray(parsed) ? parsed : [];
+                    } catch {
+                        return [] as string[];
+                    }
+                })(),
                 proxyProtocol: row.proxyProtocol,
                 proxyProtocolVersion: row.proxyProtocolVersion ?? 1,
                 path: row.path, // the targets will all have the same path
@@ -454,6 +467,67 @@ export async function getTraefikConfig(
                 priority: priority,
                 ...(resource.ssl ? { tls } : {})
             };
+
+            if (Array.isArray(resource.redirectDomains)) {
+                resource.redirectDomains.forEach(
+                    (sourceDomain: string, index: number) => {
+                        const normalizedSourceDomain = sourceDomain
+                            .trim()
+                            .toLowerCase();
+
+                        if (
+                            !normalizedSourceDomain ||
+                            normalizedSourceDomain === fullDomain.toLowerCase()
+                        ) {
+                            return;
+                        }
+
+                        const redirectMiddlewareName = `${key}-redirect-domain-${index}-middleware`;
+                        const redirectRouterHttpName = `${key}-redirect-domain-${index}-http`;
+                        const redirectRouterHttpsName = `${key}-redirect-domain-${index}-https`;
+                        const targetScheme = resource.ssl ? "https" : "http";
+
+                        if (!config_output.http.middlewares) {
+                            config_output.http.middlewares = {};
+                        }
+
+                        config_output.http.middlewares[redirectMiddlewareName] =
+                            {
+                                redirectRegex: {
+                                    regex: "^https?://[^/]+(.*)",
+                                    replacement: `${targetScheme}://${fullDomain}$1`,
+                                    permanent: true
+                                }
+                            };
+
+                        config_output.http.routers![redirectRouterHttpName] = {
+                            entryPoints: [
+                                config.getRawConfig().traefik.http_entrypoint
+                            ],
+                            middlewares: [redirectMiddlewareName],
+                            service: "noop@internal",
+                            rule: `Host(\`${normalizedSourceDomain}\`)`,
+                            priority: 2000
+                        };
+
+                        if (resource.ssl) {
+                            config_output.http.routers![
+                                redirectRouterHttpsName
+                            ] = {
+                                entryPoints: [
+                                    config.getRawConfig().traefik
+                                        .https_entrypoint
+                                ],
+                                middlewares: [redirectMiddlewareName],
+                                service: "noop@internal",
+                                rule: `Host(\`${normalizedSourceDomain}\`)`,
+                                priority: 2000,
+                                tls
+                            };
+                        }
+                    }
+                );
+            }
 
             if (resource.ssl) {
                 config_output.http.routers![routerName + "-redirect"] = {

--- a/server/private/lib/traefik/getTraefikConfig.ts
+++ b/server/private/lib/traefik/getTraefikConfig.ts
@@ -94,6 +94,7 @@ export async function getTraefikConfig(
             setHostHeader: resources.setHostHeader,
             enableProxy: resources.enableProxy,
             headers: resources.headers,
+            redirectDomains: resources.redirectDomains,
             proxyProtocol: resources.proxyProtocol,
             proxyProtocolVersion: resources.proxyProtocolVersion,
 
@@ -224,6 +225,18 @@ export async function getTraefikConfig(
                 enableProxy: row.enableProxy,
                 targets: [],
                 headers: row.headers,
+                redirectDomains: (() => {
+                    if (!row.redirectDomains) {
+                        return [] as string[];
+                    }
+
+                    try {
+                        const parsed = JSON.parse(row.redirectDomains);
+                        return Array.isArray(parsed) ? parsed : [];
+                    } catch {
+                        return [] as string[];
+                    }
+                })(),
                 proxyProtocol: row.proxyProtocol,
                 proxyProtocolVersion: row.proxyProtocolVersion ?? 1,
                 path: row.path, // the targets will all have the same path
@@ -654,6 +667,67 @@ export async function getTraefikConfig(
                 priority: priority,
                 ...(resource.ssl ? { tls } : {})
             };
+
+            if (Array.isArray(resource.redirectDomains)) {
+                resource.redirectDomains.forEach(
+                    (sourceDomain: string, index: number) => {
+                        const normalizedSourceDomain = sourceDomain
+                            .trim()
+                            .toLowerCase();
+
+                        if (
+                            !normalizedSourceDomain ||
+                            normalizedSourceDomain === fullDomain.toLowerCase()
+                        ) {
+                            return;
+                        }
+
+                        const redirectMiddlewareName = `${key}-redirect-domain-${index}-middleware`;
+                        const redirectRouterHttpName = `${key}-redirect-domain-${index}-http`;
+                        const redirectRouterHttpsName = `${key}-redirect-domain-${index}-https`;
+                        const targetScheme = resource.ssl ? "https" : "http";
+
+                        if (!config_output.http.middlewares) {
+                            config_output.http.middlewares = {};
+                        }
+
+                        config_output.http.middlewares[redirectMiddlewareName] =
+                            {
+                                redirectRegex: {
+                                    regex: "^https?://[^/]+(.*)",
+                                    replacement: `${targetScheme}://${fullDomain}$1`,
+                                    permanent: true
+                                }
+                            };
+
+                        config_output.http.routers![redirectRouterHttpName] = {
+                            entryPoints: [
+                                config.getRawConfig().traefik.http_entrypoint
+                            ],
+                            middlewares: [redirectMiddlewareName],
+                            service: "noop@internal",
+                            rule: `Host(\`${normalizedSourceDomain}\`)`,
+                            priority: 2000
+                        };
+
+                        if (resource.ssl) {
+                            config_output.http.routers![
+                                redirectRouterHttpsName
+                            ] = {
+                                entryPoints: [
+                                    config.getRawConfig().traefik
+                                        .https_entrypoint
+                                ],
+                                middlewares: [redirectMiddlewareName],
+                                service: "noop@internal",
+                                rule: `Host(\`${normalizedSourceDomain}\`)`,
+                                priority: 2000,
+                                tls
+                            };
+                        }
+                    }
+                );
+            }
 
             config_output.http.services![serviceName] = {
                 loadBalancer: {

--- a/server/routers/resource/createResource.ts
+++ b/server/routers/resource/createResource.ts
@@ -17,7 +17,7 @@ import createHttpError from "http-errors";
 import { eq, and } from "drizzle-orm";
 import { fromError } from "zod-validation-error";
 import logger from "@server/logger";
-import { subdomainSchema } from "@server/lib/schemas";
+import { subdomainSchema, tlsNameSchema } from "@server/lib/schemas";
 import config from "@server/lib/config";
 import { OpenAPITags, registry } from "@server/openApi";
 import { build } from "@server/build";
@@ -37,7 +37,8 @@ const createHttpResourceSchema = z
         protocol: z.enum(["tcp", "udp"]),
         domainId: z.string(),
         stickySession: z.boolean().optional(),
-        postAuthPath: z.string().nullable().optional()
+        postAuthPath: z.string().nullable().optional(),
+        redirectDomains: z.array(tlsNameSchema).max(100).nullable().optional()
     })
     .refine(
         (data) => {
@@ -192,6 +193,7 @@ async function createHttpResource(
     const { name, domainId, postAuthPath } = parsedBody.data;
     const subdomain = parsedBody.data.subdomain;
     const stickySession = parsedBody.data.stickySession;
+    const redirectDomains = parsedBody.data.redirectDomains;
 
     // Validate domain and construct full domain
     const domainResult = await validateAndConstructDomain(
@@ -239,6 +241,16 @@ async function createHttpResource(
         }
     }
 
+    const normalizedRedirectDomains = redirectDomains
+        ? Array.from(
+              new Set(
+                  redirectDomains
+                      .map((domain) => domain.trim().toLowerCase())
+                      .filter((domain) => domain.length > 0)
+              )
+          ).filter((domain) => domain !== fullDomain.toLowerCase())
+        : [];
+
     let resource: Resource | undefined;
 
     const niceId = await getUniqueResourceName(orgId);
@@ -257,7 +269,11 @@ async function createHttpResource(
                 protocol: "tcp",
                 ssl: true,
                 stickySession: stickySession,
-                postAuthPath: postAuthPath
+                postAuthPath: postAuthPath,
+                redirectDomains:
+                    normalizedRedirectDomains.length > 0
+                        ? JSON.stringify(normalizedRedirectDomains)
+                        : null
             })
             .returning();
 

--- a/server/routers/resource/getResource.ts
+++ b/server/routers/resource/getResource.ts
@@ -44,9 +44,10 @@ async function query(resourceId?: number, niceId?: string, orgId?: string) {
 
 export type GetResourceResponse = Omit<
     NonNullable<Awaited<ReturnType<typeof query>>>,
-    "headers"
+    "headers" | "redirectDomains"
 > & {
     headers: { name: string; value: string }[] | null;
+    redirectDomains: string[] | null;
 };
 
 registry.registerPath({
@@ -103,12 +104,29 @@ export async function getResource(
             );
         }
 
+        let parsedHeaders: { name: string; value: string }[] | null = null;
+        if (resource.headers) {
+            try {
+                parsedHeaders = JSON.parse(resource.headers);
+            } catch {
+                parsedHeaders = null;
+            }
+        }
+
+        let parsedRedirectDomains: string[] | null = null;
+        if (resource.redirectDomains) {
+            try {
+                parsedRedirectDomains = JSON.parse(resource.redirectDomains);
+            } catch {
+                parsedRedirectDomains = null;
+            }
+        }
+
         return response<GetResourceResponse>(res, {
             data: {
                 ...resource,
-                headers: resource.headers
-                    ? JSON.parse(resource.headers)
-                    : resource.headers
+                headers: parsedHeaders,
+                redirectDomains: parsedRedirectDomains
             },
             success: true,
             error: false,

--- a/server/routers/resource/updateResource.ts
+++ b/server/routers/resource/updateResource.ts
@@ -56,7 +56,8 @@ const updateHttpResourceBodySchema = z
         maintenanceTitle: z.string().max(255).nullable().optional(),
         maintenanceMessage: z.string().max(2000).nullable().optional(),
         maintenanceEstimatedTime: z.string().max(100).nullable().optional(),
-        postAuthPath: z.string().nullable().optional()
+        postAuthPath: z.string().nullable().optional(),
+        redirectDomains: z.array(tlsNameSchema).max(100).nullable().optional()
     })
     .refine((data) => Object.keys(data).length > 0, {
         error: "At least one field must be provided for update"
@@ -265,6 +266,8 @@ async function updateHttpResource(
         }
     }
 
+    let effectiveFullDomain = resource.fullDomain;
+
     if (updateData.domainId) {
         const domainId = updateData.domainId;
 
@@ -328,6 +331,8 @@ async function updateHttpResource(
                 .where(eq(resources.resourceId, resource.resourceId));
         }
 
+        effectiveFullDomain = fullDomain;
+
         // Update the subdomain in the update data
         updateData.subdomain = finalSubdomain;
 
@@ -343,6 +348,32 @@ async function updateHttpResource(
         headers = null;
     }
 
+    let redirectDomains = undefined;
+    if (updateData.redirectDomains !== undefined) {
+        const normalizedRedirectDomains = (
+            updateData.redirectDomains || []
+        ).map((domain) => domain.trim().toLowerCase());
+
+        const uniqueRedirectDomains = Array.from(
+            new Set(normalizedRedirectDomains)
+        ).filter((domain) => {
+            if (domain.length === 0) {
+                return false;
+            }
+
+            if (!effectiveFullDomain) {
+                return true;
+            }
+
+            return domain !== effectiveFullDomain.toLowerCase();
+        });
+
+        redirectDomains =
+            uniqueRedirectDomains.length > 0
+                ? JSON.stringify(uniqueRedirectDomains)
+                : null;
+    }
+
     const isLicensed = await isLicensedOrSubscribed(resource.orgId, tierMatrix.maintencePage);
     if (!isLicensed) {
         updateData.maintenanceModeEnabled = undefined;
@@ -354,7 +385,7 @@ async function updateHttpResource(
 
     const updatedResource = await db
         .update(resources)
-        .set({ ...updateData, headers })
+        .set({ ...updateData, headers, redirectDomains })
         .where(eq(resources.resourceId, resource.resourceId))
         .returning();
 

--- a/server/setup/migrationsPg.ts
+++ b/server/setup/migrationsPg.ts
@@ -19,6 +19,7 @@ import m11 from "./scriptsPg/1.14.0";
 import m12 from "./scriptsPg/1.15.0";
 import m13 from "./scriptsPg/1.15.3";
 import m14 from "./scriptsPg/1.15.4";
+import m15 from "./scriptsPg/1.15.5";
 
 // THIS CANNOT IMPORT ANYTHING FROM THE SERVER
 // EXCEPT FOR THE DATABASE AND THE SCHEMA
@@ -38,7 +39,8 @@ const migrations = [
     { version: "1.14.0", run: m11 },
     { version: "1.15.0", run: m12 },
     { version: "1.15.3", run: m13 },
-    { version: "1.15.4", run: m14 }
+    { version: "1.15.4", run: m14 },
+    { version: "1.15.5", run: m15 }
     // Add new migrations here as they are created
 ] as {
     version: string;

--- a/server/setup/migrationsSqlite.ts
+++ b/server/setup/migrationsSqlite.ts
@@ -37,6 +37,7 @@ import m32 from "./scriptsSqlite/1.14.0";
 import m33 from "./scriptsSqlite/1.15.0";
 import m34 from "./scriptsSqlite/1.15.3";
 import m35 from "./scriptsSqlite/1.15.4";
+import m36 from "./scriptsSqlite/1.15.5";
 
 // THIS CANNOT IMPORT ANYTHING FROM THE SERVER
 // EXCEPT FOR THE DATABASE AND THE SCHEMA
@@ -72,7 +73,8 @@ const migrations = [
     { version: "1.14.0", run: m32 },
     { version: "1.15.0", run: m33 },
     { version: "1.15.3", run: m34 },
-    { version: "1.15.4", run: m35 }
+    { version: "1.15.4", run: m35 },
+    { version: "1.15.5", run: m36 }
     // Add new migrations here as they are created
 ] as const;
 

--- a/server/setup/scriptsPg/1.15.5.ts
+++ b/server/setup/scriptsPg/1.15.5.ts
@@ -1,0 +1,24 @@
+import { db } from "@server/db/pg/driver";
+import { sql } from "drizzle-orm";
+
+const version = "1.15.5";
+
+export default async function migration() {
+    console.log(`Running setup script ${version}...`);
+
+    try {
+        await db.execute(sql`BEGIN`);
+        await db.execute(
+            sql`ALTER TABLE "resources" ADD COLUMN "redirectDomains" text;`
+        );
+        await db.execute(sql`COMMIT`);
+        console.log("Migrated database");
+    } catch (e) {
+        await db.execute(sql`ROLLBACK`);
+        console.log("Unable to migrate database");
+        console.log(e);
+        throw e;
+    }
+
+    console.log(`${version} migration complete`);
+}

--- a/server/setup/scriptsSqlite/1.15.5.ts
+++ b/server/setup/scriptsSqlite/1.15.5.ts
@@ -1,0 +1,27 @@
+import Database from "better-sqlite3";
+import path from "path";
+import { APP_PATH } from "@server/lib/consts";
+
+const version = "1.15.5";
+
+export default async function migration() {
+    console.log(`Running setup script ${version}...`);
+
+    const location = path.join(APP_PATH, "db", "db.sqlite");
+    const db = new Database(location);
+
+    try {
+        db.transaction(() => {
+            db.prepare(
+                `ALTER TABLE 'resources' ADD 'redirectDomains' text;`
+            ).run();
+        })();
+
+        console.log("Migrated database");
+    } catch (e) {
+        console.log("Failed to migrate db:", e);
+        throw e;
+    }
+
+    console.log(`${version} migration complete`);
+}

--- a/src/app/[orgId]/settings/resources/proxy/[niceId]/general/page.tsx
+++ b/src/app/[orgId]/settings/resources/proxy/[niceId]/general/page.tsx
@@ -480,7 +480,8 @@ export default function GeneralForm() {
             name: z.string().min(1).max(255),
             niceId: z.string().min(1).max(255).optional(),
             domainId: z.string().optional(),
-            proxyPort: z.number().int().min(1).max(65535).optional()
+            proxyPort: z.number().int().min(1).max(65535).optional(),
+            redirectDomainsText: z.string().optional()
         })
         .refine(
             (data) => {
@@ -509,7 +510,10 @@ export default function GeneralForm() {
             niceId: resource.niceId,
             subdomain: resource.subdomain ? resource.subdomain : undefined,
             domainId: resource.domainId || undefined,
-            proxyPort: resource.proxyPort || undefined
+            proxyPort: resource.proxyPort || undefined,
+            redirectDomainsText: (resource.redirectDomains || [])
+                .map((domain) => toUnicode(domain))
+                .join("\n")
         },
         mode: "onChange"
     });
@@ -521,21 +525,26 @@ export default function GeneralForm() {
         if (!isValid) return;
 
         const data = form.getValues();
+        const redirectDomains = Array.from(
+            new Set(
+                (data.redirectDomainsText || "")
+                    .split("\n")
+                    .map((host) => host.trim())
+                    .filter((host) => host.length > 0)
+                    .map((host) => toASCII(host).toLowerCase())
+            )
+        );
 
         const res = await api
-            .post<AxiosResponse<UpdateResourceResponse>>(
-                `resource/${resource?.resourceId}`,
-                {
-                    enabled: data.enabled,
-                    name: data.name,
-                    niceId: data.niceId,
-                    subdomain: data.subdomain
-                        ? toASCII(data.subdomain)
-                        : undefined,
-                    domainId: data.domainId,
-                    proxyPort: data.proxyPort
-                }
-            )
+            .post<AxiosResponse<UpdateResourceResponse>>(`resource/${resource?.resourceId}`, {
+                enabled: data.enabled,
+                name: data.name,
+                niceId: data.niceId,
+                subdomain: data.subdomain ? toASCII(data.subdomain) : undefined,
+                domainId: data.domainId,
+                proxyPort: data.proxyPort,
+                ...(resource.http ? { redirectDomains } : {})
+            })
             .catch((e) => {
                 toast({
                     variant: "destructive",
@@ -557,7 +566,8 @@ export default function GeneralForm() {
                 subdomain: data.subdomain,
                 fullDomain: updated.fullDomain,
                 proxyPort: data.proxyPort,
-                domainId: data.domainId
+                domainId: data.domainId,
+                redirectDomains
             });
 
             toast({
@@ -715,24 +725,60 @@ export default function GeneralForm() {
                                     )}
 
                                     {resource.http && (
-                                        <div className="space-y-2">
-                                            <Label>{t("resourceDomain")}</Label>
-                                            <div className="border p-2 rounded-md flex items-center justify-between">
-                                                <span className="text-sm flex items-center gap-2">
-                                                    <Globe size="14" />
-                                                    {resourceFullDomain}
-                                                </span>
-                                                <Button
-                                                    variant="secondary"
-                                                    type="button"
-                                                    size="sm"
-                                                    onClick={() =>
-                                                        setEditDomainOpen(true)
-                                                    }
-                                                >
-                                                    {t("resourceEditDomain")}
-                                                </Button>
+                                        <div className="space-y-4">
+                                            <div className="space-y-2">
+                                                <Label>
+                                                    {t("resourceDomain")}
+                                                </Label>
+                                                <div className="border p-2 rounded-md flex items-center justify-between">
+                                                    <span className="text-sm flex items-center gap-2">
+                                                        <Globe size="14" />
+                                                        {resourceFullDomain}
+                                                    </span>
+                                                    <Button
+                                                        variant="secondary"
+                                                        type="button"
+                                                        size="sm"
+                                                        onClick={() =>
+                                                            setEditDomainOpen(
+                                                                true
+                                                            )
+                                                        }
+                                                    >
+                                                        {t(
+                                                            "resourceEditDomain"
+                                                        )}
+                                                    </Button>
+                                                </div>
                                             </div>
+
+                                            <FormField
+                                                control={form.control}
+                                                name="redirectDomainsText"
+                                                render={({ field }) => (
+                                                    <FormItem>
+                                                        <FormLabel>
+                                                            Redirect domains
+                                                        </FormLabel>
+                                                        <FormControl>
+                                                            <Textarea
+                                                                {...field}
+                                                                rows={5}
+                                                                placeholder={`www.${resourceFullDomainName}\nexample.org`}
+                                                            />
+                                                        </FormControl>
+                                                        <FormDescription>
+                                                            One source host per
+                                                            line. Requests to
+                                                            these hosts will
+                                                            redirect to this
+                                                            resource domain and
+                                                            preserve path/query.
+                                                        </FormDescription>
+                                                        <FormMessage />
+                                                    </FormItem>
+                                                )}
+                                            />
                                         </div>
                                     )}
                                 </form>

--- a/src/app/[orgId]/settings/resources/proxy/[niceId]/general/page.tsx
+++ b/src/app/[orgId]/settings/resources/proxy/[niceId]/general/page.tsx
@@ -42,7 +42,7 @@ import { createApiClient, formatAxiosError } from "@app/lib/api";
 import { finalizeSubdomainSanitize } from "@app/lib/subdomain-utils";
 import { UpdateResourceResponse } from "@server/routers/resource";
 import { AxiosResponse } from "axios";
-import { AlertCircle, Globe } from "lucide-react";
+import { AlertCircle, Globe, X } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useParams, useRouter } from "next/navigation";
 import { toASCII, toUnicode } from "punycode";
@@ -442,6 +442,7 @@ export default function GeneralForm() {
     const router = useRouter();
     const t = useTranslations();
     const [editDomainOpen, setEditDomainOpen] = useState(false);
+    const [editRedirectOpen, setEditRedirectOpen] = useState(false);
 
     const { env } = useEnvContext();
 
@@ -472,6 +473,23 @@ export default function GeneralForm() {
         fullDomain: string;
         baseDomain: string;
     } | null>(null);
+    const [selectedRedirectDomain, setSelectedRedirectDomain] = useState<{
+        domainId: string;
+        domainNamespaceId?: string;
+        subdomain?: string;
+        fullDomain: string;
+        baseDomain: string;
+    } | null>(null);
+
+    const normalizeDomain = (domain: string) => {
+        try {
+            return toASCII(domain).trim().toLowerCase();
+        } catch {
+            return "";
+        }
+    };
+    const tx = (key: string, fallback: string) =>
+        t.has(key as any) ? t(key as any) : fallback;
 
     const GeneralFormSchema = z
         .object({
@@ -481,7 +499,7 @@ export default function GeneralForm() {
             niceId: z.string().min(1).max(255).optional(),
             domainId: z.string().optional(),
             proxyPort: z.number().int().min(1).max(65535).optional(),
-            redirectDomainsText: z.string().optional()
+            redirectDomains: z.array(z.string()).optional()
         })
         .refine(
             (data) => {
@@ -511,12 +529,11 @@ export default function GeneralForm() {
             subdomain: resource.subdomain ? resource.subdomain : undefined,
             domainId: resource.domainId || undefined,
             proxyPort: resource.proxyPort || undefined,
-            redirectDomainsText: (resource.redirectDomains || [])
-                .map((domain) => toUnicode(domain))
-                .join("\n")
+            redirectDomains: resource.redirectDomains || []
         },
         mode: "onChange"
     });
+    const redirectDomainValues = form.watch("redirectDomains") || [];
 
     const [, formAction, saveLoading] = useActionState(onSubmit, null);
 
@@ -525,15 +542,14 @@ export default function GeneralForm() {
         if (!isValid) return;
 
         const data = form.getValues();
+        const normalizedPrimaryDomain = normalizeDomain(resourceFullDomainName);
         const redirectDomains = Array.from(
             new Set(
-                (data.redirectDomainsText || "")
-                    .split("\n")
-                    .map((host) => host.trim())
+                (data.redirectDomains || [])
+                    .map((host) => normalizeDomain(host))
                     .filter((host) => host.length > 0)
-                    .map((host) => toASCII(host).toLowerCase())
             )
-        );
+        ).filter((host) => host !== normalizedPrimaryDomain);
 
         const res = await api
             .post<AxiosResponse<UpdateResourceResponse>>(`resource/${resource?.resourceId}`, {
@@ -754,26 +770,85 @@ export default function GeneralForm() {
 
                                             <FormField
                                                 control={form.control}
-                                                name="redirectDomainsText"
-                                                render={({ field }) => (
+                                                name="redirectDomains"
+                                                render={() => (
                                                     <FormItem>
                                                         <FormLabel>
-                                                            Redirect domains
+                                                            {tx(
+                                                                "resourceRedirects",
+                                                                "Redirects"
+                                                            )}
                                                         </FormLabel>
-                                                        <FormControl>
-                                                            <Textarea
-                                                                {...field}
-                                                                rows={5}
-                                                                placeholder={`www.${resourceFullDomainName}\nexample.org`}
-                                                            />
-                                                        </FormControl>
+                                                        <div className="border p-2 rounded-md space-y-2">
+                                                            {redirectDomainValues.map(
+                                                                (domain) => (
+                                                                    <div
+                                                                        key={
+                                                                            domain
+                                                                        }
+                                                                        className="flex items-center justify-between gap-2"
+                                                                    >
+                                                                        <span className="text-sm flex items-center gap-2">
+                                                                            <Globe
+                                                                                size="14"
+                                                                            />
+                                                                            {toUnicode(
+                                                                                domain
+                                                                            )}
+                                                                        </span>
+                                                                        <Button
+                                                                            type="button"
+                                                                            size="sm"
+                                                                            variant="ghost"
+                                                                            onClick={() => {
+                                                                                const current =
+                                                                                    form.getValues(
+                                                                                        "redirectDomains"
+                                                                                    ) ||
+                                                                                    [];
+                                                                                form.setValue(
+                                                                                    "redirectDomains",
+                                                                                    current.filter(
+                                                                                        (
+                                                                                            d
+                                                                                        ) =>
+                                                                                            d !==
+                                                                                            domain
+                                                                                    )
+                                                                                );
+                                                                            }}
+                                                                        >
+                                                                            <X
+                                                                                size="14"
+                                                                            />
+                                                                        </Button>
+                                                                    </div>
+                                                                )
+                                                            )}
+                                                            <div className="flex sm:justify-end">
+                                                                <Button
+                                                                    type="button"
+                                                                    variant="secondary"
+                                                                    size="sm"
+                                                                    className="w-full sm:w-auto"
+                                                                    onClick={() =>
+                                                                        setEditRedirectOpen(
+                                                                            true
+                                                                        )
+                                                                    }
+                                                                >
+                                                                    {tx(
+                                                                        "resourceAddRedirect",
+                                                                        "Add Redirect"
+                                                                    )}
+                                                                </Button>
+                                                            </div>
+                                                        </div>
                                                         <FormDescription>
-                                                            One source host per
-                                                            line. Requests to
-                                                            these hosts will
-                                                            redirect to this
-                                                            resource domain and
-                                                            preserve path/query.
+                                                            {tx(
+                                                                "resourceRedirectDomainsDescription",
+                                                                "Redirect requests from other domains to this resource."
+                                                            )}
                                                         </FormDescription>
                                                         <FormMessage />
                                                     </FormItem>
@@ -812,9 +887,12 @@ export default function GeneralForm() {
             >
                 <CredenzaContent>
                     <CredenzaHeader>
-                        <CredenzaTitle>Edit Domain</CredenzaTitle>
+                        <CredenzaTitle>{t("resourceEditDomain")}</CredenzaTitle>
                         <CredenzaDescription>
-                            Select a domain for your resource
+                            {tx(
+                                "resourceEditDomainDescription",
+                                "Select a domain for your resource"
+                            )}
                         </CredenzaDescription>
                     </CredenzaHeader>
                     <CredenzaBody>
@@ -880,7 +958,135 @@ export default function GeneralForm() {
                                 }
                             }}
                         >
-                            Select Domain
+                            {tx("selectDomain", "Select Domain")}
+                        </Button>
+                    </CredenzaFooter>
+                </CredenzaContent>
+            </Credenza>
+
+            <Credenza
+                open={editRedirectOpen}
+                onOpenChange={(setOpen) => {
+                    setEditRedirectOpen(setOpen);
+                    if (!setOpen) {
+                        setSelectedRedirectDomain(null);
+                    }
+                }}
+            >
+                <CredenzaContent>
+                    <CredenzaHeader>
+                        <CredenzaTitle>
+                            {tx("resourceAddRedirect", "Add Redirect")}
+                        </CredenzaTitle>
+                        <CredenzaDescription>
+                            {tx(
+                                "resourceAddRedirectDescription",
+                                "Select a redirect source domain (for example www.example.com)"
+                            )}
+                        </CredenzaDescription>
+                    </CredenzaHeader>
+                    <CredenzaBody>
+                        <DomainPicker
+                            orgId={orgId as string}
+                            cols={1}
+                            defaultDomainId={form.watch("domainId")}
+                            onDomainChange={(res) => {
+                                const selected =
+                                    res === null
+                                        ? null
+                                        : {
+                                              domainId: res.domainId,
+                                              subdomain: res.subdomain,
+                                              fullDomain: res.fullDomain,
+                                              baseDomain: res.baseDomain,
+                                              domainNamespaceId:
+                                                  res.domainNamespaceId
+                                          };
+
+                                setSelectedRedirectDomain(selected);
+                            }}
+                        />
+                    </CredenzaBody>
+                    <CredenzaFooter>
+                        <CredenzaClose asChild>
+                            <Button variant="outline">{t("cancel")}</Button>
+                        </CredenzaClose>
+                        <Button
+                            disabled={!selectedRedirectDomain}
+                            onClick={() => {
+                                if (selectedRedirectDomain) {
+                                    const sanitizedSubdomain =
+                                        selectedRedirectDomain.subdomain
+                                            ? finalizeSubdomainSanitize(
+                                                  selectedRedirectDomain.subdomain
+                                              )
+                                            : "";
+
+                                    const fullRedirectDomain =
+                                        sanitizedSubdomain
+                                            ? `${sanitizedSubdomain}.${selectedRedirectDomain.baseDomain}`
+                                            : selectedRedirectDomain.baseDomain;
+
+                                    const normalizedRedirectDomain =
+                                        normalizeDomain(fullRedirectDomain);
+                                    const normalizedPrimaryDomain =
+                                        normalizeDomain(resourceFullDomainName);
+
+                                    if (
+                                        !normalizedRedirectDomain ||
+                                        normalizedRedirectDomain ===
+                                            normalizedPrimaryDomain
+                                    ) {
+                                        toast({
+                                            variant: "destructive",
+                                            title: tx(
+                                                "resourceRedirectInvalid",
+                                                "Invalid redirect domain"
+                                            ),
+                                            description: tx(
+                                                "resourceRedirectInvalidDescription",
+                                                "Redirect domain must be different from the primary domain."
+                                            )
+                                        });
+                                        return;
+                                    }
+
+                                    const currentRedirectDomains =
+                                        form.getValues("redirectDomains") || [];
+                                    const nextRedirectDomains = Array.from(
+                                        new Set([
+                                            ...currentRedirectDomains,
+                                            normalizedRedirectDomain
+                                        ])
+                                    );
+
+                                    if (
+                                        nextRedirectDomains.length ===
+                                        currentRedirectDomains.length
+                                    ) {
+                                        toast({
+                                            variant: "destructive",
+                                            title: tx(
+                                                "resourceRedirectDuplicate",
+                                                "Redirect already added"
+                                            ),
+                                            description: tx(
+                                                "resourceRedirectDuplicateDescription",
+                                                "That redirect domain is already in the list."
+                                            )
+                                        });
+                                        return;
+                                    }
+
+                                    form.setValue(
+                                        "redirectDomains",
+                                        nextRedirectDomains
+                                    );
+                                    setEditRedirectOpen(false);
+                                }
+                            }}
+                        >
+                            {tx("resourceAddRedirect", "Add Redirect")}
                         </Button>
                     </CredenzaFooter>
                 </CredenzaContent>


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description

I’m not sure of the best migration approach here, since this feature requires adding a new column to the resources table so its bundle inside of the PR, but maintainers may want to change it to a minor version since its a new feature?

however, there may be another option which we create a dedicate table for this? 🤷🏻 

  - add redirect domains section in resource settings
  - add "Add Redirect" flow using DomainPicker
  - validate redirect domains to prevent primary-domain and duplicate entries
  - normalize redirect domains before save (ASCII/lowercase)
  - support removing redirect domains from the configured list
  - add translation-key fallbacks for new redirect copy

## How to test?

When editing a resource, under the general tab you now have "Redirect" options which allow you to set subdomains or another domain (that added in the system) to redirect to the currently edited resource. This is useful as users may host a website on the base domain and requests to `www.` should be redirected to the base domain on a permanent redirect (or the reverse depending on the user preference).

<img width="1767" height="711" alt="image" src="https://github.com/user-attachments/assets/8108555e-079d-465c-84e9-2b58eeaa54af" />

Before scaffolding this feature the only option would be to create another resource that take the subdomain and points to the same target, however, that is not scalable and creates duplicate records.

Open to comments/feedback on the PR as direction may have to change or may prompt new ideas on how to achieve this.