### PR TITLE
enhance(installer): use ldflags to inject versions

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -289,22 +289,14 @@ jobs:
                   echo "LATEST_BADGER_TAG=$LATEST_TAG" >> $GITHUB_ENV
               shell: bash
 
-            - name: Update install/main.go
-              run: |
-                  PANGOLIN_VERSION=${{ env.TAG }}
-                  GERBIL_VERSION=${{ env.LATEST_GERBIL_TAG }}
-                  BADGER_VERSION=${{ env.LATEST_BADGER_TAG }}
-                  sed -i "s/config.PangolinVersion = \".*\"/config.PangolinVersion = \"$PANGOLIN_VERSION\"/" install/main.go
-                  sed -i "s/config.GerbilVersion = \".*\"/config.GerbilVersion = \"$GERBIL_VERSION\"/" install/main.go
-                  sed -i "s/config.BadgerVersion = \".*\"/config.BadgerVersion = \"$BADGER_VERSION\"/" install/main.go
-                  echo "Updated install/main.go with Pangolin version $PANGOLIN_VERSION, Gerbil version $GERBIL_VERSION, and Badger version $BADGER_VERSION"
-                  cat install/main.go
-              shell: bash
-
             - name: Build installer
               working-directory: install
               run: |
-                  make go-build-release
+                  make go-build-release \
+                    PANGOLIN_VERSION=${{ env.TAG }} \
+                    GERBIL_VERSION=${{ env.LATEST_GERBIL_TAG }} \
+                    BADGER_VERSION=${{ env.LATEST_BADGER_TAG }}
+              shell: bash
 
             - name: Upload artifacts from /install/bin
               uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0

--- a/install/Makefile
+++ b/install/Makefile
@@ -1,41 +1,24 @@
-all: update-versions go-build-release put-back
-dev-all: dev-update-versions dev-build dev-clean
+all: go-build-release
+
+# Build with version injection via ldflags
+# Versions can be passed via: make go-build-release PANGOLIN_VERSION=x.x.x GERBIL_VERSION=x.x.x BADGER_VERSION=x.x.x
+# Or fetched automatically if not provided (requires curl and jq)
+
+PANGOLIN_VERSION ?= $(shell curl -s https://api.github.com/repos/fosrl/pangolin/tags | jq -r '.[0].name')
+GERBIL_VERSION ?= $(shell curl -s https://api.github.com/repos/fosrl/gerbil/tags | jq -r '.[0].name')
+BADGER_VERSION ?= $(shell curl -s https://api.github.com/repos/fosrl/badger/tags | jq -r '.[0].name')
+
+LDFLAGS = -X main.pangolinVersion=$(PANGOLIN_VERSION) \
+          -X main.gerbilVersion=$(GERBIL_VERSION) \
+          -X main.badgerVersion=$(BADGER_VERSION)
 
 go-build-release:
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bin/installer_linux_amd64
-	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o bin/installer_linux_arm64
+	@echo "Building with versions - Pangolin: $(PANGOLIN_VERSION), Gerbil: $(GERBIL_VERSION), Badger: $(BADGER_VERSION)"
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o bin/installer_linux_amd64
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags "$(LDFLAGS)" -o bin/installer_linux_arm64
 
 clean:
 	rm -f bin/installer_linux_amd64
 	rm -f bin/installer_linux_arm64
 
-update-versions:
-	@echo "Fetching latest versions..."
-	cp main.go main.go.bak && \
-	$(MAKE) dev-update-versions
-
-put-back:
-	mv main.go.bak main.go
-
-dev-update-versions:
-	if [ -z "$(tag)" ]; then \
-		PANGOLIN_VERSION=$$(curl -s https://api.github.com/repos/fosrl/pangolin/tags | jq -r '.[0].name'); \
-	else \
-		PANGOLIN_VERSION=$(tag); \
-	fi && \
-	GERBIL_VERSION=$$(curl -s https://api.github.com/repos/fosrl/gerbil/tags | jq -r '.[0].name') && \
-	BADGER_VERSION=$$(curl -s https://api.github.com/repos/fosrl/badger/tags | jq -r '.[0].name') && \
-	echo "Latest versions - Pangolin: $$PANGOLIN_VERSION, Gerbil: $$GERBIL_VERSION, Badger: $$BADGER_VERSION" && \
-	sed -i "s/config.PangolinVersion = \".*\"/config.PangolinVersion = \"$$PANGOLIN_VERSION\"/" main.go && \
-	sed -i "s/config.GerbilVersion = \".*\"/config.GerbilVersion = \"$$GERBIL_VERSION\"/" main.go && \
-	sed -i "s/config.BadgerVersion = \".*\"/config.BadgerVersion = \"$$BADGER_VERSION\"/" main.go && \
-	echo "Updated main.go with latest versions"
-
-dev-build: go-build-release
-
-dev-clean:
-	@echo "Restoring version values ..."
-	sed -i "s/config.PangolinVersion = \".*\"/config.PangolinVersion = \"replaceme\"/" main.go && \
-	sed -i "s/config.GerbilVersion = \".*\"/config.GerbilVersion = \"replaceme\"/" main.go && \
-	sed -i "s/config.BadgerVersion = \".*\"/config.BadgerVersion = \"replaceme\"/" main.go
-	@echo "Restored version strings in main.go"
+.PHONY: all go-build-release clean

--- a/install/main.go
+++ b/install/main.go
@@ -2,12 +2,12 @@ package main
 
 import (
 	"bufio"
+	"crypto/rand"
 	"embed"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"io/fs"
-	"crypto/rand"
-	"encoding/base64"
 	"net"
 	"net/http"
 	"net/url"
@@ -20,11 +20,17 @@ import (
 	"time"
 )
 
-// DO NOT EDIT THIS FUNCTION; IT MATCHED BY REGEX IN CICD
+// Version variables injected at build time via -ldflags
+var (
+	pangolinVersion string
+	gerbilVersion   string
+	badgerVersion   string
+)
+
 func loadVersions(config *Config) {
-	config.PangolinVersion = "replaceme"
-	config.GerbilVersion = "replaceme"
-	config.BadgerVersion = "replaceme"
+	config.PangolinVersion = pangolinVersion
+	config.GerbilVersion = gerbilVersion
+	config.BadgerVersion = badgerVersion
 }
 
 //go:embed config/*


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description

Instead of the CI/CD using sed to replace the 'replaceme' text we can instead use ldflags which can inject variables at build time to the versions. The makefile had a bunch of workarounds for dev so these have been removed to cleanup etc etc and fetchs versions from the gh api directly if the variables are not injected like the CI/CD does

## How to test?

Using `make` or explicit `make go-build-release PANGOLIN_VERSION=1.15.4 GERBIL_VERSION=1.0.0 BADGER_VERSION=1.0.0` will inject the variables into the binary without using `sed`
