### PR TITLE
Podman Quadlet: Network=host for newt

### DIFF
--- a/src/components/newt-install-commands.tsx
+++ b/src/components/newt-install-commands.tsx
@@ -114,6 +114,7 @@ Description=Newt container
 [Container]
 ContainerName=newt
 Image=docker.io/fosrl/newt
+Network=host
 Environment=PANGOLIN_ENDPOINT=${endpoint}
 Environment=NEWT_ID=${id}
 Environment=NEWT_SECRET=${secret}${!acceptClients ? "\nEnvironment=DISABLE_CLIENTS=true" : ""}


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description
`newt` needs to run on the `host` network in order to communicate with local services exposed at 127.0.0.1 or localhost.

## How to test?
Try running the Podman Quadlet `newt` without this setting -- it won't be able to connect to local services.

