### PR TITLE
fix(analytics): prevent countries from getting stuck highlighted on world map

### DIFF
--- a/src/components/WorldMap.tsx
+++ b/src/components/WorldMap.tsx
@@ -164,7 +164,7 @@ const countryClass = cn(
 
 const highlightedCountryClass = cn(
     sharedCountryClass,
-    "stroke-2",
+    "stroke-[3]",
     "fill-[#f4f4f5]",
     "stroke-[#f36117]",
     "dark:fill-[#3f3f46]"
@@ -194,11 +194,20 @@ function drawInteractiveCountries(
     const path = setupProjetionPath();
     const data = parseWorldTopoJsonToGeoJsonFeatures();
     const svg = d3.select(element);
+    const countriesLayer = svg.append("g");
+    const hoverLayer = svg.append("g").style("pointer-events", "none");
+    const hoverPath = hoverLayer
+        .append("path")
+        .datum(null)
+        .attr("class", highlightedCountryClass)
+        .style("display", "none");
 
-    svg.selectAll("path")
+    countriesLayer
+        .selectAll("path")
         .data(data)
         .enter()
         .append("path")
+        .attr("data-country-path", "true")
         .attr("class", countryClass)
         .attr("d", path as never)
 
@@ -209,9 +218,10 @@ function drawInteractiveCountries(
                 y,
                 hoveredCountryAlpha3Code: country.properties.a3
             });
-            // brings country to front
-            this.parentNode?.appendChild(this);
-            d3.select(this).attr("class", highlightedCountryClass);
+            hoverPath
+                .datum(country)
+                .attr("d", path(country) as string)
+                .style("display", null);
         })
 
         .on("mousemove", function (event) {
@@ -221,7 +231,7 @@ function drawInteractiveCountries(
 
         .on("mouseout", function () {
             setTooltip({ x: 0, y: 0, hoveredCountryAlpha3Code: null });
-            d3.select(this).attr("class", countryClass);
+            hoverPath.style("display", "none");
         });
 
     return svg;
@@ -257,7 +267,7 @@ function colorInCountriesWithValues(
     const svg = d3.select(element);
 
     return svg
-        .selectAll("path")
+        .selectAll('path[data-country-path="true"]')
         .style("fill", (countryPath) => {
             const country = getCountryByCountryPath(countryPath);
             if (!country?.count) {


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description
This fixes an issue on the analytics world map where hovered countries could remain highlighted after the cursor moved away.

I was able to reproduce this on the analytics page and traced it back to the hover implementation in `WorldMap.tsx`.

Before:

https://github.com/user-attachments/assets/268c63d3-9784-43e2-bde9-e8cfd4778e06

After applying this fix:

https://github.com/user-attachments/assets/e7a5ba94-2e49-4fe9-b019-dac927079dac


## Cause

The previous implementation moved the hovered SVG country path to the end of the DOM during hover so it would render on top of neighboring countries.

That helped visually, but it also seems to interfere with hover cleanup in some cases, which can leave countries stuck in the highlighted state.

## Fix

Instead of reordering the original country node during hover, this change renders the hovered country in a separate overlay path above the base map layer.

This keeps the hovered country visually on top while avoiding the sticky hover behavior.


## How to test?
This can be tested by navigating to the `/{orgId}/settings/logs/analytics` and interacting with the map on the bottom of the screen.
