### PR TITLE
fix: use targetId as row identifier

### DIFF
--- a/src/app/[orgId]/settings/resources/proxy/[niceId]/proxy/page.tsx
+++ b/src/app/[orgId]/settings/resources/proxy/[niceId]/proxy/page.tsx
@@ -678,6 +678,7 @@ function ProxyResourceTargetsForm({
         getPaginationRowModel: getPaginationRowModel(),
         getSortedRowModel: getSortedRowModel(),
         getFilteredRowModel: getFilteredRowModel(),
+        getRowId: (row) => String(row.targetId),
         state: {
             pagination: {
                 pageIndex: 0,

--- a/src/app/[orgId]/settings/resources/proxy/create/page.tsx
+++ b/src/app/[orgId]/settings/resources/proxy/create/page.tsx
@@ -999,6 +999,7 @@ export default function Page() {
         getPaginationRowModel: getPaginationRowModel(),
         getSortedRowModel: getSortedRowModel(),
         getFilteredRowModel: getFilteredRowModel(),
+        getRowId: (row) => String(row.targetId),
         state: {
             pagination: {
                 pageIndex: 0,


### PR DESCRIPTION
fix: #2797

## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description

When no `getRowId` function is provided it uses the index of the array for the tanstack table. This causes render issues if the data is nested and causes the problem outline in #2797.

## How to test?

What is odd is that I could not reproduce the issue by creating three targets under the same site. To match the user's setup, I had to create three separate sites, since the dashboard uses the site itself as the data point being displayed.

From what I can see, the correct ID does appear to be deleted. The issue seems to be with the UI not updating properly afterward, likely because the data passed into the render is deeply nested and React is not re-rendering that state correctly.

closed #2798 because pointed to wrong branch 🤦🏻 