### PR TITLE
fix(worldmap): correct topojson feature typing

### DIFF
--- a/src/components/WorldMap.tsx
+++ b/src/components/WorldMap.tsx
@@ -237,7 +237,7 @@ function drawInteractiveCountries(
     return svg;
 }
 
-type WorldJsonCountryData = { properties: { name: string; a3: string } };
+type WorldJsonCountryData = d3.ExtendedFeature<d3.GeoGeometryObjects | null, { name: string; a3: string }>;
 
 function parseWorldTopoJsonToGeoJsonFeatures(): Array<WorldJsonCountryData> {
     const collection = topojson.feature(


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Summary
This is a small follow-up to my previously merged world map hover fix: [#2825](https://github.com/fosrl/pangolin/pull/2825).

That earlier change fixed the stuck hover state on the analytics map, but it also introduced a TypeScript error. This PR corrects that typing so the fix passes TypeScript cleanly as well.

There is no intended behavior change here. This is just a typing fix for the already-merged hover-state change that I should have included in the original PR. Sorry about that.

## How to test?
`npm run dev:check`