### PR TITLE
fix: blueprint overwrites sso-users and sso-roles when empty arrays provided

### DIFF
--- a/server/lib/blueprints/proxyResources.ts
+++ b/server/lib/blueprints/proxyResources.ts
@@ -349,7 +349,7 @@ export async function updateProxyResources(
                     }
                 }
 
-                if (resourceData.auth?.["sso-roles"]) {
+                if (resourceData.auth?.["sso-roles"] && resourceData.auth["sso-roles"].length > 0) {
                     const ssoRoles = resourceData.auth?.["sso-roles"];
                     await syncRoleResources(
                         existingResource.resourceId,
@@ -359,7 +359,7 @@ export async function updateProxyResources(
                     );
                 }
 
-                if (resourceData.auth?.["sso-users"]) {
+                if (resourceData.auth?.["sso-users"] && resourceData.auth["sso-users"].length > 0) {
                     const ssoUsers = resourceData.auth?.["sso-users"];
                     await syncUserResources(
                         existingResource.resourceId,
@@ -767,7 +767,7 @@ export async function updateProxyResources(
                 resourceId: newResource.resourceId
             });
 
-            if (resourceData.auth?.["sso-roles"]) {
+            if (resourceData.auth?.["sso-roles"] && resourceData.auth["sso-roles"].length > 0) {
                 const ssoRoles = resourceData.auth?.["sso-roles"];
                 await syncRoleResources(
                     newResource.resourceId,
@@ -777,7 +777,7 @@ export async function updateProxyResources(
                 );
             }
 
-            if (resourceData.auth?.["sso-users"]) {
+            if (resourceData.auth?.["sso-users"] && resourceData.auth["sso-users"].length > 0) {
                 const ssoUsers = resourceData.auth?.["sso-users"];
                 await syncUserResources(
                     newResource.resourceId,


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

Fixes #2197

## Problem
When a blueprint defines `sso-enabled` and `auto-login-idp` but omits `sso-users` and `sso-roles`, the sync functions were being called with empty arrays, causing all existing users and roles to be cleared on every redeploy.

## Fix
Added `.length > 0` check before calling `syncRoleResources` and `syncUserResources`, consistent with how `whitelist-users` was already handled.
