### PR TITLE
feat: Adding an organization sites bandwidth reset API

### DIFF
--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -1096,6 +1096,7 @@
     "setupTokenDescription": "Enter the setup token from the server console.",
     "setupTokenRequired": "Setup token is required",
     "actionUpdateSite": "Update Site",
+    "actionResetSiteBandwidth": "Reset Organization Bandwidth",
     "actionListSiteRoles": "List Allowed Site Roles",
     "actionCreateResource": "Create Resource",
     "actionDeleteResource": "Delete Resource",

--- a/server/auth/actions.ts
+++ b/server/auth/actions.ts
@@ -19,6 +19,7 @@ export enum ActionsEnum {
     getSite = "getSite",
     listSites = "listSites",
     updateSite = "updateSite",
+    resetSiteBandwidth = "resetSiteBandwidth",
     reGenerateSecret = "reGenerateSecret",
     createResource = "createResource",
     deleteResource = "deleteResource",

--- a/server/routers/integration.ts
+++ b/server/routers/integration.ts
@@ -134,6 +134,13 @@ authenticated.post(
     logActionAudit(ActionsEnum.updateSite),
     site.updateSite
 );
+authenticated.post(
+    "/org/:orgId/reset-bandwidth",
+    verifyApiKeyOrgAccess,
+    verifyApiKeyHasAction(ActionsEnum.resetSiteBandwidth),
+    logActionAudit(ActionsEnum.resetSiteBandwidth),
+    org.resetOrgBandwidth
+);
 
 authenticated.delete(
     "/site/:siteId",

--- a/server/routers/org/index.ts
+++ b/server/routers/org/index.ts
@@ -8,3 +8,4 @@ export * from "./getOrgOverview";
 export * from "./listOrgs";
 export * from "./pickOrgDefaults";
 export * from "./checkOrgUserAccess";
+export * from "./resetOrgBandwidth";

--- a/server/routers/org/resetOrgBandwidth.ts
+++ b/server/routers/org/resetOrgBandwidth.ts
@@ -1,0 +1,83 @@
+import { NextFunction, Request, Response } from "express";
+import { z } from "zod";
+import { db, sites } from "@server/db";
+import { eq } from "drizzle-orm";
+import response from "@server/lib/response";
+import HttpCode from "@server/types/HttpCode";
+import createHttpError from "http-errors";
+import logger from "@server/logger";
+import { fromError } from "zod-validation-error";
+import { OpenAPITags, registry } from "@server/openApi";
+
+const resetOrgBandwidthParamsSchema = z.strictObject({
+    orgId: z.string()
+});
+
+registry.registerPath({
+    method: "post",
+    path: "/org/{orgId}/reset-bandwidth",
+    description: "Reset all sites in selected organization bandwidth counters.",
+    tags: [OpenAPITags.Org, OpenAPITags.Site],
+    request: {
+        params: resetOrgBandwidthParamsSchema
+    },
+    responses: {}
+});
+
+export async function resetOrgBandwidth(
+    req: Request,
+    res: Response,
+    next: NextFunction
+): Promise<any> {
+    try {
+        const parsedParams = resetOrgBandwidthParamsSchema.safeParse(
+            req.params
+        );
+        if (!parsedParams.success) {
+            return next(
+                createHttpError(
+                    HttpCode.BAD_REQUEST,
+                    fromError(parsedParams.error).toString()
+                )
+            );
+        }
+
+        const { orgId } = parsedParams.data;
+
+        const [site] = await db
+            .select({ siteId: sites.siteId })
+            .from(sites)
+            .where(eq(sites.orgId, orgId))
+            .limit(1);
+
+        if (!site) {
+            return next(
+                createHttpError(
+                    HttpCode.NOT_FOUND,
+                    `No sites found in org ${orgId}`
+                )
+            );
+        }
+
+        await db
+            .update(sites)
+            .set({
+                megabytesIn: 0,
+                megabytesOut: 0
+            })
+            .where(eq(sites.orgId, orgId));
+
+        return response(res, {
+            data: {},
+            success: true,
+            error: false,
+            message: "Sites bandwidth reset successfully",
+            status: HttpCode.OK
+        });
+    } catch (error) {
+        logger.error(error);
+        return next(
+            createHttpError(HttpCode.INTERNAL_SERVER_ERROR, "An error occurred")
+        );
+    }
+}

--- a/src/components/PermissionsSelectBox.tsx
+++ b/src/components/PermissionsSelectBox.tsx
@@ -26,6 +26,7 @@ function getActionsCategories(root: boolean) {
             [t("actionGetOrg")]: "getOrg",
             [t("actionUpdateOrg")]: "updateOrg",
             [t("actionGetOrgUser")]: "getOrgUser",
+            [t("actionResetSiteBandwidth")]: "resetSiteBandwidth",
             [t("actionInviteUser")]: "inviteUser",
             [t("actionRemoveInvitation")]: "removeInvitation",
             [t("actionListInvitations")]: "listInvitations",


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description
This feature change adds an API to manually reset bandwidth for all sites in the selected organization so that the users can reset the bandwidth counter when needed.
It is useful for the user hosted on VPS to see the monthly bandwidth counter instead of seeing accumulated counter by resetting the counter monthly. 

The API call is `POST /org/{orgId}/reset-bandwidth`, OpenAPI and permission is added to the system.

