### PR TITLE
Add kustomize manifests for Kubernetes deployment

### DIFF
--- a/kustomize/README.md
+++ b/kustomize/README.md
@@ -1,0 +1,294 @@
+# Kubernetes Deployment with Kustomize
+
+This directory contains Kubernetes manifests for deploying Pangolin using kustomize.
+
+## Architecture
+
+The deployment consists of:
+
+1. **Pangolin Server** - Main application server
+   - Image: `fosrl/pangolin:latest`
+   - Port: 3001 (API)
+   - Requires config volume for configuration and database
+
+2. **Gerbil + Traefik (Sidecar)** - VPN tunnel and reverse proxy
+   - Gerbil Image: `fosrl/gerbil:latest`
+   - Traefik Image: `traefik:v3.6`
+   - Runs as a single pod with both containers (sidecar pattern)
+   - Gerbil requires NET_ADMIN and SYS_MODULE capabilities
+   - Traefik handles HTTP/HTTPS routing (ports 80, 443)
+   - Gerbil handles WireGuard VPN (ports 51820, 21820 UDP)
+
+## Prerequisites
+
+- Kubernetes cluster (1.24+)
+- `kubectl` configured to access your cluster
+- Persistent volume provisioner (for config storage)
+- LoadBalancer support (for external access) or NodePort/Ingress
+
+## Quick Start
+
+1. **Prepare Configuration**
+
+   Before deploying, you need to create a configuration file. Copy the example config:
+
+   ```bash
+   kubectl create namespace pangolin --dry-run=client -o yaml | kubectl apply -f -
+   ```
+
+   Create a config.yml based on `config/config.example.yml` and create a ConfigMap or mount it via PVC.
+
+2. **Deploy with Kustomize**
+
+   ```bash
+   kubectl apply -k kustomize/base
+   ```
+
+3. **Verify Deployment**
+
+   ```bash
+   kubectl get all -n pangolin
+   kubectl logs -n pangolin -l app.kubernetes.io/name=pangolin
+   ```
+
+## Configuration
+
+### Persistent Storage
+
+The deployment uses a single PVC (`pangolin-config-pvc`) that stores:
+- Pangolin configuration (`/app/config`)
+- Gerbil keys (`/var/config`)
+- Traefik configuration (`/etc/traefik`)
+- Let's Encrypt certificates (`/letsencrypt`)
+
+By default, it requests 1GB of storage. Adjust as needed in your kustomize overlay.
+
+### Traefik Configuration
+
+You'll need to create a Traefik configuration file. Example structure:
+
+```
+config/
+├── config.yml         # Pangolin configuration
+├── traefik/
+│   ├── traefik_config.yml
+│   └── ... (other traefik configs)
+├── db/               # Database files (if using SQLite)
+└── letsencrypt/      # Let's Encrypt certificates
+```
+
+### Environment Variables
+
+You can customize the deployment by creating overlays. Create a `kustomization.yaml` in `overlays/production/`:
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../base
+
+namespace: pangolin-production
+
+images:
+- name: fosrl/pangolin
+  newTag: v1.0.0
+- name: fosrl/gerbil
+  newTag: v1.0.0
+
+configMapGenerator:
+- name: pangolin-config
+  files:
+  - config.yml=path/to/your/config.yml
+
+patchesStrategicMerge:
+- patches/pvc-size.yaml
+```
+
+## Accessing the Service
+
+The deployment exposes:
+- **LoadBalancer Service** (gerbil): External access for HTTP/HTTPS and WireGuard
+  - Port 80: HTTP
+  - Port 443: HTTPS
+  - Port 51820: WireGuard UDP
+  - Port 21820: WireGuard UDP (alternative)
+
+- **ClusterIP Service** (pangolin): Internal API access
+  - Port 3001: API endpoint
+
+### Option 1: LoadBalancer (Default)
+
+If your cluster supports LoadBalancer services (e.g., cloud provider, MetalLB):
+
+```bash
+kubectl get svc gerbil -n pangolin
+```
+
+Use the external IP to access Pangolin.
+
+### Option 2: NodePort
+
+Create an overlay to change the service type:
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: gerbil
+  namespace: pangolin
+spec:
+  type: NodePort
+```
+
+### Option 3: Ingress
+
+Create an Ingress resource to expose the service through an Ingress Controller:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: pangolin
+  namespace: pangolin
+spec:
+  ingressClassName: nginx  # or your ingress class
+  rules:
+  - host: pangolin.yourdomain.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: gerbil
+            port:
+              number: 80
+```
+
+## Resource Requirements
+
+Default resource requests and limits:
+
+| Container | CPU Request | CPU Limit | Memory Request | Memory Limit |
+|-----------|-------------|-----------|----------------|--------------|
+| Pangolin  | 100m        | 1000m     | 256Mi          | 1Gi          |
+| Gerbil    | 100m        | 500m      | 128Mi          | 512Mi        |
+| Traefik   | 100m        | 500m      | 128Mi          | 512Mi        |
+
+Adjust these in your production overlay based on your needs.
+
+## Security Considerations
+
+1. **Capabilities**: Gerbil requires `NET_ADMIN` and `SYS_MODULE` capabilities for WireGuard tunneling
+2. **RBAC**: Consider implementing proper RBAC rules for production
+3. **Network Policies**: Restrict network access as needed
+4. **TLS/SSL**: Traefik handles TLS termination. Configure certificates appropriately
+5. **Secrets**: Store sensitive data (database passwords, API keys) in Kubernetes Secrets
+
+## Production Recommendations
+
+For production deployments:
+
+1. **Separate Configurations**: Use separate PVCs for different components instead of one shared PVC
+2. **Database**: Use an external managed database (PostgreSQL) instead of SQLite
+3. **High Availability**: Run multiple replicas with proper affinity/anti-affinity rules
+4. **Monitoring**: Add Prometheus ServiceMonitor and appropriate metrics
+5. **Backup**: Implement backup strategies for your PVCs and configuration
+6. **GitOps**: Use GitOps tools (ArgoCD, Flux) for deployment management
+
+## Troubleshooting
+
+### Check Pod Status
+
+```bash
+kubectl get pods -n pangolin
+kubectl describe pod <pod-name> -n pangolin
+```
+
+### View Logs
+
+```bash
+# Pangolin logs
+kubectl logs -n pangolin -l app.kubernetes.io/component=server -c pangolin
+
+# Gerbil logs
+kubectl logs -n pangolin -l app.kubernetes.io/component=tunnel -c gerbil
+
+# Traefik logs
+kubectl logs -n pangolin -l app.kubernetes.io/component=tunnel -c traefik
+```
+
+### Common Issues
+
+1. **PVC not binding**: Check your storage class and PVC configuration
+2. **Gerbil container failing**: Ensure NET_ADMIN capability is available in your cluster
+3. **Traefik not routing**: Verify Traefik configuration and certificate setup
+4. **Pangolin not starting**: Check database connection and configuration file
+
+## Customization Examples
+
+### Change Image Tags
+
+Create `overlays/production/kustomization.yaml`:
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../base
+
+images:
+- name: fosrl/pangolin
+  newTag: v1.2.3
+- name: fosrl/gerbil
+  newTag: v1.2.3
+```
+
+### Adjust PVC Size
+
+Create `overlays/production/patches/pvc.yaml`:
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pangolin-config-pvc
+  namespace: pangolin
+spec:
+  resources:
+    requests:
+      storage: 5Gi
+```
+
+### Add Node Selector
+
+Create `overlays/production/patches/node-selector.yaml`:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pangolin
+  namespace: pangolin
+spec:
+  template:
+    spec:
+      nodeSelector:
+        kubernetes.io/role: worker
+```
+
+## Further Reading
+
+- [Pangolin Documentation](https://docs.pangolin.net)
+- [Kustomize Documentation](https://kubectl.docs.kubernetes.io/guides/introduction/kustomize/)
+- [Traefik Documentation](https://doc.traefik.io/traefik/)
+
+## Contributing
+
+Please see the main [CONTRIBUTING.md](../../CONTRIBUTING.md) for contribution guidelines.
+
+## License
+
+This project is dual licensed under AGPL-3 and the Fossorial Commercial License. See [LICENSE](../../LICENSE) for details.

--- a/kustomize/base/gerbil-deployment.yaml
+++ b/kustomize/base/gerbil-deployment.yaml
@@ -1,0 +1,118 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gerbil
+  namespace: pangolin
+  labels:
+    app.kubernetes.io/name: pangolin
+    app.kubernetes.io/component: tunnel
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: pangolin
+      app.kubernetes.io/component: tunnel
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: pangolin
+        app.kubernetes.io/component: tunnel
+    spec:
+      containers:
+      - name: gerbil
+        image: fosrl/gerbil:latest
+        imagePullPolicy: Always
+        args:
+        - --reachableAt=http://localhost:3004
+        - --generateAndSaveKeyTo=/var/config/key
+        - --remoteConfig=http://pangolin:3001/api/v1/
+        ports:
+        - name: wireguard
+          containerPort: 51820
+          protocol: UDP
+        - name: wireguard-alt
+          containerPort: 21820
+          protocol: UDP
+        volumeMounts:
+        - name: config
+          mountPath: /var/config
+          readOnly: false
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+            - SYS_MODULE
+        resources:
+          requests:
+            memory: "128Mi"
+            cpu: "100m"
+          limits:
+            memory: "512Mi"
+            cpu: "500m"
+      - name: traefik
+        image: traefik:v3.6
+        imagePullPolicy: IfNotPresent
+        args:
+        - --configFile=/etc/traefik/traefik_config.yml
+        ports:
+        - name: http
+          containerPort: 80
+          protocol: TCP
+        - name: https
+          containerPort: 443
+          protocol: TCP
+        volumeMounts:
+        - name: traefik-config
+          mountPath: /etc/traefik
+          readOnly: true
+        - name: letsencrypt
+          mountPath: /letsencrypt
+          readOnly: false
+        resources:
+          requests:
+            memory: "128Mi"
+            cpu: "100m"
+          limits:
+            memory: "512Mi"
+            cpu: "500m"
+      volumes:
+      - name: config
+        persistentVolumeClaim:
+          claimName: pangolin-config-pvc
+      - name: traefik-config
+        persistentVolumeClaim:
+          claimName: pangolin-config-pvc
+      - name: letsencrypt
+        persistentVolumeClaim:
+          claimName: pangolin-config-pvc
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: gerbil
+  namespace: pangolin
+  labels:
+    app.kubernetes.io/name: pangolin
+    app.kubernetes.io/component: tunnel
+spec:
+  type: LoadBalancer
+  ports:
+  - name: wireguard
+    port: 51820
+    targetPort: wireguard
+    protocol: UDP
+  - name: wireguard-alt
+    port: 21820
+    targetPort: wireguard-alt
+    protocol: UDP
+  - name: http
+    port: 80
+    targetPort: 80
+    protocol: TCP
+  - name: https
+    port: 443
+    targetPort: 443
+    protocol: TCP
+  selector:
+    app.kubernetes.io/name: pangolin
+    app.kubernetes.io/component: tunnel

--- a/kustomize/base/kustomization.yaml
+++ b/kustomize/base/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- namespace.yaml
+- pangolin-deployment.yaml
+- gerbil-deployment.yaml
+
+commonLabels:
+  app.kubernetes.io/managed-by: kustomize
+  app.kubernetes.io/part-of: pangolin

--- a/kustomize/base/namespace.yaml
+++ b/kustomize/base/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: pangolin
+  labels:
+    app.kubernetes.io/name: pangolin
+    app.kubernetes.io/component: namespace

--- a/kustomize/base/pangolin-deployment.yaml
+++ b/kustomize/base/pangolin-deployment.yaml
@@ -1,0 +1,96 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pangolin
+  namespace: pangolin
+  labels:
+    app.kubernetes.io/name: pangolin
+    app.kubernetes.io/component: server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: pangolin
+      app.kubernetes.io/component: server
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: pangolin
+        app.kubernetes.io/component: server
+    spec:
+      containers:
+      - name: pangolin
+        image: fosrl/pangolin:latest
+        imagePullPolicy: Always
+        ports:
+        - name: api
+          containerPort: 3001
+          protocol: TCP
+        env:
+        - name: NODE_ENV
+          value: "production"
+        volumeMounts:
+        - name: config
+          mountPath: /app/config
+          readOnly: false
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "100m"
+          limits:
+            memory: "1Gi"
+            cpu: "1000m"
+        livenessProbe:
+          httpGet:
+            path: /api/v1/
+            port: api
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 3
+          failureThreshold: 15
+        readinessProbe:
+          httpGet:
+            path: /api/v1/
+            port: api
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          timeoutSeconds: 3
+          failureThreshold: 3
+      volumes:
+      - name: config
+        persistentVolumeClaim:
+          claimName: pangolin-config-pvc
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pangolin
+  namespace: pangolin
+  labels:
+    app.kubernetes.io/name: pangolin
+    app.kubernetes.io/component: server
+spec:
+  type: ClusterIP
+  ports:
+  - name: api
+    port: 3001
+    targetPort: api
+    protocol: TCP
+  selector:
+    app.kubernetes.io/name: pangolin
+    app.kubernetes.io/component: server
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pangolin-config-pvc
+  namespace: pangolin
+  labels:
+    app.kubernetes.io/name: pangolin
+    app.kubernetes.io/component: storage
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi


### PR DESCRIPTION
Fixes #921

## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description

This PR adds Kubernetes deployment manifests using kustomize, enabling users to deploy Pangolin on Kubernetes clusters. This addresses the community request for Kubernetes support as discussed in #921.

The implementation includes:
- **Pangolin server deployment** with health checks and resource limits
- **Gerbil + Traefik deployment** using a sidecar pattern (matching the docker-compose architecture where traefik shares gerbil's network namespace)
- **Persistent storage** for configuration and data
- **LoadBalancer service** for external access (WireGuard ports + HTTP/HTTPS)
- **Comprehensive documentation** with deployment guides and troubleshooting tips

### Architecture

The deployment follows the docker-compose structure:
1. **Pangolin** - Main application server (port 3001)
2. **Gerbil + Traefik** - Combined pod with sidecar pattern:
   - Gerbil: WireGuard VPN tunnel (ports 51820, 21820 UDP)
   - Traefik: Reverse proxy (ports 80, 443 TCP)
   - Shares network namespace like in docker-compose

### Key Features
- Uses official images: `fosrl/pangolin:latest`, `fosrl/gerbil:latest`, `traefik:v3.6`
- Proper capability management (NET_ADMIN, SYS_MODULE for Gerbil)
- Health checks and readiness probes
- Configurable resource limits
- Single PVC for all config data (can be separated for production)
- Kustomize-ready structure with base layer

## How to test?

### Prerequisites
- Kubernetes cluster (1.24+)
- kubectl configured
- Persistent volume provisioner
- LoadBalancer support (or use NodePort/Ingress)

### Quick Test

1. **Create namespace and deploy**:
   ```bash
   kubectl apply -k kustomize/base
   ```

2. **Verify deployment**:
   ```bash
   kubectl get all -n pangolin
   kubectl logs -n pangolin -l app.kubernetes.io/name=pangolin
   ```

3. **Check pod status**:
   ```bash
   kubectl get pods -n pangolin
   ```

   Expected output:
   ```
   NAME                       READY   STATUS    RESTARTS   AGE
   pangolin-xxx-xxx          1/1     Running   0          1m
   gerbil-xxx-xxx            2/2     Running   0          1m
   ```

4. **Verify services**:
   ```bash
   kubectl get svc -n pangolin
   ```

   Expected services:
   - `pangolin` (ClusterIP on port 3001)
   - `gerbil` (LoadBalancer with ports 80, 443, 51820, 21820)

### Configuration Testing

Before production use, you'll need to:
1. Create a config.yml based on `config/config.example.yml`
2. Set up Traefik configuration in `config/traefik/`
3. Configure database (SQLite or external PostgreSQL)

See `kustomize/README.md` for detailed configuration instructions.

### Validation

All YAML files have been validated for syntax:
```bash
# Validate YAML syntax
python3 -c "import yaml; list(yaml.safe_load_all(open('kustomize/base/pangolin-deployment.yaml')))"

# List resources
find kustomize -type f
```

## Files Changed

```
kustomize/README.md                     | 294 ++++++++++++++++++++++++++++++++
kustomize/base/gerbil-deployment.yaml   | 118 +++++++++++++
kustomize/base/kustomization.yaml       |  11 ++
kustomize/base/namespace.yaml           |   7 +
kustomize/base/pangolin-deployment.yaml |  96 +++++++++++
5 files changed, 526 insertions(+)
```

## Production Considerations

This is an initial implementation suitable for testing and development. For production:
- Use separate PVCs for different components
- Configure external PostgreSQL database
- Implement proper RBAC and network policies
- Add monitoring with Prometheus ServiceMonitor
- Use GitOps tools (ArgoCD, Flux) for deployment

See the comprehensive README in `kustomize/README.md` for production best practices.