### PR TITLE
fix: local targets ignored when newt site is unhealthy (mixed target failover)

### DIFF
--- a/server/lib/traefik/getTraefikConfig.ts
+++ b/server/lib/traefik/getTraefikConfig.ts
@@ -477,7 +477,10 @@ export async function getTraefikConfig(
 
                         // TODO: HOW TO HANDLE ^^^^^^ BETTER
                         const anySitesOnline = targets.some(
-                            (target) => target.site.online
+                            (target) =>
+                            target.site.online ||
+                            target.site.type === "local" ||
+                            target.site.type === "wireguard"
                         );
 
                         return (
@@ -491,10 +494,6 @@ export async function getTraefikConfig(
                                         return false;
                                     }
                                     
-                                    // Local sites don't report online status, always include them as fallback
-                                    if (target.site.type === "local") {
-                                        return true;
-                                    }
                                     // If any sites are online, exclude offline sites
                                     if (anySitesOnline && !target.site.online) {
                                         return false;
@@ -609,18 +608,16 @@ export async function getTraefikConfig(
                     servers: (() => {
                         // Check if any sites are online
                         const anySitesOnline = targets.some(
-                            (target) => target.site.online
+                            (target) =>
+                            target.site.online ||
+                            target.site.type === "local" ||
+                            target.site.type === "wireguard"
                         );
 
                         return targets
                             .filter((target) => {
                                 if (!target.enabled) {
                                     return false;
-                                }
-
-                                // Local sites don't report online status, always include them as fallback
-                                if (target.site.type === "local") {
-                                    return true;
                                 }
                                 
                                 // If any sites are online, exclude offline sites

--- a/server/private/lib/traefik/getTraefikConfig.ts
+++ b/server/private/lib/traefik/getTraefikConfig.ts
@@ -665,7 +665,10 @@ export async function getTraefikConfig(
 
                         // TODO: HOW TO HANDLE ^^^^^^ BETTER
                         const anySitesOnline = targets.some(
-                            (target) => target.site.online
+                            (target) =>
+                            target.site.online ||
+                            target.site.type === "local" ||
+                            target.site.type === "wireguard"
                         );
 
                         return (
@@ -678,11 +681,6 @@ export async function getTraefikConfig(
                                     if (target.health == "unhealthy") {
                                         return false;
                                     }
-
-                                    // Local sites don't report online status, always include them as fallback
-                                    if (target.site.type === "local") {
-                                        return true;
-                                    } 
 
                                     // If any sites are online, exclude offline sites
                                     if (anySitesOnline && !target.site.online) {
@@ -798,18 +796,16 @@ export async function getTraefikConfig(
                     servers: (() => {
                         // Check if any sites are online
                         const anySitesOnline = targets.some(
-                            (target) => target.site.online
+                            (target) =>
+                            target.site.online ||
+                            target.site.type === "local" ||
+                            target.site.type === "wireguard"
                         );
 
                         return targets
                             .filter((target) => {
                                 if (!target.enabled) {
                                     return false;
-                                }
-                                
-                                // Local sites don't report online status, always include them as fallback
-                                if (target.site.type === "local") {
-                                    return true;
                                 }
 
                                 // If any sites are online, exclude offline sites


### PR DESCRIPTION
## Community Contribution License Agreement

By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

Fixes #2448

## Problem
Local targets were ignored when Newt targets became unhealthy because 
local sites always have online=false and were excluded by the anySitesOnline check.

## Fix
Added early return for local site type in the target filter so they are 
always considered available as fallback servers.
