### PR TITLE
fix: correct session DELETE tautology and HTTP cookie domain interpolation

### DIFF
--- a/server/auth/sessions/resource.ts
+++ b/server/auth/sessions/resource.ts
@@ -87,7 +87,7 @@ export async function validateResourceSessionToken(
     if (Date.now() >= resourceSession.expiresAt) {
         await db
             .delete(resourceSessions)
-            .where(eq(resourceSessions.sessionId, resourceSessions.sessionId));
+            .where(eq(resourceSessions.sessionId, sessionId));
         return { resourceSession: null };
     } else if (
         Date.now() >=
@@ -181,7 +181,7 @@ export function serializeResourceSessionCookie(
         return `${cookieName}_s.${now}=${token}; HttpOnly; SameSite=Lax; Expires=${expiresAt.toUTCString()}; Path=/; Secure; Domain=${domain}`;
     } else {
         if (expiresAt === undefined) {
-            return `${cookieName}.${now}=${token}; HttpOnly; SameSite=Lax; Path=/; Domain=$domain}`;
+            return `${cookieName}.${now}=${token}; HttpOnly; SameSite=Lax; Path=/; Domain=${domain}`;
         }
         return `${cookieName}.${now}=${token}; HttpOnly; SameSite=Lax; Expires=${expiresAt.toUTCString()}; Path=/; Domain=${domain}`;
     }


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description
Two bugs in `server/auth/sessions/resource.ts` with minimal, surgical fixes.
Changes are limited to two single-line corrections — no architecture changes, no new abstractions.

Closes #2534

## Fix 1 — Session DELETE tautology

`validateResourceSessionToken` was deleting all rows in `resourceSessions` on any expiry because the WHERE clause compared the column to itself:

```ts
// Before — tautology, deletes everything
.where(eq(resourceSessions.sessionId, resourceSessions.sessionId)

// After — targets only the expired session
.where(eq(resourceSessions.sessionId, sessionId)
```

## Fix 2 — HTTP cookie Domain broken template literal

`serializeResourceSessionCookie` had a missing `{` in the HTTP path:
```ts
// Before — sends literal string "$domain}" to browser
`... Domain=$domain}`

// After — correctly interpolates the domain variable
`... Domain=${domain}`
```

## Testing

- [x] Verified expired session only deletes itself, not others
- [x] Verified HTTP resource cookie is correctly scoped to domain
