### PR TITLE
fix: Display actual values for WireGuard site credentials

### DIFF
--- a/src/app/[orgId]/settings/sites/[niceId]/credentials/page.tsx
+++ b/src/app/[orgId]/settings/sites/[niceId]/credentials/page.tsx
@@ -39,6 +39,7 @@ import { PaidFeaturesAlert } from "@app/components/PaidFeaturesAlert";
 import { NewtSiteInstallCommands } from "@app/components/newt-install-commands";
 import { usePaidStatus } from "@app/hooks/usePaidStatus";
 import { tierMatrix } from "@server/lib/billing/tierMatrix";
+import type { AxiosResponse } from "axios";
 
 export default function CredentialsPage() {
     const { env } = useEnvContext();
@@ -100,7 +101,9 @@ export default function CredentialsPage() {
                 generatedPublicKey = generatedKeypair.publicKey;
                 setPublicKey(generatedPublicKey);
 
-                const res = await api.get(`/org/${orgId}/pick-site-defaults`);
+                const res = await api.get<
+                    AxiosResponse<PickSiteDefaultsResponse>
+                >(`/org/${orgId}/pick-site-defaults`);
                 if (res && res.status === 200) {
                     const data = res.data.data;
                     setSiteDefaults(data);
@@ -108,7 +111,7 @@ export default function CredentialsPage() {
                     // generate config with the fetched data
                     generatedWgConfig = generateWireGuardConfig(
                         generatedKeypair.privateKey,
-                        data.publicKey,
+                        generatedKeypair.publicKey,
                         data.subnet,
                         data.address,
                         data.endpoint,
@@ -322,7 +325,7 @@ export default function CredentialsPage() {
                             {!loadingDefaults && (
                                 <>
                                     {wgConfig ? (
-                                        <div className="flex flex-col sm:flex-row items-center gap-4">
+                                        <div className="flex flex-col lg:flex-row items-center gap-4">
                                             <CopyTextBox
                                                 text={wgConfig}
                                                 outline={true}
@@ -342,25 +345,20 @@ export default function CredentialsPage() {
                                             text={generateObfuscatedWireGuardConfig(
                                                 {
                                                     subnet:
-                                                        siteDefaults?.subnet ||
                                                         site?.subnet ||
+                                                        siteDefaults?.subnet ||
                                                         null,
                                                     address:
-                                                        siteDefaults?.address ||
                                                         site?.address ||
+                                                        siteDefaults?.address ||
                                                         null,
                                                     endpoint:
-                                                        siteDefaults?.endpoint ||
                                                         site?.endpoint ||
+                                                        siteDefaults?.endpoint ||
                                                         null,
                                                     listenPort:
-                                                        siteDefaults?.listenPort ||
                                                         site?.listenPort ||
-                                                        null,
-                                                    publicKey:
-                                                        siteDefaults?.publicKey ||
-                                                        site?.publicKey ||
-                                                        site?.pubKey ||
+                                                        siteDefaults?.listenPort ||
                                                         null
                                                 }
                                             )}

--- a/src/lib/wireguard.ts
+++ b/src/lib/wireguard.ts
@@ -26,7 +26,6 @@ export function generateObfuscatedWireGuardConfig(options?: {
     address?: string | null;
     endpoint?: string | null;
     listenPort?: number | string | null;
-    publicKey?: string | null;
 }): string {
     const obfuscate = (
         value: string | null | undefined,
@@ -54,7 +53,6 @@ export function generateObfuscatedWireGuardConfig(options?: {
             ? options.listenPort
             : options.listenPort
         : 51820;
-    const publicKey = obfuscateKey(options?.publicKey);
 
     return `[Interface]
 Address = ${subnetWithCidr}
@@ -62,7 +60,7 @@ ListenPort = 51820
 PrivateKey = ${obfuscateKey(null)}
 
 [Peer]
-PublicKey = ${publicKey}
+PublicKey = ${obfuscateKey(null)}
 AllowedIPs = ${address}/32
 Endpoint = ${endpoint}:${listenPort}
 PersistentKeepalive = 5`;


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Summary

**Changes**:
- Show the actual values from the DB in wireguard site credentials
- Also made it so that the public key in wireguard site credentials is obfuscated 
- Bug fix: When regenerating credentials for sites using wireguard, the public key shown always `abc123` instead the actual generated public key

fixes #2341  

## Screenshots

| Name                    | Screenshots |
| :----------------: | :-----------: |
| Obfuscated wireguard credentials | <img width="1475" height="1061" alt="Screenshot 2026-03-12 at 23 40 09" src="https://github.com/user-attachments/assets/96e78e1c-205b-40b4-b66b-e30e56e2e1f8" /> |
| Obfuscated wireguard credentials (in DB) | <img width="1475" height="1061" alt="Screenshot 2026-03-12 at 23 40 29" src="https://github.com/user-attachments/assets/d468a595-817c-4c54-bf13-93692325f3f5" /> |
| Regenerated public key before  |  <img width="1028" height="524" alt="Screenshot 2026-03-12 at 23 46 30" src="https://github.com/user-attachments/assets/cdbe8691-44de-4124-89a7-b23b2cfeec3a" /> |
| Regenerated public key after | <img width="1035" height="575" alt="Screenshot 2026-03-12 at 23 46 51" src="https://github.com/user-attachments/assets/6f351de7-9085-4984-9e10-027791dd9d57" /> |

