### PR TITLE
fix(newt): Format ipv6 targets for go

### DIFF
--- a/server/routers/newt/buildConfiguration.ts
+++ b/server/routers/newt/buildConfiguration.ts
@@ -14,7 +14,11 @@ import logger from "@server/logger";
 import { initPeerAddHandshake, updatePeer } from "../olm/peers";
 import { eq, and } from "drizzle-orm";
 import config from "@server/lib/config";
-import { generateSubnetProxyTargets, SubnetProxyTarget } from "@server/lib/ip";
+import {
+    formatEndpoint,
+    generateSubnetProxyTargets,
+    SubnetProxyTarget
+} from "@server/lib/ip";
 
 export async function buildClientConfigurationForNewtClient(
     site: Site,
@@ -219,8 +223,8 @@ export async function buildTargetConfigurationForNewtClient(siteId: number) {
                 return acc;
             }
 
-            // Format target into string
-            const formattedTarget = `${target.internalPort}:${target.ip}:${target.port}`;
+            // Format target into string (handles IPv6 bracketing)
+            const formattedTarget = `${target.internalPort}:${formatEndpoint(target.ip, target.port)}`;
 
             // Add to the appropriate protocol array
             if (target.protocol === "tcp") {


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description

We added support https://github.com/fosrl/newt/releases/tag/1.10.3 for ipv6 targets from newt -> application, but we need to ensure that we handle if user provides a none bracketed ipv6 string

## How to test?

When adding ipv6 target to pangolin they should be sent to newt in a golang format for `ip:port`