### PR TITLE
Fix invite email encoding

### DIFF
--- a/server/routers/user/inviteUser.ts
+++ b/server/routers/user/inviteUser.ts
@@ -1,7 +1,14 @@
 import { Request, Response, NextFunction } from "express";
 import { z } from "zod";
 import { db } from "@server/db";
-import { orgs, roles, userInviteRoles, userInvites, userOrgs, users } from "@server/db";
+import {
+    orgs,
+    roles,
+    userInviteRoles,
+    userInvites,
+    userOrgs,
+    users
+} from "@server/db";
 import { and, eq, inArray } from "drizzle-orm";
 import response from "@server/lib/response";
 import HttpCode from "@server/types/HttpCode";
@@ -37,8 +44,7 @@ const inviteUserBodySchema = z
         regenerate: z.boolean().optional()
     })
     .refine(
-        (d) =>
-            (d.roleIds != null && d.roleIds.length > 0) || d.roleId != null,
+        (d) => (d.roleIds != null && d.roleIds.length > 0) || d.roleId != null,
         { message: "roleIds or roleId is required", path: ["roleIds"] }
     )
     .transform((data) => ({
@@ -265,7 +271,7 @@ export async function inviteUser(
                     )
                 );
 
-            const inviteLink = `${config.getRawConfig().app.dashboard_url}/invite?token=${inviteId}-${token}&email=${encodeURIComponent(email)}`;
+            const inviteLink = `${config.getRawConfig().app.dashboard_url}/invite?token=${inviteId}-${token}&email=${email}`;
 
             if (doEmail) {
                 await sendEmail(
@@ -314,12 +320,12 @@ export async function inviteUser(
                 expiresAt,
                 tokenHash
             });
-            await trx.insert(userInviteRoles).values(
-                uniqueRoleIds.map((roleId) => ({ inviteId, roleId }))
-            );
+            await trx
+                .insert(userInviteRoles)
+                .values(uniqueRoleIds.map((roleId) => ({ inviteId, roleId })));
         });
 
-        const inviteLink = `${config.getRawConfig().app.dashboard_url}/invite?token=${inviteId}-${token}&email=${encodeURIComponent(email)}`;
+        const inviteLink = `${config.getRawConfig().app.dashboard_url}/invite?token=${inviteId}-${token}&email=${email}`;
 
         if (doEmail) {
             await sendEmail(

--- a/src/components/InviteStatusCard.tsx
+++ b/src/components/InviteStatusCard.tsx
@@ -39,7 +39,11 @@ export default function InviteStatusCard({
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState("");
     const [type, setType] = useState<
-        "rejected" | "wrong_user" | "user_does_not_exist" | "not_logged_in" | "user_limit_exceeded"
+        | "rejected"
+        | "wrong_user"
+        | "user_does_not_exist"
+        | "not_logged_in"
+        | "user_limit_exceeded"
     >("rejected");
 
     useEffect(() => {
@@ -90,12 +94,12 @@ export default function InviteStatusCard({
 
             if (!user && type === "user_does_not_exist") {
                 const redirectUrl = email
-                    ? `/auth/signup?redirect=/invite?token=${tokenParam}&email=${encodeURIComponent(email)}`
+                    ? `/auth/signup?redirect=/invite?token=${tokenParam}&email=${email}`
                     : `/auth/signup?redirect=/invite?token=${tokenParam}`;
                 router.push(redirectUrl);
             } else if (!user && type === "not_logged_in") {
                 const redirectUrl = email
-                    ? `/auth/login?redirect=/invite?token=${tokenParam}&email=${encodeURIComponent(email)}`
+                    ? `/auth/login?redirect=/invite?token=${tokenParam}&email=${email}`
                     : `/auth/login?redirect=/invite?token=${tokenParam}`;
                 router.push(redirectUrl);
             } else {
@@ -109,7 +113,7 @@ export default function InviteStatusCard({
     async function goToLogin() {
         await api.post("/auth/logout", {});
         const redirectUrl = email
-            ? `/auth/login?redirect=/invite?token=${tokenParam}&email=${encodeURIComponent(email)}`
+            ? `/auth/login?redirect=/invite?token=${tokenParam}&email=${email}`
             : `/auth/login?redirect=/invite?token=${tokenParam}`;
         router.push(redirectUrl);
     }
@@ -117,7 +121,7 @@ export default function InviteStatusCard({
     async function goToSignup() {
         await api.post("/auth/logout", {});
         const redirectUrl = email
-            ? `/auth/signup?redirect=/invite?token=${tokenParam}&email=${encodeURIComponent(email)}`
+            ? `/auth/signup?redirect=/invite?token=${tokenParam}&email=${email}`
             : `/auth/signup?redirect=/invite?token=${tokenParam}`;
         router.push(redirectUrl);
     }
@@ -157,7 +161,9 @@ export default function InviteStatusCard({
                         Cannot Accept Invite
                     </p>
                     <p className="text-center text-sm">
-                        This organization has reached its user limit. Please contact the organization administrator to upgrade their plan before accepting this invite.
+                        This organization has reached its user limit. Please
+                        contact the organization administrator to upgrade their
+                        plan before accepting this invite.
                     </p>
                 </div>
             );


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description
Invite links fail email validation due to encoding error.

## How to test?
When sending an invite link to john.doe@domain.com the URI encoding converts the @ symbol to %40 resulting in the sign-up form failing validation on an active email address.

Cypress E2E testing added for validation/verification.

<img width="640" height="791" alt="sign-in-bug" src="https://github.com/user-attachments/assets/79ca7872-08f4-4186-87a3-0b74fd6d6f14" />
