### PR TITLE
fix(zod): Add openapi call after catch

### DIFF
--- a/server/routers/siteResource/listSiteResources.ts
+++ b/server/routers/siteResource/listSiteResources.ts
@@ -31,12 +31,23 @@ const listSiteResourcesQuerySchema = z.object({
     sort_by: z
         .enum(["name"])
         .optional()
-        .catch(undefined),
+        .catch(undefined)
+        .openapi({
+            type: "string",
+            enum: ["name"],
+            description: "Field to sort by"
+        }),
     order: z
         .enum(["asc", "desc"])
         .optional()
         .default("asc")
         .catch("asc")
+        .openapi({
+            type: "string",
+            enum: ["asc", "desc"],
+            default: "asc",
+            description: "Sort order"
+        })
 });
 
 export type ListSiteResourcesResponse = {


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description

fix: #2561
without making an explicit call to openapi a runtime error happens because it cannot infer a catch (UnknownZodTypeError), the call to openapi is the same across the codebase

## How to test?

Calls to the integration api should succeed
