### PR TITLE
fix: exclude labels from container search to prevent false positives

### DIFF
--- a/src/components/ContainersSelector.tsx
+++ b/src/components/ContainersSelector.tsx
@@ -171,8 +171,7 @@ const DockerContainersTable: FC<{
                 ...Object.values(container.networks)
                     .map((n) => n.ipAddress)
                     .filter(Boolean),
-                ...getExposedPorts(container).map((p) => p.toString()),
-                ...Object.entries(container.labels).flat()
+                ...getExposedPorts(container).map((p) => p.toString())
             ];
 
             return searchableFields.some((field) =>


### PR DESCRIPTION
## Community Contribution License Agreement

By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

Fixes #2228

## Problem
Container search was including Docker labels in searchable fields. This caused false positives when using Docker Compose, since all containers in a stack share the same compose file path in their labels.

## Fix
Removed labels from the search fields. Labels are already accessible via their own dedicated column and popover, so excluding them from search gives more accurate results.