### PR TITLE
Refactor migration scripts for safe column removals and roleId handling

### DIFF
--- a/server/setup/scriptsPg/1.17.0.ts
+++ b/server/setup/scriptsPg/1.17.0.ts
@@ -22,8 +22,16 @@ export default async function migration() {
             orgId: string;
             roleId: number;
         }[];
-    } catch {
-        // column already removed – nothing to migrate
+    } catch (e: any) {
+        if (
+            e?.message?.includes('column "roleId"') ||
+            e?.message?.includes("column roleId") ||
+            e?.code === "42703"
+        ) {
+            // column already removed – nothing to migrate
+        } else {
+            throw e;
+        }
     }
 
     console.log(
@@ -44,8 +52,16 @@ export default async function migration() {
             inviteId: string;
             roleId: number;
         }[];
-    } catch {
-        // column already removed – nothing to migrate
+    } catch (e: any) {
+        if (
+            e?.message?.includes('column "roleId"') ||
+            e?.message?.includes("column roleId") ||
+            e?.code === "42703"
+        ) {
+            // column already removed – nothing to migrate
+        } else {
+            throw e;
+        }
     }
 
     console.log(

--- a/server/setup/scriptsPg/1.17.0.ts
+++ b/server/setup/scriptsPg/1.17.0.ts
@@ -6,28 +6,47 @@ const version = "1.17.0";
 export default async function migration() {
     console.log(`Running setup script ${version}...`);
 
-    // Query existing roleId data from userOrgs before the transaction destroys it
-    const existingRolesQuery = await db.execute(
-        sql`SELECT "userId", "orgId", "roleId" FROM "userOrgs" WHERE "roleId" IS NOT NULL`
-    );
-    const existingUserOrgRoles = existingRolesQuery.rows as {
+    // Query existing roleId data from userOrgs before the transaction destroys it.
+    // Guard against schemas where the column was already removed (e.g. RC upgrades).
+    let existingUserOrgRoles: {
         userId: string;
         orgId: string;
         roleId: number;
-    }[];
+    }[] = [];
+    try {
+        const existingRolesQuery = await db.execute(
+            sql`SELECT "userId", "orgId", "roleId" FROM "userOrgs" WHERE "roleId" IS NOT NULL`
+        );
+        existingUserOrgRoles = existingRolesQuery.rows as {
+            userId: string;
+            orgId: string;
+            roleId: number;
+        }[];
+    } catch {
+        // column already removed – nothing to migrate
+    }
 
     console.log(
         `Found ${existingUserOrgRoles.length} existing userOrgs role assignment(s) to migrate`
     );
 
-    // Query existing roleId data from userInvites before the transaction destroys it
-    const existingInviteRolesQuery = await db.execute(
-        sql`SELECT "inviteId", "roleId" FROM "userInvites" WHERE "roleId" IS NOT NULL`
-    );
-    const existingUserInviteRoles = existingInviteRolesQuery.rows as {
+    // Query existing roleId data from userInvites before the transaction destroys it.
+    // Guard against schemas where the column was already removed (e.g. RC upgrades).
+    let existingUserInviteRoles: {
         inviteId: string;
         roleId: number;
-    }[];
+    }[] = [];
+    try {
+        const existingInviteRolesQuery = await db.execute(
+            sql`SELECT "inviteId", "roleId" FROM "userInvites" WHERE "roleId" IS NOT NULL`
+        );
+        existingUserInviteRoles = existingInviteRolesQuery.rows as {
+            inviteId: string;
+            roleId: number;
+        }[];
+    } catch {
+        // column already removed – nothing to migrate
+    }
 
     console.log(
         `Found ${existingUserInviteRoles.length} existing userInvites role assignment(s) to migrate`
@@ -105,7 +124,7 @@ export default async function migration() {
             );
         `);
         await db.execute(
-            sql`ALTER TABLE "userOrgs" DROP CONSTRAINT "userOrgs_roleId_roles_roleId_fk";`
+            sql`ALTER TABLE "userOrgs" DROP CONSTRAINT IF EXISTS "userOrgs_roleId_roles_roleId_fk";`
         );
         await db.execute(
             sql`ALTER TABLE "userOrgRoles" ADD CONSTRAINT "userOrgRoles_userId_user_id_fk" FOREIGN KEY ("userId") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;`
@@ -116,10 +135,10 @@ export default async function migration() {
         await db.execute(
             sql`ALTER TABLE "userOrgRoles" ADD CONSTRAINT "userOrgRoles_roleId_roles_roleId_fk" FOREIGN KEY ("roleId") REFERENCES "public"."roles"("roleId") ON DELETE cascade ON UPDATE no action;`
         );
-        await db.execute(sql`ALTER TABLE "userOrgs" DROP COLUMN "roleId";`);
+        await db.execute(sql`ALTER TABLE "userOrgs" DROP COLUMN IF EXISTS "roleId";`);
 
         await db.execute(
-            sql`ALTER TABLE "userInvites" DROP CONSTRAINT "userInvites_roleId_roles_roleId_fk";`
+            sql`ALTER TABLE "userInvites" DROP CONSTRAINT IF EXISTS "userInvites_roleId_roles_roleId_fk";`
         );
         await db.execute(
             sql`ALTER TABLE "accessAuditLog" ADD COLUMN "siteResourceId" integer;`
@@ -176,7 +195,7 @@ export default async function migration() {
         await db.execute(
             sql`CREATE INDEX "idx_accessAuditLog_siteResourceId" ON "connectionAuditLog" USING btree ("siteResourceId");`
         );
-        await db.execute(sql`ALTER TABLE "userInvites" DROP COLUMN "roleId";`);
+        await db.execute(sql`ALTER TABLE "userInvites" DROP COLUMN IF EXISTS "roleId";`);
         await db.execute(sql`ALTER TABLE "siteProvisioningKeys" ADD COLUMN "approveNewSites" boolean DEFAULT true NOT NULL;`);
         await db.execute(sql`ALTER TABLE "sites" ADD COLUMN "status" varchar DEFAULT 'approved';`);
 

--- a/server/setup/scriptsSqlite/1.17.0.ts
+++ b/server/setup/scriptsSqlite/1.17.0.ts
@@ -13,23 +13,50 @@ export default async function migration() {
     try {
         db.pragma("foreign_keys = OFF");
 
-        // Query existing roleId data from userOrgs before the transaction destroys it
-        const existingUserOrgRoles = db
-            .prepare(
-                `SELECT "userId", "orgId", "roleId" FROM 'userOrgs' WHERE "roleId" IS NOT NULL`
-            )
-            .all() as { userId: string; orgId: string; roleId: number }[];
+        // Check whether the legacy roleId column still exists before querying it.
+        // When upgrading from an RC whose initial schema already omitted roleId the
+        // column will be absent and an unconditional SELECT would crash immediately.
+        const userOrgsColumns = db
+            .prepare(`PRAGMA table_info('userOrgs')`)
+            .all() as { name: string }[];
+        const userOrgsHasRoleId = userOrgsColumns.some(
+            (col) => col.name === "roleId"
+        );
+
+        const existingUserOrgRoles: {
+            userId: string;
+            orgId: string;
+            roleId: number;
+        }[] = userOrgsHasRoleId
+            ? (db
+                  .prepare(
+                      `SELECT "userId", "orgId", "roleId" FROM 'userOrgs' WHERE "roleId" IS NOT NULL`
+                  )
+                  .all() as { userId: string; orgId: string; roleId: number }[])
+            : [];
 
         console.log(
             `Found ${existingUserOrgRoles.length} existing userOrgs role assignment(s) to migrate`
         );
 
+        const userInvitesColumns = db
+            .prepare(`PRAGMA table_info('userInvites')`)
+            .all() as { name: string }[];
+        const userInvitesHasRoleId = userInvitesColumns.some(
+            (col) => col.name === "roleId"
+        );
+
         // Query existing roleId data from userInvites before the transaction destroys it
-        const existingUserInviteRoles = db
-            .prepare(
-                `SELECT "inviteId", "roleId" FROM 'userInvites' WHERE "roleId" IS NOT NULL`
-            )
-            .all() as { inviteId: string; roleId: number }[];
+        const existingUserInviteRoles: {
+            inviteId: string;
+            roleId: number;
+        }[] = userInvitesHasRoleId
+            ? (db
+                  .prepare(
+                      `SELECT "inviteId", "roleId" FROM 'userInvites' WHERE "roleId" IS NOT NULL`
+                  )
+                  .all() as { inviteId: string; roleId: number }[])
+            : [];
 
         console.log(
             `Found ${existingUserInviteRoles.length} existing userInvites role assignment(s) to migrate`
@@ -109,7 +136,7 @@ export default async function migration() {
 
             db.prepare(
                 `
-                CREATE TABLE 'userOrgRoles' (
+                CREATE TABLE IF NOT EXISTS 'userOrgRoles' (
                    	'userId' text NOT NULL,
                    	'orgId' text NOT NULL,
                    	'roleId' integer NOT NULL,
@@ -121,9 +148,10 @@ export default async function migration() {
             ).run();
 
             db.prepare(
-                `CREATE UNIQUE INDEX 'userOrgRoles_userId_orgId_roleId_unique' ON 'userOrgRoles' ('userId','orgId','roleId');`
+                `CREATE UNIQUE INDEX IF NOT EXISTS 'userOrgRoles_userId_orgId_roleId_unique' ON 'userOrgRoles' ('userId','orgId','roleId');`
             ).run();
 
+            db.prepare(`DROP TABLE IF EXISTS '__new_userOrgs';`).run();
             db.prepare(
                 `
                 CREATE TABLE '__new_userOrgs' (
@@ -147,7 +175,7 @@ export default async function migration() {
             ).run();
             db.prepare(
                 `
-                CREATE TABLE 'userInviteRoles' (
+                CREATE TABLE IF NOT EXISTS 'userInviteRoles' (
                    	'inviteId' text NOT NULL,
                    	'roleId' integer NOT NULL,
                    	PRIMARY KEY('inviteId', 'roleId'),
@@ -156,6 +184,7 @@ export default async function migration() {
                 );
             `
             ).run();
+            db.prepare(`DROP TABLE IF EXISTS '__new_userInvites';`).run();
             db.prepare(
                 `
                 CREATE TABLE '__new_userInvites' (


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description (generated by Copilot)

This pull request improves the robustness and idempotency of the 1.17.0 database migration scripts for both PostgreSQL and SQLite backends. The changes ensure that migrations can be safely run on databases that may already have some schema changes applied (such as from release candidate upgrades), preventing crashes and errors due to missing columns or constraints.

**PostgreSQL migration script improvements (`server/setup/scriptsPg/1.17.0.ts`):**

* Added guards when querying `roleId` columns from `userOrgs` and `userInvites` to handle cases where the columns may have already been removed, preventing migration failures on partially-upgraded schemas.
* Changed `DROP CONSTRAINT` and `DROP COLUMN` statements to use `IF EXISTS`, making the migration idempotent and preventing errors if the constraints or columns are already absent. [[1]](diffhunk://#diff-a329ba1abb0c9766012185262aefb8f56a6e6bc9a4119a66a74995a9008d2550L108-R127) [[2]](diffhunk://#diff-a329ba1abb0c9766012185262aefb8f56a6e6bc9a4119a66a74995a9008d2550L119-R141) [[3]](diffhunk://#diff-a329ba1abb0c9766012185262aefb8f56a6e6bc9a4119a66a74995a9008d2550L179-R198)

**SQLite migration script improvements (`server/setup/scriptsSqlite/1.17.0.ts`):**

* Checked for the existence of `roleId` columns in `userOrgs` and `userInvites` tables before querying, ensuring migrations work even if those columns were already dropped in previous upgrades.
* Used `CREATE TABLE IF NOT EXISTS` and `CREATE UNIQUE INDEX IF NOT EXISTS` for new tables and indexes to avoid errors if the migration is re-run. [[1]](diffhunk://#diff-db717df51f45b096d2c284f5c3c4563878c122a0b64af0bb4f71877e7aeb65faL112-R139) [[2]](diffhunk://#diff-db717df51f45b096d2c284f5c3c4563878c122a0b64af0bb4f71877e7aeb65faL124-R154) [[3]](diffhunk://#diff-db717df51f45b096d2c284f5c3c4563878c122a0b64af0bb4f71877e7aeb65faL150-R178)
* Added `DROP TABLE IF EXISTS` statements before creating temporary tables to ensure a clean migration state. [[1]](diffhunk://#diff-db717df51f45b096d2c284f5c3c4563878c122a0b64af0bb4f71877e7aeb65faL124-R154) [[2]](diffhunk://#diff-db717df51f45b096d2c284f5c3c4563878c122a0b64af0bb4f71877e7aeb65faR187)

## How to test?

Run Migration