### PR TITLE
fix: show contextual toast when saving with no targets

### DIFF
--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -568,6 +568,8 @@
     "targetErrorInvalidPortDescription": "Please enter a valid port number",
     "targetErrorNoSite": "No site selected",
     "targetErrorNoSiteDescription": "Please select a site for the target",
+    "targetTargetsCleared": "Targets cleared",
+    "targetTargetsClearedDescription": "All targets have been removed from this resource",
     "targetCreated": "Target created",
     "targetCreatedDescription": "Target has been created successfully",
     "targetErrorCreate": "Failed to create target",

--- a/src/app/[orgId]/settings/resources/proxy/[niceId]/proxy/page.tsx
+++ b/src/app/[orgId]/settings/resources/proxy/[niceId]/proxy/page.tsx
@@ -774,8 +774,12 @@ function ProxyResourceTargetsForm({
             }
 
             toast({
-                title: t("settingsUpdated"),
-                description: t("settingsUpdatedDescription")
+                title: targets.length === 0
+                    ? t("targetTargetsCleared")
+                    : t("settingsUpdated"),
+                description: targets.length === 0
+                    ? t("targetTargetsClearedDescription")
+                    : t("settingsUpdatedDescription")
             });
 
             setTargetsToRemove([]);


### PR DESCRIPTION
## Summary
Follow-up to #2711 based on maintainer feedback — saving with no targets should still work (to allow clearing targets), but the notification should reflect what actually happened.

**What changed:** Instead of always showing "Settings updated" when saving, the toast now shows:
- **"Targets cleared"** when the target list is empty
- **"Settings updated"** when targets were actually saved

No save action is blocked — this only changes the notification text.

Fixes #586

## Test plan
- [x] Save with no targets → toast says "Targets cleared"
- [x] Save with targets → toast says "Settings updated"  
- [x] Remove all targets and save → deletions process correctly, toast says "Targets cleared"