### PR TITLE
fix: logo URL validation shows cryptic error instead of meaningful message

### DIFF
--- a/server/private/routers/loginPage/upsertLoginPageBranding.ts
+++ b/server/private/routers/loginPage/upsertLoginPageBranding.ts
@@ -35,76 +35,80 @@ const paramsSchema = z.strictObject({
 
 const bodySchema = z.strictObject({
     logoUrl: z
-        .union([
-            z.literal(""),
-            z
-                .string()
-                .superRefine(async (urlOrPath, ctx) => {
-                    const parseResult = z.url().safeParse(urlOrPath);
-                    if (!parseResult.success) {
-                        if (build !== "enterprise") {
-                            ctx.addIssue({
-                                code: "custom",
-                                message: "Must be a valid URL"
-                            });
-                            return;
-                        } else {
-                            try {
-                                validateLocalPath(urlOrPath);
-                            } catch (error) {
-                                ctx.addIssue({
-                                    code: "custom",
-                                    message: "Must be either a valid image URL or a valid pathname starting with `/` and not containing query parameters, `..` or `*`"
-                                });
-                            } finally {
-                                return;
-                            }
-                        }
-                    }
+        .string()
+        .superRefine(async (urlOrPath, ctx) => {
+            // Allow empty string (no logo)
+            if (urlOrPath.length === 0) {
+                return;
+            }
 
+            const parseResult = z.url().safeParse(urlOrPath);
+            if (!parseResult.success) {
+                if (build !== "enterprise") {
+                    ctx.addIssue({
+                        code: "custom",
+                        message: "Must be a valid URL"
+                    });
+                    return;
+                } else {
                     try {
-                        const response = await fetch(urlOrPath, {
-                            method: "HEAD"
-                        }).catch(() => {
-                            // If HEAD fails (CORS or method not allowed), try GET
-                            return fetch(urlOrPath, { method: "GET" });
-                        });
-
-                        if (response.status !== 200) {
-                            ctx.addIssue({
-                                code: "custom",
-                                message: `Failed to load image. Please check that the URL is accessible.`
-                            });
-                            return;
-                        }
-
-                        const contentType =
-                            response.headers.get("content-type") ?? "";
-                        if (!contentType.startsWith("image/")) {
-                            ctx.addIssue({
-                                code: "custom",
-                                message: `URL does not point to an image. Please provide a URL to an image file (e.g., .png, .jpg, .svg).`
-                            });
-                            return;
-                        }
+                        validateLocalPath(urlOrPath);
                     } catch (error) {
-                        let errorMessage =
-                            "Unable to verify image URL. Please check that the URL is accessible and points to an image file.";
-
-                        if (error instanceof TypeError && error.message.includes("fetch")) {
-                            errorMessage =
-                                "Network error: Unable to reach the URL. Please check your internet connection and verify the URL is correct.";
-                        } else if (error instanceof Error) {
-                            errorMessage = `Error verifying URL: ${error.message}`;
-                        }
-
                         ctx.addIssue({
                             code: "custom",
-                            message: errorMessage
+                            message:
+                                "Must be either a valid image URL or a valid pathname starting with `/` and not containing query parameters, `..` or `*`"
                         });
+                    } finally {
+                        return;
                     }
-                })
-        ])
+                }
+            }
+
+            try {
+                const response = await fetch(urlOrPath, {
+                    method: "HEAD"
+                }).catch(() => {
+                    // If HEAD fails (CORS or method not allowed), try GET
+                    return fetch(urlOrPath, { method: "GET" });
+                });
+
+                if (response.status !== 200) {
+                    ctx.addIssue({
+                        code: "custom",
+                        message: `Failed to load image. Please check that the URL is accessible.`
+                    });
+                    return;
+                }
+
+                const contentType = response.headers.get("content-type") ?? "";
+                if (!contentType.startsWith("image/")) {
+                    ctx.addIssue({
+                        code: "custom",
+                        message: `URL does not point to an image. Please provide a URL to an image file (e.g., .png, .jpg, .svg).`
+                    });
+                    return;
+                }
+            } catch (error) {
+                let errorMessage =
+                    "Unable to verify image URL. Please check that the URL is accessible and points to an image file.";
+
+                if (
+                    error instanceof TypeError &&
+                    error.message.includes("fetch")
+                ) {
+                    errorMessage =
+                        "Network error: Unable to reach the URL. Please check your internet connection and verify the URL is correct.";
+                } else if (error instanceof Error) {
+                    errorMessage = `Error verifying URL: ${error.message}`;
+                }
+
+                ctx.addIssue({
+                    code: "custom",
+                    message: errorMessage
+                });
+            }
+        })
         .transform((val) => (val === "" ? null : val))
         .nullish(),
     logoWidth: z.coerce.number<number>().min(1),

--- a/src/components/AuthPageBrandingForm.tsx
+++ b/src/components/AuthPageBrandingForm.tsx
@@ -44,77 +44,76 @@ export type AuthPageCustomizationProps = {
 };
 
 const AuthPageFormSchema = z.object({
-    logoUrl: z.union([
-        z.literal(""),
-        z.string().superRefine(async (urlOrPath, ctx) => {
-            const parseResult = z.url().safeParse(urlOrPath);
-            if (!parseResult.success) {
-                if (build !== "enterprise") {
-                    ctx.addIssue({
-                        code: "custom",
-                        message: "Must be a valid URL"
-                    });
-                    return;
-                } else {
-                    try {
-                        validateLocalPath(urlOrPath);
-                    } catch (error) {
-                        ctx.addIssue({
-                            code: "custom",
-                            message:
-                                "Must be either a valid image URL or a valid pathname starting with `/` and not containing query parameters, `..` or `*`"
-                        });
-                    } finally {
-                        return;
-                    }
-                }
-            }
+    logoUrl: z.string().superRefine(async (urlOrPath, ctx) => {
+        // Allow empty string (no logo)
+        if (urlOrPath.length === 0) {
+            return;
+        }
 
-            try {
-                const response = await fetch(urlOrPath, {
-                    method: "HEAD"
-                }).catch(() => {
-                    // If HEAD fails (CORS or method not allowed), try GET
-                    return fetch(urlOrPath, { method: "GET" });
-                });
-
-                if (response.status !== 200) {
-                    ctx.addIssue({
-                        code: "custom",
-                        message: `Failed to load image. Please check that the URL is accessible.`
-                    });
-                    return;
-                }
-
-                const contentType = response.headers.get("content-type") ?? "";
-                if (!contentType.startsWith("image/")) {
-                    ctx.addIssue({
-                        code: "custom",
-                        message: `URL does not point to an image. Please provide a URL to an image file (e.g., .png, .jpg, .svg).`
-                    });
-                    return;
-                }
-            } catch (error) {
-                let errorMessage =
-                    "Unable to verify image URL. Please check that the URL is accessible and points to an image file.";
-
-                if (
-                    error instanceof TypeError &&
-                    error.message.includes("fetch")
-                ) {
-                    errorMessage =
-                        "Network error: Unable to reach the URL. Please check your internet connection and verify the URL is correct.";
-                } else if (error instanceof Error) {
-                    errorMessage = `Error verifying URL: ${error.message}`;
-                }
-
+        const parseResult = z.url().safeParse(urlOrPath);
+        if (!parseResult.success) {
+            if (build !== "enterprise") {
                 ctx.addIssue({
                     code: "custom",
-                    message: errorMessage
+                    message: "Must be a valid URL"
                 });
+                return;
+            } else {
+                try {
+                    validateLocalPath(urlOrPath);
+                } catch (error) {
+                    ctx.addIssue({
+                        code: "custom",
+                        message:
+                            "Must be either a valid image URL or a valid pathname starting with `/` and not containing query parameters, `..` or `*`"
+                    });
+                } finally {
+                    return;
+                }
             }
-        })
-    ]),
+        }
+
+        try {
+            const response = await fetch(urlOrPath, {
+                method: "HEAD"
+            }).catch(() => {
+                // If HEAD fails (CORS or method not allowed), try GET
+                return fetch(urlOrPath, { method: "GET" });
+            });
+
+            if (response.status !== 200) {
+                ctx.addIssue({
+                    code: "custom",
+                    message: `Failed to load image. Please check that the URL is accessible.`
+                });
+                return;
+            }
+
+            const contentType = response.headers.get("content-type") ?? "";
+            if (!contentType.startsWith("image/")) {
+                ctx.addIssue({
+                    code: "custom",
+                    message: `URL does not point to an image. Please provide a URL to an image file (e.g., .png, .jpg, .svg).`
+                });
+                return;
+            }
+        } catch (error) {
+            let errorMessage =
+                "Unable to verify image URL. Please check that the URL is accessible and points to an image file.";
+
+            if (error instanceof TypeError && error.message.includes("fetch")) {
+                errorMessage =
+                    "Network error: Unable to reach the URL. Please check your internet connection and verify the URL is correct.";
+            } else if (error instanceof Error) {
+                errorMessage = `Error verifying URL: ${error.message}`;
+            }
+
+            ctx.addIssue({
+                code: "custom",
+                message: errorMessage
+            });
+        }
+    }),
     logoWidth: z.coerce.number<number>().min(1),
     logoHeight: z.coerce.number<number>().min(1),
     orgTitle: z.string().optional(),


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Summary

Fixes #2325

- Replaced `z.union([z.literal(""), z.string().superRefine(...)])` with a single `z.string().superRefine(...)` that handles the empty string case internally
- Applied the same fix to both client-side (`AuthPageBrandingForm.tsx`) and server-side (`upsertLoginPageBranding.ts`) validation schemas

## Problem

When entering a logo URL that fails validation (e.g., the server doesn't return an `image/*` content-type), users see the cryptic error:

> `Too big: expected string to have <=0 characters`

This happens because Zod's `z.union` tries all branches when one fails. The first branch (`z.literal("")`) expects an empty string, so its error message about `<=0 characters` gets surfaced instead of the actual validation error from the `superRefine` branch.

## Fix

Move the empty string check inside the `superRefine` callback as an early return. This eliminates the `z.union` entirely, so validation errors (invalid URL, non-image content-type, network errors, etc.) are always reported directly to the user.

## How to test?

All existing validation cases are preserved:
- Empty string (no logo) -> passes
- Invalid URL -> `"Must be a valid URL"`
- URL returns non-200 -> `"Failed to load image..."`
- URL doesn't serve image content-type -> `"URL does not point to an image..."`
- Network/fetch error -> specific error message
- Enterprise local path validation -> unchanged