### PR TITLE
fix: use targetId as row identifier

### DIFF
--- a/src/app/[orgId]/settings/resources/proxy/[niceId]/proxy/page.tsx
+++ b/src/app/[orgId]/settings/resources/proxy/[niceId]/proxy/page.tsx
@@ -678,6 +678,7 @@ function ProxyResourceTargetsForm({
         getPaginationRowModel: getPaginationRowModel(),
         getSortedRowModel: getSortedRowModel(),
         getFilteredRowModel: getFilteredRowModel(),
+        getRowId: (row) => String(row.targetId),
         state: {
             pagination: {
                 pageIndex: 0,

--- a/src/app/[orgId]/settings/resources/proxy/create/page.tsx
+++ b/src/app/[orgId]/settings/resources/proxy/create/page.tsx
@@ -999,6 +999,7 @@ export default function Page() {
         getPaginationRowModel: getPaginationRowModel(),
         getSortedRowModel: getSortedRowModel(),
         getFilteredRowModel: getFilteredRowModel(),
+        getRowId: (row) => String(row.targetId),
         state: {
             pagination: {
                 pageIndex: 0,


### PR DESCRIPTION
fix: #2797

## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description

When no `getRowId` function is provided it uses the index of the array for the tanstack table. This causes render issues and causes the problem outline in #2797.

## How to test?

Well this is the odd thing, I couldnt replicate the issue by creating 3 targets from the same site, I had to create 3 sites as the user had to replicate the "site" being the data point shown in the dashboard. However, I think the correct ID is being deleted but since the data is deep nested react is not updating correctly on screen.