### PR TITLE
enhance(sidebar): make mobile org selector sticky

### DIFF
--- a/src/components/LayoutMobileMenu.tsx
+++ b/src/components/LayoutMobileMenu.tsx
@@ -69,15 +69,16 @@ export function LayoutMobileMenu({
                                     <SheetDescription className="sr-only">
                                         {t("navbarDescription")}
                                     </SheetDescription>
-                                    <div className="px-1 shrink-0">
-                                        <OrgSelector
-                                            orgId={orgId}
-                                            orgs={orgs}
-                                        />
+                                    <div className="w-full border-b border-border">
+                                        <div className="px-1 shrink-0">
+                                            <OrgSelector
+                                                orgId={orgId}
+                                                orgs={orgs}
+                                            />
+                                        </div>
                                     </div>
-                                    <div className="w-full border-b border-border" />
                                     <div className="flex-1 overflow-y-auto relative">
-                                        <div className="px-3 pt-3">
+                                        <div className="px-3">
                                             {!isAdminPage &&
                                                 user.serverAdmin && (
                                                     <div className="mb-1">


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description

Make org selector sticky on mobile sidebar

Move OrgSelector outside the scrollable container so it stays fixed at the top while menu items scroll, matching the desktop sidebar behavior introduced in 9b2c0d0b.

this may have been deliberately chosen to not sticky on mobile when the commit above was done, if so feel free to close.

## How to test?

When viewing the mobile dashboard, the organization selector will be sticky at the top so even if the user scrolls the menu they have easier access to moving organizations.
