### PR TITLE
feat(resources): add resource groups for organizing proxy resources

### DIFF
--- a/server/db/pg/schema/schema.ts
+++ b/server/db/pg/schema/schema.ts
@@ -96,6 +96,15 @@ export const sites = pgTable("sites", {
     dockerSocketEnabled: boolean("dockerSocketEnabled").notNull().default(true)
 });
 
+export const resourceGroups = pgTable("resourceGroups", {
+    groupId: serial("groupId").primaryKey(),
+    orgId: varchar("orgId")
+        .references(() => orgs.orgId, { onDelete: "cascade" })
+        .notNull(),
+    name: varchar("name").notNull(),
+    sortOrder: integer("sortOrder").notNull().default(0)
+});
+
 export const resources = pgTable("resources", {
     resourceId: serial("resourceId").primaryKey(),
     resourceGuid: varchar("resourceGuid", { length: 36 })
@@ -145,7 +154,10 @@ export const resources = pgTable("resources", {
     maintenanceTitle: text("maintenanceTitle"),
     maintenanceMessage: text("maintenanceMessage"),
     maintenanceEstimatedTime: text("maintenanceEstimatedTime"),
-    postAuthPath: text("postAuthPath")
+    postAuthPath: text("postAuthPath"),
+    groupId: integer("groupId").references(() => resourceGroups.groupId, {
+        onDelete: "set null"
+    })
 });
 
 export const targets = pgTable("targets", {

--- a/server/db/sqlite/schema/schema.ts
+++ b/server/db/sqlite/schema/schema.ts
@@ -101,6 +101,15 @@ export const sites = sqliteTable("sites", {
         .default(true)
 });
 
+export const resourceGroups = sqliteTable("resourceGroups", {
+    groupId: integer("groupId").primaryKey({ autoIncrement: true }),
+    orgId: text("orgId")
+        .references(() => orgs.orgId, { onDelete: "cascade" })
+        .notNull(),
+    name: text("name").notNull(),
+    sortOrder: integer("sortOrder").notNull().default(0)
+});
+
 export const resources = sqliteTable("resources", {
     resourceId: integer("resourceId").primaryKey({ autoIncrement: true }),
     resourceGuid: text("resourceGuid", { length: 36 })
@@ -160,7 +169,10 @@ export const resources = sqliteTable("resources", {
     maintenanceTitle: text("maintenanceTitle"),
     maintenanceMessage: text("maintenanceMessage"),
     maintenanceEstimatedTime: text("maintenanceEstimatedTime"),
-    postAuthPath: text("postAuthPath")
+    postAuthPath: text("postAuthPath"),
+    groupId: integer("groupId").references(() => resourceGroups.groupId, {
+        onDelete: "set null"
+    })
 });
 
 export const targets = sqliteTable("targets", {

--- a/server/routers/external.ts
+++ b/server/routers/external.ts
@@ -433,6 +433,34 @@ authenticated.get(
 );
 
 authenticated.get(
+    "/org/:orgId/resource-groups",
+    verifyOrgAccess,
+    verifyUserHasAction(ActionsEnum.listResources),
+    resource.listResourceGroups
+);
+
+authenticated.put(
+    "/org/:orgId/resource-group",
+    verifyOrgAccess,
+    verifyUserHasAction(ActionsEnum.createResource),
+    resource.createResourceGroup
+);
+
+authenticated.post(
+    "/org/:orgId/resource-group/:groupId",
+    verifyOrgAccess,
+    verifyUserHasAction(ActionsEnum.updateResource),
+    resource.updateResourceGroup
+);
+
+authenticated.delete(
+    "/org/:orgId/resource-group/:groupId",
+    verifyOrgAccess,
+    verifyUserHasAction(ActionsEnum.deleteResource),
+    resource.deleteResourceGroup
+);
+
+authenticated.get(
     "/org/:orgId/user-resources",
     verifyOrgAccess,
     resource.getUserResources

--- a/server/routers/resource/createResourceGroup.ts
+++ b/server/routers/resource/createResourceGroup.ts
@@ -1,0 +1,77 @@
+import { db, resourceGroups } from "@server/db";
+import response from "@server/lib/response";
+import HttpCode from "@server/types/HttpCode";
+import { NextFunction, Request, Response } from "express";
+import createHttpError from "http-errors";
+import { z } from "zod";
+import { fromZodError } from "zod-validation-error";
+import logger from "@server/logger";
+
+const createResourceGroupParamsSchema = z.strictObject({
+    orgId: z.string()
+});
+
+const createResourceGroupBodySchema = z.strictObject({
+    name: z.string().min(1).max(100)
+});
+
+export type CreateResourceGroupResponse = {
+    groupId: number;
+    name: string;
+    sortOrder: number;
+};
+
+export async function createResourceGroup(
+    req: Request,
+    res: Response,
+    next: NextFunction
+): Promise<any> {
+    try {
+        const parsedParams = createResourceGroupParamsSchema.safeParse(
+            req.params
+        );
+        if (!parsedParams.success) {
+            return next(
+                createHttpError(
+                    HttpCode.BAD_REQUEST,
+                    fromZodError(parsedParams.error)
+                )
+            );
+        }
+
+        const parsedBody = createResourceGroupBodySchema.safeParse(req.body);
+        if (!parsedBody.success) {
+            return next(
+                createHttpError(
+                    HttpCode.BAD_REQUEST,
+                    fromZodError(parsedBody.error)
+                )
+            );
+        }
+
+        const { orgId } = parsedParams.data;
+        const { name } = parsedBody.data;
+
+        const [created] = await db
+            .insert(resourceGroups)
+            .values({ orgId, name, sortOrder: 0 })
+            .returning({
+                groupId: resourceGroups.groupId,
+                name: resourceGroups.name,
+                sortOrder: resourceGroups.sortOrder
+            });
+
+        return response<CreateResourceGroupResponse>(res, {
+            data: created,
+            success: true,
+            error: false,
+            message: "Resource group created successfully",
+            status: HttpCode.CREATED
+        });
+    } catch (error) {
+        logger.error(error);
+        return next(
+            createHttpError(HttpCode.INTERNAL_SERVER_ERROR, "An error occurred")
+        );
+    }
+}

--- a/server/routers/resource/deleteResourceGroup.ts
+++ b/server/routers/resource/deleteResourceGroup.ts
@@ -1,0 +1,75 @@
+import { db, resourceGroups } from "@server/db";
+import response from "@server/lib/response";
+import HttpCode from "@server/types/HttpCode";
+import { and, eq } from "drizzle-orm";
+import { NextFunction, Request, Response } from "express";
+import createHttpError from "http-errors";
+import { z } from "zod";
+import { fromZodError } from "zod-validation-error";
+import logger from "@server/logger";
+
+const deleteResourceGroupParamsSchema = z.strictObject({
+    orgId: z.string(),
+    groupId: z.string().transform(Number).pipe(z.int().positive())
+});
+
+export type DeleteResourceGroupResponse = {};
+
+export async function deleteResourceGroup(
+    req: Request,
+    res: Response,
+    next: NextFunction
+): Promise<any> {
+    try {
+        const parsedParams = deleteResourceGroupParamsSchema.safeParse(
+            req.params
+        );
+        if (!parsedParams.success) {
+            return next(
+                createHttpError(
+                    HttpCode.BAD_REQUEST,
+                    fromZodError(parsedParams.error)
+                )
+            );
+        }
+
+        const { orgId, groupId } = parsedParams.data;
+
+        const [existing] = await db
+            .select()
+            .from(resourceGroups)
+            .where(
+                and(
+                    eq(resourceGroups.groupId, groupId),
+                    eq(resourceGroups.orgId, orgId)
+                )
+            )
+            .limit(1);
+
+        if (!existing) {
+            return next(
+                createHttpError(
+                    HttpCode.NOT_FOUND,
+                    `Resource group with ID ${groupId} not found`
+                )
+            );
+        }
+
+        await db
+            .delete(resourceGroups)
+            .where(eq(resourceGroups.groupId, groupId));
+
+        return response<DeleteResourceGroupResponse>(res, {
+            data: {},
+            success: true,
+            error: false,
+            message: "Resource group deleted successfully",
+            status: HttpCode.OK
+        });
+    } catch (error) {
+        logger.error(error);
+        return next(
+            createHttpError(HttpCode.INTERNAL_SERVER_ERROR, "An error occurred")
+        );
+    }
+}

--- a/server/routers/resource/index.ts
+++ b/server/routers/resource/index.ts
@@ -31,3 +31,7 @@ export * from "./addUserToResource";
 export * from "./removeUserFromResource";
 export * from "./listAllResourceNames";
 export * from "./removeEmailFromResourceWhitelist";
+export * from "./listResourceGroups";
+export * from "./createResourceGroup";
+export * from "./updateResourceGroup";
+export * from "./deleteResourceGroup";

--- a/server/routers/resource/listResourceGroups.ts
+++ b/server/routers/resource/listResourceGroups.ts
@@ -1,0 +1,62 @@
+import { db, resourceGroups } from "@server/db";
+import response from "@server/lib/response";
+import HttpCode from "@server/types/HttpCode";
+import { asc, eq } from "drizzle-orm";
+import { NextFunction, Request, Response } from "express";
+import createHttpError from "http-errors";
+import { z } from "zod";
+import { fromZodError } from "zod-validation-error";
+import logger from "@server/logger";
+
+const listResourceGroupsParamsSchema = z.strictObject({
+    orgId: z.string()
+});
+
+export type ListResourceGroupsResponse = {
+    groups: { groupId: number; name: string; sortOrder: number }[];
+};
+
+export async function listResourceGroups(
+    req: Request,
+    res: Response,
+    next: NextFunction
+): Promise<any> {
+    try {
+        const parsedParams = listResourceGroupsParamsSchema.safeParse(
+            req.params
+        );
+        if (!parsedParams.success) {
+            return next(
+                createHttpError(
+                    HttpCode.BAD_REQUEST,
+                    fromZodError(parsedParams.error)
+                )
+            );
+        }
+
+        const { orgId } = parsedParams.data;
+
+        const groups = await db
+            .select({
+                groupId: resourceGroups.groupId,
+                name: resourceGroups.name,
+                sortOrder: resourceGroups.sortOrder
+            })
+            .from(resourceGroups)
+            .where(eq(resourceGroups.orgId, orgId))
+            .orderBy(asc(resourceGroups.sortOrder), asc(resourceGroups.name));
+
+        return response<ListResourceGroupsResponse>(res, {
+            data: { groups },
+            success: true,
+            error: false,
+            message: "Resource groups retrieved successfully",
+            status: HttpCode.OK
+        });
+    } catch (error) {
+        logger.error(error);
+        return next(
+            createHttpError(HttpCode.INTERNAL_SERVER_ERROR, "An error occurred")
+        );
+    }
+}

--- a/server/routers/resource/listResources.ts
+++ b/server/routers/resource/listResources.ts
@@ -1,5 +1,6 @@
 import {
     db,
+    resourceGroups,
     resourceHeaderAuth,
     resourceHeaderAuthExtendedCompatibility,
     resourcePassword,
@@ -132,6 +133,7 @@ export type ResourceWithTargets = {
     domainId: string | null;
     niceId: string;
     headerAuthId: number | null;
+    groupId: number | null;
     targets: Array<{
         targetId: number;
         ip: string;
@@ -181,7 +183,8 @@ function queryResourcesBase() {
             niceId: resources.niceId,
             headerAuthId: resourceHeaderAuth.headerAuthId,
             headerAuthExtendedCompatibilityId:
-                resourceHeaderAuthExtendedCompatibility.headerAuthExtendedCompatibilityId
+                resourceHeaderAuthExtendedCompatibility.headerAuthExtendedCompatibilityId,
+            groupId: resources.groupId
         })
         .from(resources)
         .leftJoin(
@@ -213,7 +216,8 @@ function queryResourcesBase() {
             resourcePassword.passwordId,
             resourcePincode.pincodeId,
             resourceHeaderAuth.headerAuthId,
-            resourceHeaderAuthExtendedCompatibility.headerAuthExtendedCompatibilityId
+            resourceHeaderAuthExtendedCompatibility.headerAuthExtendedCompatibilityId,
+            resources.groupId
         );
 }
 
@@ -477,6 +481,7 @@ export async function listResources(
                     enabled: row.enabled,
                     domainId: row.domainId,
                     headerAuthId: row.headerAuthId,
+                    groupId: row.groupId,
                     targets: []
                 };
                 map.set(row.resourceId, entry);

--- a/server/routers/resource/updateResource.ts
+++ b/server/routers/resource/updateResource.ts
@@ -64,7 +64,8 @@ const updateHttpResourceBodySchema = z
         maintenanceTitle: z.string().max(255).nullable().optional(),
         maintenanceMessage: z.string().max(2000).nullable().optional(),
         maintenanceEstimatedTime: z.string().max(100).nullable().optional(),
-        postAuthPath: z.string().nullable().optional()
+        postAuthPath: z.string().nullable().optional(),
+        groupId: z.number().int().positive().nullable().optional()
     })
     .refine((data) => Object.keys(data).length > 0, {
         error: "At least one field must be provided for update"
@@ -156,7 +157,8 @@ const updateRawResourceBodySchema = z
         stickySession: z.boolean().optional(),
         enabled: z.boolean().optional(),
         proxyProtocol: z.boolean().optional(),
-        proxyProtocolVersion: z.int().min(1).optional()
+        proxyProtocolVersion: z.int().min(1).optional(),
+        groupId: z.number().int().positive().nullable().optional()
     })
     .refine((data) => Object.keys(data).length > 0, {
         error: "At least one field must be provided for update"

--- a/server/routers/resource/updateResourceGroup.ts
+++ b/server/routers/resource/updateResourceGroup.ts
@@ -1,0 +1,104 @@
+import { db, resourceGroups } from "@server/db";
+import response from "@server/lib/response";
+import HttpCode from "@server/types/HttpCode";
+import { and, eq } from "drizzle-orm";
+import { NextFunction, Request, Response } from "express";
+import createHttpError from "http-errors";
+import { z } from "zod";
+import { fromZodError } from "zod-validation-error";
+import logger from "@server/logger";
+
+const updateResourceGroupParamsSchema = z.strictObject({
+    orgId: z.string(),
+    groupId: z.string().transform(Number).pipe(z.int().positive())
+});
+
+const updateResourceGroupBodySchema = z
+    .strictObject({
+        name: z.string().min(1).max(100).optional(),
+        sortOrder: z.number().int().optional()
+    })
+    .refine((data) => Object.keys(data).length > 0, {
+        message: "At least one field must be provided for update"
+    });
+
+export type UpdateResourceGroupResponse = {
+    groupId: number;
+    name: string;
+    sortOrder: number;
+};
+
+export async function updateResourceGroup(
+    req: Request,
+    res: Response,
+    next: NextFunction
+): Promise<any> {
+    try {
+        const parsedParams = updateResourceGroupParamsSchema.safeParse(
+            req.params
+        );
+        if (!parsedParams.success) {
+            return next(
+                createHttpError(
+                    HttpCode.BAD_REQUEST,
+                    fromZodError(parsedParams.error)
+                )
+            );
+        }
+
+        const parsedBody = updateResourceGroupBodySchema.safeParse(req.body);
+        if (!parsedBody.success) {
+            return next(
+                createHttpError(
+                    HttpCode.BAD_REQUEST,
+                    fromZodError(parsedBody.error)
+                )
+            );
+        }
+
+        const { orgId, groupId } = parsedParams.data;
+
+        const [existing] = await db
+            .select()
+            .from(resourceGroups)
+            .where(
+                and(
+                    eq(resourceGroups.groupId, groupId),
+                    eq(resourceGroups.orgId, orgId)
+                )
+            )
+            .limit(1);
+
+        if (!existing) {
+            return next(
+                createHttpError(
+                    HttpCode.NOT_FOUND,
+                    `Resource group with ID ${groupId} not found`
+                )
+            );
+        }
+
+        const [updated] = await db
+            .update(resourceGroups)
+            .set(parsedBody.data)
+            .where(eq(resourceGroups.groupId, groupId))
+            .returning({
+                groupId: resourceGroups.groupId,
+                name: resourceGroups.name,
+                sortOrder: resourceGroups.sortOrder
+            });
+
+        return response<UpdateResourceGroupResponse>(res, {
+            data: updated,
+            success: true,
+            error: false,
+            message: "Resource group updated successfully",
+            status: HttpCode.OK
+        });
+    } catch (error) {
+        logger.error(error);
+        return next(
+            createHttpError(HttpCode.INTERNAL_SERVER_ERROR, "An error occurred")
+        );
+    }
+}

--- a/server/setup/migrationsPg.ts
+++ b/server/setup/migrationsPg.ts
@@ -21,6 +21,7 @@ import m12 from "./scriptsPg/1.15.0";
 import m13 from "./scriptsPg/1.15.3";
 import m14 from "./scriptsPg/1.15.4";
 import m15 from "./scriptsPg/1.16.0";
+import m16 from "./scriptsPg/1.17.0";
 
 // THIS CANNOT IMPORT ANYTHING FROM THE SERVER
 // EXCEPT FOR THE DATABASE AND THE SCHEMA
@@ -41,7 +42,8 @@ const migrations = [
     { version: "1.15.0", run: m12 },
     { version: "1.15.3", run: m13 },
     { version: "1.15.4", run: m14 },
-    { version: "1.16.0", run: m15 }
+    { version: "1.16.0", run: m15 },
+    { version: "1.17.0", run: m16 }
     // Add new migrations here as they are created
 ] as {
     version: string;

--- a/server/setup/migrationsSqlite.ts
+++ b/server/setup/migrationsSqlite.ts
@@ -39,6 +39,7 @@ import m33 from "./scriptsSqlite/1.15.0";
 import m34 from "./scriptsSqlite/1.15.3";
 import m35 from "./scriptsSqlite/1.15.4";
 import m36 from "./scriptsSqlite/1.16.0";
+import m37 from "./scriptsSqlite/1.17.0";
 
 // THIS CANNOT IMPORT ANYTHING FROM THE SERVER
 // EXCEPT FOR THE DATABASE AND THE SCHEMA
@@ -75,7 +76,8 @@ const migrations = [
     { version: "1.15.0", run: m33 },
     { version: "1.15.3", run: m34 },
     { version: "1.15.4", run: m35 },
-    { version: "1.16.0", run: m36 }
+    { version: "1.16.0", run: m36 },
+    { version: "1.17.0", run: m37 }
     // Add new migrations here as they are created
 ] as const;
 

--- a/server/setup/scriptsPg/1.17.0.ts
+++ b/server/setup/scriptsPg/1.17.0.ts
@@ -1,0 +1,41 @@
+import { db } from "@server/db/pg/driver";
+import { sql } from "drizzle-orm";
+
+const version = "1.17.0";
+
+export default async function migration() {
+    console.log(`Running setup script ${version}...`);
+
+    try {
+        await db.execute(sql`BEGIN`);
+
+        await db.execute(sql`
+            CREATE TABLE "resourceGroups" (
+                "groupId" serial PRIMARY KEY NOT NULL,
+                "orgId" varchar NOT NULL REFERENCES "orgs"("orgId") ON DELETE cascade,
+                "name" varchar NOT NULL,
+                "sortOrder" integer NOT NULL DEFAULT 0
+            );
+        `);
+
+        await db.execute(
+            sql`ALTER TABLE "resources" ADD COLUMN "groupId" integer;`
+        );
+
+        await db.execute(sql`
+            ALTER TABLE "resources"
+            ADD CONSTRAINT "resources_groupId_fk"
+            FOREIGN KEY ("groupId") REFERENCES "resourceGroups"("groupId") ON DELETE set null;
+        `);
+
+        await db.execute(sql`COMMIT`);
+        console.log("Migrated database");
+    } catch (e) {
+        await db.execute(sql`ROLLBACK`);
+        console.log("Unable to migrate database");
+        console.log(e);
+        throw e;
+    }
+
+    console.log(`${version} migration complete`);
+}

--- a/server/setup/scriptsSqlite/1.17.0.ts
+++ b/server/setup/scriptsSqlite/1.17.0.ts
@@ -1,0 +1,42 @@
+import { APP_PATH } from "@server/lib/consts";
+import Database from "better-sqlite3";
+import path from "path";
+
+const version = "1.17.0";
+
+export default async function migration() {
+    console.log(`Running setup script ${version}...`);
+
+    const location = path.join(APP_PATH, "db", "db.sqlite");
+    const db = new Database(location);
+
+    try {
+        db.pragma("foreign_keys = OFF");
+
+        db.transaction(() => {
+            db.prepare(
+                `
+                CREATE TABLE 'resourceGroups' (
+                    'groupId' integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+                    'orgId' text NOT NULL REFERENCES 'orgs'('orgId') ON DELETE cascade,
+                    'name' text NOT NULL,
+                    'sortOrder' integer NOT NULL DEFAULT 0
+                );
+                `
+            ).run();
+
+            db.prepare(
+                `ALTER TABLE 'resources' ADD 'groupId' integer REFERENCES 'resourceGroups'('groupId') ON DELETE set null;`
+            ).run();
+        })();
+
+        db.pragma("foreign_keys = ON");
+
+        console.log(`Migrated database`);
+    } catch (e) {
+        console.log("Failed to migrate db:", e);
+        throw e;
+    }
+
+    console.log(`${version} migration complete`);
+}

--- a/src/app/[orgId]/settings/resources/proxy/page.tsx
+++ b/src/app/[orgId]/settings/resources/proxy/page.tsx
@@ -6,7 +6,10 @@ import { internal } from "@app/lib/api";
 import { authCookieHeader } from "@app/lib/api/cookies";
 import OrgProvider from "@app/providers/OrgProvider";
 import type { GetOrgResponse } from "@server/routers/org";
-import type { ListResourcesResponse } from "@server/routers/resource";
+import type {
+    ListResourcesResponse,
+    ListResourceGroupsResponse
+} from "@server/routers/resource";
 import type { ListAllSiteResourcesByOrgResponse } from "@server/routers/siteResource";
 import type { AxiosResponse } from "axios";
 import { getTranslations } from "next-intl/server";
@@ -40,6 +43,14 @@ export default async function ProxyResourcesPage(
         const responseData = res.data.data;
         resources = responseData.resources;
         pagination = responseData.pagination;
+    } catch (e) {}
+
+    let groups: ListResourceGroupsResponse["groups"] = [];
+    try {
+        const res = await internal.get<
+            AxiosResponse<ListResourceGroupsResponse>
+        >(`/org/${params.orgId}/resource-groups`, await authCookieHeader());
+        groups = res.data.data.groups;
     } catch (e) {}
 
     let siteResources: ListAllSiteResourcesByOrgResponse["siteResources"] = [];
@@ -96,7 +107,8 @@ export default async function ProxyResourcesPage(
                 port: target.port,
                 enabled: target.enabled,
                 healthStatus: target.healthStatus
-            }))
+            })),
+            groupId: resource.groupId ?? null
         };
     });
     return (
@@ -117,6 +129,7 @@ export default async function ProxyResourcesPage(
                         pageIndex: pagination.page - 1,
                         pageSize: pagination.pageSize
                     }}
+                    groups={groups}
                 />
             </OrgProvider>
         </>

--- a/src/components/CreateResourceGroupDialog.tsx
+++ b/src/components/CreateResourceGroupDialog.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { Button } from "@app/components/ui/button";
+import { Input } from "@app/components/ui/input";
+import { Label } from "@app/components/ui/label";
+import {
+    Credenza,
+    CredenzaBody,
+    CredenzaClose,
+    CredenzaContent,
+    CredenzaFooter,
+    CredenzaHeader,
+    CredenzaTitle
+} from "@app/components/Credenza";
+import { createApiClient, formatAxiosError } from "@app/lib/api";
+import { useEnvContext } from "@app/hooks/useEnvContext";
+import { toast } from "@app/hooks/useToast";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { z } from "zod";
+
+const nameSchema = z.string().min(1).max(100);
+
+type CreateResourceGroupDialogProps = {
+    open: boolean;
+    setOpen: (open: boolean) => void;
+    orgId: string;
+};
+
+export default function CreateResourceGroupDialog({
+    open,
+    setOpen,
+    orgId
+}: CreateResourceGroupDialogProps) {
+    const { env } = useEnvContext();
+    const api = createApiClient({ env });
+    const router = useRouter();
+    const [name, setName] = useState("");
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    async function handleCreate() {
+        const parsed = nameSchema.safeParse(name.trim());
+        if (!parsed.success) {
+            setError("Group name must be between 1 and 100 characters.");
+            return;
+        }
+        setLoading(true);
+        setError(null);
+        try {
+            await api.put(`/org/${orgId}/resource-group`, {
+                name: parsed.data
+            });
+            setOpen(false);
+            setName("");
+            router.refresh();
+        } catch (e) {
+            toast({
+                variant: "destructive",
+                title: "Error creating group",
+                description: formatAxiosError(e, "Could not create group")
+            });
+        } finally {
+            setLoading(false);
+        }
+    }
+
+    return (
+        <Credenza
+            open={open}
+            onOpenChange={(val) => {
+                setOpen(val);
+                if (!val) {
+                    setName("");
+                    setError(null);
+                }
+            }}
+        >
+            <CredenzaContent>
+                <CredenzaHeader>
+                    <CredenzaTitle>Create Group</CredenzaTitle>
+                </CredenzaHeader>
+                <CredenzaBody>
+                    <div className="space-y-2">
+                        <Label htmlFor="group-name">Group Name</Label>
+                        <Input
+                            id="group-name"
+                            value={name}
+                            onChange={(e) => setName(e.target.value)}
+                            placeholder="e.g. Production, Internal, ..."
+                            onKeyDown={(e) => {
+                                if (e.key === "Enter") handleCreate();
+                            }}
+                        />
+                        {error && (
+                            <p className="text-sm text-destructive">{error}</p>
+                        )}
+                    </div>
+                </CredenzaBody>
+                <CredenzaFooter>
+                    <CredenzaClose asChild>
+                        <Button variant="outline">Cancel</Button>
+                    </CredenzaClose>
+                    <Button onClick={handleCreate} disabled={loading}>
+                        {loading ? "Creating..." : "Create"}
+                    </Button>
+                </CredenzaFooter>
+            </CredenzaContent>
+        </Credenza>
+    );
+}

--- a/src/components/MoveResourceToGroupDialog.tsx
+++ b/src/components/MoveResourceToGroupDialog.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { Button } from "@app/components/ui/button";
+import { Label } from "@app/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "@app/components/ui/radio-group";
+import {
+    Credenza,
+    CredenzaBody,
+    CredenzaClose,
+    CredenzaContent,
+    CredenzaFooter,
+    CredenzaHeader,
+    CredenzaTitle
+} from "@app/components/Credenza";
+import { createApiClient, formatAxiosError } from "@app/lib/api";
+import { useEnvContext } from "@app/hooks/useEnvContext";
+import { toast } from "@app/hooks/useToast";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+type Group = { groupId: number; name: string; sortOrder: number };
+
+type MoveResourceToGroupDialogProps = {
+    open: boolean;
+    setOpen: (open: boolean) => void;
+    resourceId: number;
+    resourceName: string;
+    currentGroupId: number | null;
+    groups: Group[];
+};
+
+export default function MoveResourceToGroupDialog({
+    open,
+    setOpen,
+    resourceId,
+    resourceName,
+    currentGroupId,
+    groups
+}: MoveResourceToGroupDialogProps) {
+    const { env } = useEnvContext();
+    const api = createApiClient({ env });
+    const router = useRouter();
+    const [selected, setSelected] = useState<string>(
+        currentGroupId !== null ? String(currentGroupId) : "ungrouped"
+    );
+    const [loading, setLoading] = useState(false);
+
+    async function handleMove() {
+        setLoading(true);
+        try {
+            const groupId =
+                selected === "ungrouped" ? null : Number(selected);
+            await api.post(`/resource/${resourceId}`, { groupId });
+            setOpen(false);
+            router.refresh();
+        } catch (e) {
+            toast({
+                variant: "destructive",
+                title: "Error moving resource",
+                description: formatAxiosError(e, "Could not move resource")
+            });
+        } finally {
+            setLoading(false);
+        }
+    }
+
+    return (
+        <Credenza
+            open={open}
+            onOpenChange={(val) => {
+                setOpen(val);
+                if (!val) {
+                    setSelected(
+                        currentGroupId !== null
+                            ? String(currentGroupId)
+                            : "ungrouped"
+                    );
+                }
+            }}
+        >
+            <CredenzaContent>
+                <CredenzaHeader>
+                    <CredenzaTitle>Move &quot;{resourceName}&quot; to Group</CredenzaTitle>
+                </CredenzaHeader>
+                <CredenzaBody>
+                    <RadioGroup
+                        value={selected}
+                        onValueChange={setSelected}
+                        className="space-y-2"
+                    >
+                        <div className="flex items-center space-x-2">
+                            <RadioGroupItem value="ungrouped" id="ungrouped" />
+                            <Label htmlFor="ungrouped">Ungrouped</Label>
+                        </div>
+                        {groups.map((group) => (
+                            <div
+                                key={group.groupId}
+                                className="flex items-center space-x-2"
+                            >
+                                <RadioGroupItem
+                                    value={String(group.groupId)}
+                                    id={`group-${group.groupId}`}
+                                />
+                                <Label htmlFor={`group-${group.groupId}`}>
+                                    {group.name}
+                                </Label>
+                            </div>
+                        ))}
+                    </RadioGroup>
+                </CredenzaBody>
+                <CredenzaFooter>
+                    <CredenzaClose asChild>
+                        <Button variant="outline">Cancel</Button>
+                    </CredenzaClose>
+                    <Button onClick={handleMove} disabled={loading}>
+                        {loading ? "Moving..." : "Move"}
+                    </Button>
+                </CredenzaFooter>
+            </CredenzaContent>
+        </Credenza>
+    );
+}

--- a/src/components/ProxyResourcesTable.tsx
+++ b/src/components/ProxyResourcesTable.tsx
@@ -2,6 +2,8 @@
 
 import ConfirmDeleteDialog from "@app/components/ConfirmDeleteDialog";
 import CopyToClipboard from "@app/components/CopyToClipboard";
+import CreateResourceGroupDialog from "@app/components/CreateResourceGroupDialog";
+import MoveResourceToGroupDialog from "@app/components/MoveResourceToGroupDialog";
 import { Button } from "@app/components/ui/button";
 import { ExtendedColumnDef } from "@app/components/ui/data-table";
 import {
@@ -12,6 +14,7 @@ import {
 } from "@app/components/ui/dropdown-menu";
 import { InfoPopup } from "@app/components/ui/info-popup";
 import { Switch } from "@app/components/ui/switch";
+import { TableCell, TableRow } from "@app/components/ui/table";
 import { useEnvContext } from "@app/hooks/useEnvContext";
 import { useNavigationContext } from "@app/hooks/useNavigationContext";
 import { getNextSortOrder, getSortDirection } from "@app/lib/sortColumn";
@@ -26,11 +29,14 @@ import {
     ArrowUp10Icon,
     CheckCircle2,
     ChevronDown,
+    ChevronRight,
     ChevronsUpDownIcon,
     Clock,
+    FolderOpen,
     MoreHorizontal,
     ShieldCheck,
     ShieldOff,
+    Trash2,
     XCircle
 } from "lucide-react";
 import { useTranslations } from "next-intl";
@@ -72,7 +78,10 @@ export type ResourceRow = {
     targetHost?: string;
     targetPort?: number;
     targets?: TargetHealth[];
+    groupId: number | null;
 };
+
+type Group = { groupId: number; name: string; sortOrder: number };
 
 function getOverallHealthStatus(
     targets?: TargetHealth[]
@@ -133,13 +142,15 @@ type ProxyResourcesTableProps = {
     orgId: string;
     pagination: PaginationState;
     rowCount: number;
+    groups: Group[];
 };
 
 export default function ProxyResourcesTable({
     resources,
     orgId,
     pagination,
-    rowCount
+    rowCount,
+    groups
 }: ProxyResourcesTableProps) {
     const router = useRouter();
     const {
@@ -156,6 +167,18 @@ export default function ProxyResourcesTable({
     const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
     const [selectedResource, setSelectedResource] =
         useState<ResourceRow | null>();
+
+    const [isMoveDialogOpen, setIsMoveDialogOpen] = useState(false);
+    const [moveTarget, setMoveTarget] = useState<ResourceRow | null>(null);
+
+    const [isCreateGroupDialogOpen, setIsCreateGroupDialogOpen] =
+        useState(false);
+    const [isDeleteGroupModalOpen, setIsDeleteGroupModalOpen] = useState(false);
+    const [selectedGroup, setSelectedGroup] = useState<Group | null>(null);
+
+    const [collapsedGroups, setCollapsedGroups] = useState<Set<number>>(
+        new Set()
+    );
 
     const [isRefreshing, startTransition] = useTransition();
     const [isNavigatingToAddPage, startNavigation] = useTransition();
@@ -192,6 +215,23 @@ export default function ProxyResourcesTable({
             });
     };
 
+    const deleteGroup = (groupId: number) => {
+        api.delete(`/org/${orgId}/resource-group/${groupId}`)
+            .catch((e) => {
+                toast({
+                    variant: "destructive",
+                    title: "Error deleting group",
+                    description: formatAxiosError(e, "Could not delete group")
+                });
+            })
+            .then(() => {
+                startTransition(() => {
+                    router.refresh();
+                    setIsDeleteGroupModalOpen(false);
+                });
+            });
+    };
+
     async function toggleResourceEnabled(val: boolean, resourceId: number) {
         try {
             await api.post<AxiosResponse<UpdateResourceResponse>>(
@@ -213,12 +253,24 @@ export default function ProxyResourcesTable({
         }
     }
 
+    function toggleGroupCollapsed(groupId: number) {
+        setCollapsedGroups((prev) => {
+            const next = new Set(prev);
+            if (next.has(groupId)) {
+                next.delete(groupId);
+            } else {
+                next.add(groupId);
+            }
+            return next;
+        });
+    }
+
     function TargetStatusCell({ targets }: { targets?: TargetHealth[] }) {
         const overallStatus = getOverallHealthStatus(targets);
 
         if (!targets || targets.length === 0) {
             return (
-                <div id="LOOK_FOR_ME" className="flex items-center gap-2">
+                <div className="flex items-center gap-2">
                     <StatusIcon status="unknown" />
                     <span className="text-sm">
                         {t("resourcesTableNoTargets")}
@@ -542,6 +594,14 @@ export default function ProxyResourcesTable({
                                 </Link>
                                 <DropdownMenuItem
                                     onClick={() => {
+                                        setMoveTarget(resourceRow);
+                                        setIsMoveDialogOpen(true);
+                                    }}
+                                >
+                                    Move to group...
+                                </DropdownMenuItem>
+                                <DropdownMenuItem
+                                    onClick={() => {
                                         setSelectedResource(resourceRow);
                                         setIsDeleteModalOpen(true);
                                     }}
@@ -610,6 +670,119 @@ export default function ProxyResourcesTable({
         });
     }, 300);
 
+    // Build ordered flat row list for grouped display
+    const sortedGroups = [...groups].sort(
+        (a, b) => a.sortOrder - b.sortOrder || a.name.localeCompare(b.name)
+    );
+
+    // IDs of rows that belong to a collapsed group (should be hidden)
+    const collapsedResourceIds = new Set<number>();
+
+    // displayRows: includes sentinel (first) row for each collapsed group,
+    // plus all rows for expanded groups, in order
+    const displayRows: ResourceRow[] = [];
+    if (groups.length > 0) {
+        for (const group of sortedGroups) {
+            const groupResources = resources
+                .filter((r) => r.groupId === group.groupId)
+                .sort((a, b) => a.name.localeCompare(b.name));
+            if (collapsedGroups.has(group.groupId)) {
+                // Add only the first resource as a sentinel to trigger header rendering
+                if (groupResources.length > 0) {
+                    displayRows.push(groupResources[0]);
+                    // Mark the sentinel as collapsed (hidden)
+                    collapsedResourceIds.add(groupResources[0].id);
+                }
+            } else {
+                displayRows.push(...groupResources);
+            }
+        }
+        const ungroupedResources = resources
+            .filter((r) => r.groupId === null)
+            .sort((a, b) => a.name.localeCompare(b.name));
+        if (ungroupedResources.length > 0) {
+            if (collapsedGroups.has(-1)) {
+                displayRows.push(ungroupedResources[0]);
+                collapsedResourceIds.add(ungroupedResources[0].id);
+            } else {
+                displayRows.push(...ungroupedResources);
+            }
+        }
+    }
+
+    function getGroupHeaderBeforeRow(
+        row: ResourceRow,
+        index: number,
+        prevRow: ResourceRow | undefined,
+        colSpan: number
+    ) {
+        if (groups.length === 0) return null;
+
+        const currentGroupId = row.groupId ?? -1;
+        const prevGroupId =
+            prevRow !== undefined ? (prevRow.groupId ?? -1) : null;
+
+        // Only render a header at group boundaries
+        if (currentGroupId === prevGroupId) return null;
+
+        const group: Group | null =
+            row.groupId === null
+                ? resources.some((r) => r.groupId === null)
+                    ? { groupId: -1, name: "Ungrouped", sortOrder: 9999 }
+                    : null
+                : (groups.find((g) => g.groupId === row.groupId) ?? null);
+        if (!group) return null;
+
+        const count = resources.filter((r) =>
+            group.groupId === -1
+                ? r.groupId === null
+                : r.groupId === group.groupId
+        ).length;
+
+        const isCollapsed = collapsedGroups.has(group.groupId);
+
+        return (
+            <TableRow
+                key={`group-header-${group.groupId}`}
+                className="bg-muted/40 hover:bg-muted/40"
+            >
+                <TableCell colSpan={colSpan} className="py-2 px-4">
+                    <div className="flex items-center justify-between">
+                        <button
+                            type="button"
+                            className="flex items-center gap-2 text-sm font-medium"
+                            onClick={() => toggleGroupCollapsed(group.groupId)}
+                        >
+                            {isCollapsed ? (
+                                <ChevronRight className="h-4 w-4" />
+                            ) : (
+                                <ChevronDown className="h-4 w-4" />
+                            )}
+                            <FolderOpen className="h-4 w-4 text-muted-foreground" />
+                            <span>{group.name}</span>
+                            <span className="text-muted-foreground font-normal">
+                                ({count})
+                            </span>
+                        </button>
+                        {group.groupId !== -1 && (
+                            <button
+                                type="button"
+                                className="flex items-center gap-1 text-xs text-muted-foreground hover:text-destructive"
+                                onClick={() => {
+                                    setSelectedGroup(group);
+                                    setIsDeleteGroupModalOpen(true);
+                                }}
+                            >
+                                <Trash2 className="h-3 w-3" />
+                                Delete group
+                            </button>
+                        )}
+                    </div>
+                </TableCell>
+            </TableRow>
+        );
+    }
+
     return (
         <>
             {selectedResource && (
@@ -632,9 +805,55 @@ export default function ProxyResourcesTable({
                 />
             )}
 
+            {selectedGroup && (
+                <ConfirmDeleteDialog
+                    open={isDeleteGroupModalOpen}
+                    setOpen={(val) => {
+                        setIsDeleteGroupModalOpen(val);
+                        if (!val) setSelectedGroup(null);
+                    }}
+                    dialog={
+                        <div className="space-y-2">
+                            <p>
+                                Are you sure you want to delete the group &quot;
+                                {selectedGroup.name}&quot;?
+                            </p>
+                            <p>
+                                Resources in this group will become ungrouped.
+                                They will not be deleted.
+                            </p>
+                        </div>
+                    }
+                    buttonText="Delete Group"
+                    onConfirm={async () => deleteGroup(selectedGroup.groupId)}
+                    string={selectedGroup.name}
+                    title="Delete Group"
+                />
+            )}
+
+            {moveTarget && (
+                <MoveResourceToGroupDialog
+                    open={isMoveDialogOpen}
+                    setOpen={(val) => {
+                        setIsMoveDialogOpen(val);
+                        if (!val) setMoveTarget(null);
+                    }}
+                    resourceId={moveTarget.id}
+                    resourceName={moveTarget.name}
+                    currentGroupId={moveTarget.groupId}
+                    groups={groups}
+                />
+            )}
+
+            <CreateResourceGroupDialog
+                open={isCreateGroupDialogOpen}
+                setOpen={setIsCreateGroupDialogOpen}
+                orgId={orgId}
+            />
+
             <ControlledDataTable
                 columns={proxyColumns}
-                rows={resources}
+                rows={groups.length === 0 ? resources : displayRows}
                 tableId="proxy-resources"
                 searchPlaceholder={t("resourcesSearch")}
                 pagination={pagination}
@@ -654,6 +873,24 @@ export default function ProxyResourcesTable({
                 columnVisibility={{ niceId: false }}
                 stickyLeftColumn="name"
                 stickyRightColumn="actions"
+                extraToolbarActions={
+                    <Button
+                        variant="outline"
+                        onClick={() => setIsCreateGroupDialogOpen(true)}
+                    >
+                        <FolderOpen className="mr-2 h-4 w-4" />
+                        Create Group
+                    </Button>
+                }
+                getGroupHeaderBeforeRow={
+                    groups.length > 0 ? getGroupHeaderBeforeRow : undefined
+                }
+                getRowClassName={
+                    groups.length > 0
+                        ? (row) =>
+                              collapsedResourceIds.has(row.id) ? "hidden" : ""
+                        : undefined
+                }
             />
         </>
     );

--- a/src/components/ui/controlled-data-table.tsx
+++ b/src/components/ui/controlled-data-table.tsx
@@ -33,7 +33,7 @@ import { useStoredColumnVisibility } from "@app/hooks/useStoredColumnVisibility"
 
 import { Columns, Filter, Plus, RefreshCw, Search } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { useMemo, useState } from "react";
+import { Fragment, ReactNode, useMemo, useState } from "react";
 
 // Extended ColumnDef type that includes optional friendlyName for column visibility dropdown
 export type ExtendedColumnDef<TData, TValue = unknown> = ColumnDef<
@@ -82,6 +82,14 @@ type ControlledDataTableProps<TData, TValue> = {
     stickyRightColumn?: string; // Column ID or accessorKey for right sticky column (typically "actions")
     rowCount: number;
     pagination: PaginationState;
+    extraToolbarActions?: ReactNode;
+    getGroupHeaderBeforeRow?: (
+        row: TData,
+        index: number,
+        prevRow: TData | undefined,
+        colSpan: number
+    ) => ReactNode | null;
+    getRowClassName?: (row: TData) => string;
 };
 
 export function ControlledDataTable<TData, TValue>({
@@ -104,7 +112,10 @@ export function ControlledDataTable<TData, TValue>({
     onPaginationChange,
     stickyRightColumn,
     rowCount,
-    isNavigatingToAddPage
+    isNavigatingToAddPage,
+    extraToolbarActions,
+    getGroupHeaderBeforeRow,
+    getRowClassName
 }: ControlledDataTableProps<TData, TValue>) {
     const t = useTranslations();
 
@@ -346,6 +357,9 @@ export function ControlledDataTable<TData, TValue>({
                                 </Button>
                             </div>
                         )}
+                        {extraToolbarActions && (
+                            <div>{extraToolbarActions}</div>
+                        )}
                         {onAdd && addButtonText && (
                             <div>
                                 <Button
@@ -503,52 +517,74 @@ export function ControlledDataTable<TData, TValue>({
                             </TableHeader>
                             <TableBody>
                                 {table.getRowModel().rows?.length ? (
-                                    table.getRowModel().rows.map((row) => (
-                                        <TableRow
-                                            key={row.id}
-                                            data-state={
-                                                row.getIsSelected() &&
-                                                "selected"
-                                            }
-                                        >
-                                            {row
-                                                .getVisibleCells()
-                                                .map((cell) => {
-                                                    const columnId =
-                                                        cell.column.id;
-                                                    const accessorKey = (
-                                                        cell.column
-                                                            .columnDef as any
-                                                    ).accessorKey as
-                                                        | string
-                                                        | undefined;
-                                                    const stickyClasses =
-                                                        getStickyClasses(
-                                                            columnId,
-                                                            accessorKey
-                                                        );
-                                                    const isRightSticky =
-                                                        isStickyColumn(
-                                                            columnId,
-                                                            accessorKey,
-                                                            "right"
-                                                        );
-                                                    return (
-                                                        <TableCell
-                                                            key={cell.id}
-                                                            className={`whitespace-nowrap ${stickyClasses} ${isRightSticky ? "text-right" : ""}`}
-                                                        >
-                                                            {flexRender(
-                                                                cell.column
-                                                                    .columnDef
-                                                                    .cell,
-                                                                cell.getContext()
-                                                            )}
-                                                        </TableCell>
-                                                    );
-                                                })}
-                                        </TableRow>
-                                    ))
+                                    table.getRowModel().rows.map((row, i) => {
+                                        const prevRow =
+                                            i > 0
+                                                ? table.getRowModel().rows[
+                                                      i - 1
+                                                  ]?.original
+                                                : undefined;
+                                        const groupHeader =
+                                            getGroupHeaderBeforeRow?.(
+                                                row.original,
+                                                i,
+                                                prevRow,
+                                                columns.length
+                                            );
+                                        return (
+                                            <Fragment key={row.id}>
+                                                {groupHeader}
+                                                <TableRow
+                                                    data-state={
+                                                        row.getIsSelected() &&
+                                                        "selected"
+                                                    }
+                                                    className={getRowClassName?.(row.original)}
+                                                >
+                                                    {row
+                                                        .getVisibleCells()
+                                                        .map((cell) => {
+                                                            const columnId =
+                                                                cell.column.id;
+                                                            const accessorKey =
+                                                                (
+                                                                    cell.column
+                                                                        .columnDef as any
+                                                                ).accessorKey as
+                                                                    | string
+                                                                    | undefined;
+                                                            const stickyClasses =
+                                                                getStickyClasses(
+                                                                    columnId,
+                                                                    accessorKey
+                                                                );
+                                                            const isRightSticky =
+                                                                isStickyColumn(
+                                                                    columnId,
+                                                                    accessorKey,
+                                                                    "right"
+                                                                );
+                                                            return (
+                                                                <TableCell
+                                                                    key={
+                                                                        cell.id
+                                                                    }
+                                                                    className={`whitespace-nowrap ${stickyClasses} ${isRightSticky ? "text-right" : ""}`}
+                                                                >
+                                                                    {flexRender(
+                                                                        cell
+                                                                            .column
+                                                                            .columnDef
+                                                                            .cell,
+                                                                        cell.getContext()
+                                                                    )}
+                                                                </TableCell>
+                                                            );
+                                                        })}
+                                                </TableRow>
+                                            </Fragment>
+                                        );
+                                    })
                                 ) : (
                                     <TableRow>
                                         <TableCell


### PR DESCRIPTION
Adds the ability to organize proxy resources into named groups/folders on the resources page.

**Changes:**
  - **DB**: New `resourceGroups` table with `orgId`, `name`, `sortOrder`; `groupId` FK added to `resources` (ON DELETE set null); migrations for PostgreSQL and SQLite (1.17.0)
  - **API**: CRUD endpoints for resource groups (`GET/PUT/POST/DELETE /org/:orgId/resource-group[s]`); `groupId` added to `listResources` response and `updateResource` body
  - **UI**: Collapsible group headers in the proxy resources table; "Create Group" toolbar button; "Move to group..." action in the resource row menu; group delete (resources become ungrouped, not deleted)
<img width="1549" height="924" alt="image" src="https://github.com/user-attachments/assets/0390ee87-eeee-4c56-b4b3-316dcc706726" />

## Description
Add support for grouping proxy resources to improve organization and management. This includes database schema updates to introduce a new `resourceGroups` table and a `groupId` foreign key in the `resources` table, along with migration scripts for PostgreSQL and SQLite. New API endpoints for CRUD operations on resource groups (create, list, update, delete) have been added. The frontend now features collapsible group headers in the resources table, dialogs for creating groups and moving resources between groups, and updates to resource listing and update logic to handle group assignments.

## How to test?
**Changes:**
  - **DB**: New `resourceGroups` table with `orgId`, `name`, `sortOrder`; `groupId` FK added to `resources` (ON DELETE set null); migrations for PostgreSQL and SQLite (1.17.0)
  - **API**: CRUD endpoints for resource groups (`GET/PUT/POST/DELETE /org/:orgId/resource-group[s]`); `groupId` added to `listResources` response and `updateResource` body
  - **UI**: Collapsible group headers in the proxy resources table; "Create Group" toolbar button; "Move to group..." action in the resource row menu; group delete (resources become ungrouped, not deleted)

## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.