### PR TITLE
fix: Credenza dialog max-height overflow hiding footer buttons #2572

### DIFF
--- a/src/components/Credenza.tsx
+++ b/src/components/Credenza.tsx
@@ -84,7 +84,7 @@ const CredenzaContent = ({ className, children, ...props }: CredenzaProps) => {
     return (
         <CredenzaContent
             className={cn(
-                "overflow-y-auto max-h-[100dvh] md:max-h-screen md:top-[clamp(1.5rem,12vh,200px)] md:translate-y-0",
+                "overflow-y-auto max-h-[100dvh] md:max-h-[calc(100vh-clamp(3rem,24vh,400px))] md:top-[clamp(1.5rem,12vh,200px)] md:translate-y-0",
                 className
             )}
             {...props}


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description

Fixes #2572

The `CredenzaContent` component on desktop used `max-h-screen` (100vh) but was positioned with `top: clamp(1.5rem, 12vh, 200px)`. This caused the dialog to extend up to 200px below the viewport, hiding the footer and its "Done" button behind the OS taskbar.

Changed `md:max-h-screen` to `md:max-h-[calc(100vh-clamp(3rem,24vh,400px))]` so the max-height subtracts the top offset (doubled to reserve equal space at top and bottom), keeping the dialog fully within the viewport.

## How to test?

1. Open any resource and navigate to **Proxy** tab
2. Click the healthcheck icon on a target to open the HealthCheck dialog
3. Toggle healthcheck **Enabled** to expand all form fields
4. Verify the **"Done" button** is visible at 100% zoom without needing to scroll the page
5. Zoom in/out — the dialog should stay within the viewport and scroll internally