### PR TITLE
fix: sync resource toggle states with context on initial load

### DIFF
--- a/src/app/[orgId]/settings/resources/proxy/[niceId]/authentication/page.tsx
+++ b/src/app/[orgId]/settings/resources/proxy/[niceId]/authentication/page.tsx
@@ -187,7 +187,11 @@ export default function ResourceAuthenticationPage() {
         number | null
     >(null);
 
-    const [ssoEnabled, setSsoEnabled] = useState(resource.sso);
+    const [ssoEnabled, setSsoEnabled] = useState(resource.sso ?? false);
+
+    useEffect(() => {
+        setSsoEnabled(resource.sso ?? false);
+    }, [resource.sso]);
 
     const [selectedIdpId, setSelectedIdpId] = useState<number | null>(
         resource.skipToIdpId || null
@@ -472,7 +476,7 @@ export default function ResourceAuthenticationPage() {
                             <SwitchInput
                                 id="sso-toggle"
                                 label={t("ssoUse")}
-                                defaultChecked={resource.sso}
+                                checked={ssoEnabled}
                                 onCheckedChange={(val) => setSsoEnabled(val)}
                             />
 
@@ -800,8 +804,13 @@ function OneTimePasswordFormSection({
 }: OneTimePasswordFormSectionProps) {
     const { env } = useEnvContext();
     const [whitelistEnabled, setWhitelistEnabled] = useState(
-        resource.emailWhitelistEnabled
+        resource.emailWhitelistEnabled ?? false
     );
+
+    useEffect(() => {
+        setWhitelistEnabled(resource.emailWhitelistEnabled);
+    }, [resource.emailWhitelistEnabled]);
+
     const queryClient = useQueryClient();
 
     const [loadingSaveWhitelist, startTransition] = useTransition();
@@ -894,7 +903,7 @@ function OneTimePasswordFormSection({
                     <SwitchInput
                         id="whitelist-toggle"
                         label={t("otpEmailWhitelist")}
-                        defaultChecked={resource.emailWhitelistEnabled}
+                        checked={whitelistEnabled}
                         onCheckedChange={setWhitelistEnabled}
                         disabled={!env.email.emailEnabled}
                     />

--- a/src/app/[orgId]/settings/resources/proxy/[niceId]/rules/page.tsx
+++ b/src/app/[orgId]/settings/resources/proxy/[niceId]/rules/page.tsx
@@ -113,7 +113,12 @@ export default function ResourceRules(props: {
     const [rulesToRemove, setRulesToRemove] = useState<number[]>([]);
     const [loading, setLoading] = useState(false);
     const [pageLoading, setPageLoading] = useState(true);
-    const [rulesEnabled, setRulesEnabled] = useState(resource.applyRules);
+    const [rulesEnabled, setRulesEnabled] = useState(resource.applyRules ?? false);
+
+    useEffect(() => {
+        setRulesEnabled(resource.applyRules);
+    }, [resource.applyRules]);
+
     const [openCountrySelect, setOpenCountrySelect] = useState(false);
     const [countrySelectValue, setCountrySelectValue] = useState("");
     const [openAddRuleCountrySelect, setOpenAddRuleCountrySelect] =
@@ -836,7 +841,7 @@ export default function ResourceRules(props: {
                             <SwitchInput
                                 id="rules-toggle"
                                 label={t("rulesEnable")}
-                                defaultChecked={rulesEnabled}
+                                checked={rulesEnabled}
                                 onCheckedChange={(val) => setRulesEnabled(val)}
                             />
                         </div>


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description
Fixes a hydration bug where the **Enable Rules**, **SSO**, and **Email Whitelist** toggles on resource settings pages would always render in the OFF state on cold load, regardless of the actual saved value in the database.

Closes fosrl/pangolin#2528

## Root Cause

The `SwitchInput` components were using the `defaultChecked` prop (uncontrolled), which React only reads on the **first render**. Since the resource context hydrates asynchronously after mount, the first render always sees `undefined` or a stale value, so the toggles always appeared OFF.

Additionally, the state variables were initialized once via `useState(resource.X)` with no mechanism to re-sync when the context updated.

## Changes

### `src/app/[orgId]/settings/resources/proxy/[niceId]/rules/page.tsx`
- `useState(resource.applyRules ?? false)` — added `?? false` fallback
- Added `useEffect` to sync `rulesEnabled` when `resource.applyRules` updates
- Changed `defaultChecked={rulesEnabled}` → `checked={rulesEnabled}` (controlled)

### `src/app/[orgId]/settings/resources/proxy/[niceId]/authentication/page.tsx`
- `useState(resource.sso ?? false)` — added `?? false` fallback
- Added `useEffect` to sync `ssoEnabled` when `resource.sso` updates
- Changed `defaultChecked={resource.sso}` → `checked={ssoEnabled}` (controlled)
- `useState(resource.emailWhitelistEnabled ?? false)` — added `?? false` fallback
- Added `useEffect` to sync `whitelistEnabled` when `resource.emailWhitelistEnabled` updates
- Changed `defaultChecked={resource.emailWhitelistEnabled}` → `checked={whitelistEnabled}` (controlled)

## Before / After

**Before:** Toggle always renders OFF on hard refresh, even when DB value is `true`.  
**After:** Toggle correctly reflects the saved DB value immediately on load.

## Testing

- [ ] Hard refresh (`Ctrl+Shift+R`) on a resource with `applyRules = true` → Rules toggle shows ON
- [ ] Hard refresh on a resource with `emailWhitelistEnabled = true` → Whitelist toggle shows ON
- [ ] Hard refresh on a resource with `sso = true` → SSO toggle shows ON
- [ ] Toggling any switch and saving still works correctly
- [ ] No React controlled/uncontrolled warnings in console

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)