### PR TITLE
Skip invalid Docker resources instead of failing entire blueprint (#1784)

### DIFF
--- a/server/lib/blueprints/applyNewtDockerBlueprint.ts
+++ b/server/lib/blueprints/applyNewtDockerBlueprint.ts
@@ -1,9 +1,55 @@
 import { sendToClient } from "#dynamic/routers/ws";
 import { processContainerLabels } from "./parseDockerContainers";
 import { applyBlueprint } from "./applyBlueprint";
+import { ResourceSchema, ClientResourceSchema } from "./types";
 import { db, sites } from "@server/db";
 import { eq } from "drizzle-orm";
 import logger from "@server/logger";
+
+type BlueprintResult = ReturnType<typeof processContainerLabels>;
+
+function filterInvalidResources(blueprint: BlueprintResult): {
+    skippedCount: number;
+    skippedKeys: string[];
+} {
+    const skippedKeys: string[] = [];
+
+    for (const section of ["proxy-resources", "public-resources"] as const) {
+        const resources = blueprint[section];
+        for (const [key, value] of Object.entries(resources)) {
+            const result = ResourceSchema.safeParse(value);
+            if (!result.success) {
+                const errors = result.error.issues
+                    .map((i) => `${i.path.join(".")}: ${i.message}`)
+                    .join("; ");
+                logger.warn(
+                    `Skipping invalid Docker ${section} "${key}": ${errors}`
+                );
+                delete resources[key];
+                skippedKeys.push(`${section}.${key}`);
+            }
+        }
+    }
+
+    for (const section of ["client-resources", "private-resources"] as const) {
+        const resources = blueprint[section];
+        for (const [key, value] of Object.entries(resources)) {
+            const result = ClientResourceSchema.safeParse(value);
+            if (!result.success) {
+                const errors = result.error.issues
+                    .map((i) => `${i.path.join(".")}: ${i.message}`)
+                    .join("; ");
+                logger.warn(
+                    `Skipping invalid Docker ${section} "${key}": ${errors}`
+                );
+                delete resources[key];
+                skippedKeys.push(`${section}.${key}`);
+            }
+        }
+    }
+
+    return { skippedCount: skippedKeys.length, skippedKeys };
+}
 
 export async function applyNewtDockerBlueprint(
     siteId: number,
@@ -21,17 +67,24 @@ export async function applyNewtDockerBlueprint(
         return;
     }
 
-    // logger.debug(`Applying Docker blueprint to site: ${siteId}`);
-    // logger.debug(`Containers: ${JSON.stringify(containers, null, 2)}`);
+    let skippedCount = 0;
+    let skippedKeys: string[] = [];
 
     try {
         const blueprint = processContainerLabels(containers);
 
-        logger.debug(`Received Docker blueprint: ${JSON.stringify(blueprint)}`);
+        logger.debug(
+            `Received Docker blueprint with ${Object.keys(blueprint["proxy-resources"]).length} proxy, ${Object.keys(blueprint["client-resources"]).length} client resource(s)`
+        );
 
-        // make sure this is not an empty object
-        if (isEmptyObject(blueprint)) {
-            return;
+        const filterResult = filterInvalidResources(blueprint);
+        skippedCount = filterResult.skippedCount;
+        skippedKeys = filterResult.skippedKeys;
+
+        if (skippedCount > 0) {
+            logger.warn(
+                `Filtered ${skippedCount} invalid resource(s) from Docker blueprint: ${skippedKeys.join(", ")}`
+            );
         }
 
         if (
@@ -40,6 +93,15 @@ export async function applyNewtDockerBlueprint(
             isEmptyObject(blueprint["public-resources"]) &&
             isEmptyObject(blueprint["private-resources"])
         ) {
+            if (skippedCount > 0) {
+                await sendToClient(newtId, {
+                    type: "newt/blueprint/results",
+                    data: {
+                        success: false,
+                        message: `All resources were invalid and skipped: ${skippedKeys.join(", ")}`
+                    }
+                });
+            }
             return;
         }
 
@@ -66,7 +128,10 @@ export async function applyNewtDockerBlueprint(
         type: "newt/blueprint/results",
         data: {
             success: true,
-            message: "Config updated successfully"
+            message:
+                skippedCount > 0
+                    ? `Config updated successfully. Skipped ${skippedCount} invalid resource(s): ${skippedKeys.join(", ")}`
+                    : "Config updated successfully"
         }
     });
 }


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description

Fixes #1784

If one Docker container had bad labels (like missing a port on a container with no EXPOSE), it would block every other container from updating too. Not great.

Now there's a per-resource pre-validation step in `applyNewtDockerBlueprint.ts` that catches invalid resources and filters them out before they hit `applyBlueprint()`. Valid ones still go through the normal `ConfigSchema` validation, so cross-resource checks like domain/port/alias uniqueness work the same as before. Invalid ones just get logged with the Zod error path and skipped.

Only touched `server/lib/blueprints/applyNewtDockerBlueprint.ts`. Everything else (`applyBlueprint.ts`, `types.ts`, `parseDockerContainers.ts`) is unchanged.

## How to test?

1. Set up two Docker services with Pangolin labels on the same Docker socket
2. Remove the `port` label from one service that has no `EXPOSE` directive
3. Update a label on the other (valid) service
4. **Before fix:** Both services fail to update. Log shows `Validation error: Required at "proxy-resources.testservice.targets[0].port"`
5. **After fix:** Valid service updates normally. Invalid service gets skipped with a warning: `Skipping invalid Docker proxy-resources "testservice": targets.0.port: Required`Required`