### PR TITLE
feat(kubernetes): enable newtInstances by default and update installation instructions

### DIFF
--- a/src/components/newt-install-commands.tsx
+++ b/src/components/newt-install-commands.tsx
@@ -210,19 +210,21 @@ WantedBy=default.target`
 
                 <div className="pt-4">
                     <p className="font-bold mb-3">{t("commands")}</p>
-                    <p className="text-sm text-muted-foreground mb-3">
-                        For more and up to date Kubernetes installation
-                        information, see{" "}
-                        <a
-                            href="https://docs.pangolin.net/manage/sites/install-kubernetes"
-                            target="_blank"
-                            rel="noreferrer"
-                            className="underline"
-                        >
-                            docs.pangolin.net/manage/sites/install-kubernetes
-                        </a>
-                        .
-                    </p>
+                    {platform === "kubernetes" && (
+                        <p className="text-sm text-muted-foreground mb-3">
+                            For more and up to date Kubernetes installation
+                            information, see{" "}
+                            <a
+                                href="https://docs.pangolin.net/manage/sites/install-kubernetes"
+                                target="_blank"
+                                rel="noreferrer"
+                                className="underline"
+                            >
+                                docs.pangolin.net/manage/sites/install-kubernetes
+                            </a>
+                            .
+                        </p>
+                    )}
                     <div className="mt-2 space-y-3">
                         {commands.map((item, index) => {
                             const commandText =
@@ -232,8 +234,10 @@ WantedBy=default.target`
                                     ? undefined
                                     : item.title;
 
+                            const key = `${title ?? ""}::${commandText}`;
+
                             return (
-                                <div key={index}>
+                                <div key={key}>
                                     {title && (
                                         <p className="text-sm font-medium mb-1.5">
                                             {title}


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description (Copilot + Human)

This pull request makes minor improvements to the `NewtSiteInstallCommands` component, focusing on enhancing the Helm install command and improving the user interface with additional documentation and minor code formatting updates.

Key changes include:

**Helm Install Command Update:**
- Added `--set newtInstances[0].enabled=true` to the Helm install command to explicitly enable the main tunnel instance.

**UI and Documentation Improvements:**
- Added a helpful note with a link to the official documentation for up-to-date Kubernetes installation instructions.
- Minor code formatting improvements for readability in the site configuration section done by prettier automatically.
