### PR TITLE
fix: show informative message when saving with no targets

### DIFF
--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -568,6 +568,8 @@
     "targetErrorInvalidPortDescription": "Please enter a valid port number",
     "targetErrorNoSite": "No site selected",
     "targetErrorNoSiteDescription": "Please select a site for the target",
+    "targetNoTargets": "No targets to save",
+    "targetNoTargetsDescription": "Please add at least one target before saving",
     "targetCreated": "Target created",
     "targetCreatedDescription": "Target has been created successfully",
     "targetErrorCreate": "Failed to create target",

--- a/src/app/[orgId]/settings/resources/proxy/[niceId]/proxy/page.tsx
+++ b/src/app/[orgId]/settings/resources/proxy/[niceId]/proxy/page.tsx
@@ -728,6 +728,14 @@ function ProxyResourceTargetsForm({
                 )
             );
 
+            if (targets.length === 0 && targetsToRemove.length === 0) {
+                toast({
+                    title: t("targetNoTargets"),
+                    description: t("targetNoTargetsDescription")
+                });
+                return;
+            }
+
             // Save targets
             for (const target of targets) {
                 const data: any = {


### PR DESCRIPTION
## Summary
- When saving targets with an empty target list and no removals, the app previously showed a misleading "Settings updated" success notification
- Now shows "No targets to save — Please add at least one target before saving" instead
- Added translation keys `targetNoTargets` and `targetNoTargetsDescription` to `en-US.json`

Fixes #586

## Test plan
- [ ] Navigate to a resource's proxy settings
- [ ] Without adding any targets, click "Save Targets"
- [ ] Verify the toast says "No targets to save" instead of "Settings updated"
- [ ] Add a target, save, and verify "Settings updated" still shows correctly
- [ ] Remove all targets and save — verify deletions still process correctly