### PR TITLE
fix: support chunked Docker container messages from newt

### DIFF
--- a/server/routers/newt/handleSocketMessages.ts
+++ b/server/routers/newt/handleSocketMessages.ts
@@ -33,8 +33,15 @@ export const handleDockerStatusMessage: MessageHandler = async (context) => {
     return;
 };
 
+interface ChunkAccumulator {
+    batchId: string;
+    totalChunks: number;
+    receivedChunks: number;
+    containers: any[];
+}
+
 /**
- * Get the cache key for storing in-progress chunked container data.
+ * Cache key for in-progress chunked container data, scoped by newt and batch.
  */
 function getChunkCacheKey(newtId: string): string {
     return `${newtId}:dockerContainersChunks`;
@@ -80,7 +87,7 @@ export const handleDockerContainersMessage: MessageHandler = async (
     }
 
     logger.info(`Newt ID: ${newt.newtId}, Site ID: ${newt.siteId}`);
-    const { containers, chunkIndex, totalChunks } = message.data;
+    const { containers, chunkIndex, totalChunks, batchId } = message.data;
 
     // Non-chunked message (backward compatible with older newt versions)
     if (totalChunks === undefined || totalChunks <= 1) {
@@ -92,41 +99,71 @@ export const handleDockerContainersMessage: MessageHandler = async (
         return;
     }
 
-    // Chunked message — accumulate chunks in cache then process when complete
+    // Validate chunk metadata
+    if (
+        typeof chunkIndex !== "number" ||
+        typeof totalChunks !== "number" ||
+        chunkIndex < 0 ||
+        chunkIndex >= totalChunks ||
+        totalChunks > 100
+    ) {
+        logger.warn(
+            `Invalid chunk metadata from Newt ${newt.newtId}: chunkIndex=${chunkIndex}, totalChunks=${totalChunks}`
+        );
+        return;
+    }
+
+    if (!batchId || typeof batchId !== "string") {
+        logger.warn(
+            `Missing batchId in chunked message from Newt ${newt.newtId}`
+        );
+        return;
+    }
+
     logger.info(
-        `Received chunk ${chunkIndex + 1}/${totalChunks} for Newt ${newt.newtId} (${containers?.length || 0} containers in this chunk)`
+        `Received chunk ${chunkIndex + 1}/${totalChunks} for Newt ${newt.newtId} batch=${batchId} (${containers?.length || 0} containers)`
     );
 
     const chunkKey = getChunkCacheKey(newt.newtId);
-    const existing =
-        (await cache.get<{ receivedChunks: number; containers: any[] }>(
-            chunkKey
-        )) || { receivedChunks: 0, containers: [] };
+    const existing = await cache.get<ChunkAccumulator>(chunkKey);
 
-    if (chunkIndex === 0) {
-        // First chunk — reset accumulator
-        existing.receivedChunks = 0;
-        existing.containers = [];
+    let accumulator: ChunkAccumulator;
+
+    if (!existing || existing.batchId !== batchId) {
+        // New batch or different batch — start fresh
+        // This handles concurrent sends: the newer batch supersedes the old one
+        if (existing && existing.batchId !== batchId) {
+            logger.info(
+                `New batch ${batchId} supersedes in-progress batch ${existing.batchId} for Newt ${newt.newtId}`
+            );
+        }
+        accumulator = {
+            batchId,
+            totalChunks,
+            receivedChunks: 0,
+            containers: []
+        };
+    } else {
+        accumulator = existing;
     }
 
-    if (containers && containers.length > 0) {
-        existing.containers.push(...containers);
+    if (containers && Array.isArray(containers)) {
+        accumulator.containers.push(...containers);
     }
-    existing.receivedChunks++;
+    accumulator.receivedChunks++;
 
-    if (existing.receivedChunks >= totalChunks) {
-        // All chunks received — process the complete list
+    if (accumulator.receivedChunks >= accumulator.totalChunks) {
         logger.info(
-            `All ${totalChunks} chunks received for Newt ${newt.newtId}, total containers: ${existing.containers.length}`
+            `All ${totalChunks} chunks received for Newt ${newt.newtId} batch=${batchId}, total containers: ${accumulator.containers.length}`
         );
         await cache.del(chunkKey);
         await processContainerList(
             newt.newtId,
             newt.siteId,
-            existing.containers
+            accumulator.containers
         );
     } else {
-        // Store partial data with a TTL so stale chunks don't accumulate forever
-        await cache.set(chunkKey, existing, 120);
+        // Store partial data with a TTL to prevent stale chunks from accumulating
+        await cache.set(chunkKey, accumulator, 120);
     }
 };

--- a/server/routers/newt/handleSocketMessages.ts
+++ b/server/routers/newt/handleSocketMessages.ts
@@ -33,6 +33,39 @@ export const handleDockerStatusMessage: MessageHandler = async (context) => {
     return;
 };
 
+/**
+ * Get the cache key for storing in-progress chunked container data.
+ */
+function getChunkCacheKey(newtId: string): string {
+    return `${newtId}:dockerContainersChunks`;
+}
+
+/**
+ * Process a complete container list (either received all at once or after reassembly).
+ */
+async function processContainerList(
+    newtId: string,
+    siteId: number | null,
+    containers: any[]
+) {
+    logger.info(
+        `Docker containers for Newt ${newtId}: ${containers.length}`
+    );
+
+    if (containers.length > 0) {
+        await cache.set(`${newtId}:dockerContainers`, containers, 0);
+    } else {
+        logger.warn(`Newt ${newtId} does not have Docker containers`);
+    }
+
+    if (!siteId) {
+        logger.warn("Newt has no site!");
+        return;
+    }
+
+    await applyNewtDockerBlueprint(siteId, newtId, containers);
+}
+
 export const handleDockerContainersMessage: MessageHandler = async (
     context
 ) => {
@@ -47,22 +80,53 @@ export const handleDockerContainersMessage: MessageHandler = async (
     }
 
     logger.info(`Newt ID: ${newt.newtId}, Site ID: ${newt.siteId}`);
-    const { containers } = message.data;
+    const { containers, chunkIndex, totalChunks } = message.data;
 
-    logger.info(
-        `Docker containers for Newt ${newt.newtId}: ${containers ? containers.length : 0}`
-    );
-
-    if (containers && containers.length > 0) {
-        await cache.set(`${newt.newtId}:dockerContainers`, containers, 0);
-    } else {
-        logger.warn(`Newt ${newt.newtId} does not have Docker containers`);
-    }
-
-    if (!newt.siteId) {
-        logger.warn("Newt has no site!");
+    // Non-chunked message (backward compatible with older newt versions)
+    if (totalChunks === undefined || totalChunks <= 1) {
+        await processContainerList(
+            newt.newtId,
+            newt.siteId,
+            containers || []
+        );
         return;
     }
 
-    await applyNewtDockerBlueprint(newt.siteId, newt.newtId, containers);
+    // Chunked message — accumulate chunks in cache then process when complete
+    logger.info(
+        `Received chunk ${chunkIndex + 1}/${totalChunks} for Newt ${newt.newtId} (${containers?.length || 0} containers in this chunk)`
+    );
+
+    const chunkKey = getChunkCacheKey(newt.newtId);
+    const existing =
+        (await cache.get<{ receivedChunks: number; containers: any[] }>(
+            chunkKey
+        )) || { receivedChunks: 0, containers: [] };
+
+    if (chunkIndex === 0) {
+        // First chunk — reset accumulator
+        existing.receivedChunks = 0;
+        existing.containers = [];
+    }
+
+    if (containers && containers.length > 0) {
+        existing.containers.push(...containers);
+    }
+    existing.receivedChunks++;
+
+    if (existing.receivedChunks >= totalChunks) {
+        // All chunks received — process the complete list
+        logger.info(
+            `All ${totalChunks} chunks received for Newt ${newt.newtId}, total containers: ${existing.containers.length}`
+        );
+        await cache.del(chunkKey);
+        await processContainerList(
+            newt.newtId,
+            newt.siteId,
+            existing.containers
+        );
+    } else {
+        // Store partial data with a TTL so stale chunks don't accumulate forever
+        await cache.set(chunkKey, existing, 120);
+    }
 };


### PR DESCRIPTION
## What does this PR do?

Fixes #2117

When more than ~20 Docker containers are running, the WebSocket message containing the full container list can exceed frame/buffer limits imposed by intermediary proxies (Traefik, nginx, Cloudflare tunnels, etc.), causing the Docker Container View in Pangolin to show nothing — even though newt successfully sends the data.

## Root cause analysis

The issue is **not** in the `ws` library or `node-cache` — both handle large payloads fine. The problem is the network path between newt and pangolin:

```
newt (Go) → gorilla/websocket → [Traefik / reverse proxy] → ws (Node.js) → pangolin
```

`gorilla/websocket.WriteJSON` serializes the full container list (55+ containers × 1-5KB each = 55-275KB) into a single WebSocket text frame. When this frame passes through Traefik or another reverse proxy, it can be:
- **Silently truncated** — proxy buffers the frame, hits an internal limit, drops it
- **Connection reset** — proxy closes the connection on oversized frame
- **Corrupted** — partial frame arrives, `JSON.parse` fails silently in the `try/catch`

The user's logs confirm this: pangolin logged `Docker containers for Newt: 55` on one occasion but the container view was empty — meaning the cache write at line 57 either never executed or the data was already corrupted by that point.

## Solution: chunked message protocol

### Protocol design

```
┌─────────┐                              ┌──────────┐
│  newt    │                              │ pangolin │
│  (Go)   │                              │  (TS)    │
└────┬────┘                              └────┬─────┘
     │  ≤15 containers: single message        │
     │──────────────────────────────────────>│  (backward compatible)
     │                                        │
     │  >15 containers: chunked               │
     │  chunk 0/4 (batch=a1b2c3)             │
     │──────────────────────────────────────>│  accumulate in cache
     │  chunk 1/4 (batch=a1b2c3)             │
     │──────────────────────────────────────>│  accumulate
     │  chunk 2/4 (batch=a1b2c3)             │
     │──────────────────────────────────────>│  accumulate
     │  chunk 3/4 (batch=a1b2c3)             │
     │──────────────────────────────────────>│  all chunks received → process
     │                                        │
```

Each chunk message has the same type (`newt/socket/containers`) with additional fields:

```json
{
  "containers": [...],       // subset of containers for this chunk
  "chunkIndex": 0,           // 0-based index of this chunk
  "totalChunks": 4,          // total number of chunks in this batch
  "batchId": "a1b2c3d4"     // unique ID for this batch
}
```

### Why `batchId`?

Without it, two concurrent sends (e.g., a manual fetch + a Docker event) would interleave chunks and corrupt the accumulated data. The `batchId` ensures:
- Each batch is tracked independently
- A newer batch automatically supersedes any in-progress older batch
- No silent data corruption from race conditions

### Why chunk size of 15?

Each Docker container with full metadata (labels, ports, networks, env) serializes to 1-5KB of JSON. 15 containers ≈ 15-75KB per message — well within typical proxy frame limits (most default to 64KB-1MB). The threshold of 15 was chosen to stay safely under common defaults while minimizing the number of round trips.

## Changes in this PR (pangolin server)

**`server/routers/newt/handleSocketMessages.ts`**:

- `ChunkAccumulator` typed interface for cache data (replaces inline object)
- Non-chunked messages pass through unchanged (backward compatible with older newt)
- Validates `chunkIndex`, `totalChunks`, `batchId` before processing — rejects malformed chunks
- Accumulates chunks in cache keyed by `{newtId}:dockerContainersChunks`
- New `batchId` supersedes any in-progress batch (handles concurrent sends)
- 120s TTL on partial chunks prevents stale data accumulation
- Processes complete list only after all chunks arrive

## Companion PR

**Newt (Go):** https://github.com/fosrl/newt/pull/304
- `sendContainerList()` helper splits lists >15 into chunks with `batchId`
- Small lists (≤15) sent as single message — zero behavior change for most users
- `go build` passes cleanly