### PR TITLE
fix: use web api to extract path from URL properly

### DIFF
--- a/server/routers/badger/verifySession.ts
+++ b/server/routers/badger/verifySession.ts
@@ -96,14 +96,15 @@ export async function verifyResourceSession(
     try {
         const {
             sessions,
-            host,
             originalRequestURL,
             requestIp,
-            path,
             headers,
             query,
             badgerVersion
         } = parsedBody.data;
+
+
+        const {pathname: path, host} = new URL(originalRequestURL);
 
         // Extract HTTP Basic Auth credentials if present
         const clientHeaderAuth = extractBasicAuth(headers);


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description

Fix PATH based resource rules failing to match when the request contains a query string.

Badger sends the path field with the full URI including query parameters (e.g. `/stream.html?token=111`). The `isPathAllowed` function performs segment-based matching, so `/stream.html?token=111` never matches a rule configured as `/stream.html`, causing `Bypass Auth` rules to silently fail for unauthenticated users.

Instead of relying on the path and host fields sent by Badger, both are now derived from `originalRequestURL` using the native `URL API`, which guarantees a clean `pathname` (no query string or fragment) and a consistent host.

## How to test?

1. Create a resource with `Authentication` = Protected and Rules enabled
2. Add a rule: Bypass Auth → Path → `/stream.html`
3. Send a request to the internal verify-session endpoint with path: `/stream.html?token=111` and `originalRequestURL`: `https://<resource-domain>/stream.html?token=111` and empty sessions
4. Confirm the response is `valid: true`
5. Send the same request with path: `/config.html` and confirm `valid: false`