### PR TITLE
  fix(newt): missing hcStatus in hc config on reconnect

### DIFF
--- a/server/routers/newt/buildConfiguration.ts
+++ b/server/routers/newt/buildConfiguration.ts
@@ -188,7 +188,8 @@ export async function buildTargetConfigurationForNewtClient(siteId: number) {
             hcTimeout: targetHealthCheck.hcTimeout,
             hcHeaders: targetHealthCheck.hcHeaders,
             hcMethod: targetHealthCheck.hcMethod,
-            hcTlsServerName: targetHealthCheck.hcTlsServerName
+            hcTlsServerName: targetHealthCheck.hcTlsServerName,
+            hcStatus: targetHealthCheck.hcStatus
         })
         .from(targets)
         .innerJoin(resources, eq(targets.resourceId, resources.resourceId))
@@ -261,7 +262,8 @@ export async function buildTargetConfigurationForNewtClient(siteId: number) {
             hcTimeout: target.hcTimeout, // in seconds
             hcHeaders: hcHeadersSend,
             hcMethod: target.hcMethod,
-            hcTlsServerName: target.hcTlsServerName
+            hcTlsServerName: target.hcTlsServerName,
+            hcStatus: target.hcStatus
         };
     });
 


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description

  The buildTargetConfigurationForNewtClient function was not including the
  hcStatus field when building health check targets for the newt/wg/connect
  message. This caused custom expected response codes (e.g., 409) to revert
  to the default 2xx range check after Pangolin server restart.

 Added hcStatus to both the database select query and the returned health
 check target object, matching the behavior in targets.ts addTargets.

fixes: https://github.com/fosrl/newt/issues/240

## How to test?

Follow the steps defined in https://github.com/fosrl/newt/issues/240, after this change the expected code should function correctly.