### PR TITLE
Feature/local resource healthchecks

### DIFF
--- a/server/routers/target/index.ts
+++ b/server/routers/target/index.ts
@@ -4,3 +4,4 @@ export * from "./deleteTarget";
 export * from "./updateTarget";
 export * from "./listTargets";
 export * from "./handleHealthcheckStatusMessage";
+export * from "./localHealthChecker";

--- a/server/routers/target/localHealthChecker.ts
+++ b/server/routers/target/localHealthChecker.ts
@@ -1,0 +1,349 @@
+import { db, primaryDb, sites, targetHealthCheck, targets } from "@server/db";
+import logger from "@server/logger";
+import { and, eq, inArray } from "drizzle-orm";
+import {
+    fireHealthCheckHealthyAlert,
+    fireHealthCheckUnhealthyAlert
+} from "#dynamic/lib/alerts";
+import * as net from "net";
+
+// Local healthcheck pollers run server-side for sites of type "local",
+// because there is no Newt agent on the remote side to perform the probes.
+// We re-use the targetHealthCheck table and the same alert helpers used by
+// the Newt-driven flow so the rest of the system (UI, alerts, history) is
+// unchanged.
+
+const LOCAL_HC_TICK_MS = 5 * 1000; // re-evaluate which checks are due every 5s
+const DEFAULT_INTERVAL_S = 30;
+const DEFAULT_TIMEOUT_S = 5;
+
+let localHealthCheckerInterval: NodeJS.Timeout | null = null;
+
+// In-memory state for each local healthcheck so we can implement
+// healthy / unhealthy thresholds and per-check intervals without hammering
+// the database with extra columns.
+type RunState = {
+    nextRunAtMs: number;
+    consecutiveHealthy: number;
+    consecutiveUnhealthy: number;
+    lastStatus: "unknown" | "healthy" | "unhealthy";
+    inFlight: boolean;
+};
+
+const runState = new Map<number, RunState>();
+
+function parseHcHeaders(raw: string | null | undefined): Record<string, string> {
+    if (!raw) return {};
+    try {
+        const parsed = JSON.parse(raw);
+        if (Array.isArray(parsed)) {
+            const out: Record<string, string> = {};
+            for (const h of parsed) {
+                if (h && typeof h.name === "string") {
+                    out[h.name] = String(h.value ?? "");
+                }
+            }
+            return out;
+        }
+        if (parsed && typeof parsed === "object") {
+            return parsed as Record<string, string>;
+        }
+    } catch (e) {
+        logger.warn(
+            `Failed to parse healthcheck headers, ignoring: ${(e as Error).message}`
+        );
+    }
+    return {};
+}
+
+async function probeHttp(
+    hc: typeof targetHealthCheck.$inferSelect,
+    hostname: string,
+    port: number
+): Promise<{ ok: boolean; error?: string }> {
+    const scheme =
+        (hc.hcScheme || "http").toLowerCase() === "https" ? "https" : "http";
+    const path = hc.hcPath?.startsWith("/") ? hc.hcPath : `/${hc.hcPath || ""}`;
+    const url = `${scheme}://${hostname}:${port}${path}`;
+    const method = (hc.hcMethod || "GET").toUpperCase();
+    const timeoutMs = (hc.hcTimeout || DEFAULT_TIMEOUT_S) * 1000;
+    const headers = parseHcHeaders(hc.hcHeaders);
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+        // Allow self-signed certs via undici's built-in by relying on
+        // NODE_TLS_REJECT_UNAUTHORIZED if the operator sets it; otherwise
+        // honour the system trust store. For TLS server name we fall back
+        // to the URL hostname.
+        const res = await fetch(url, {
+            method,
+            headers,
+            redirect: hc.hcFollowRedirects === false ? "manual" : "follow",
+            signal: controller.signal
+        });
+
+        const expected = hc.hcStatus;
+        if (expected != null) {
+            if (res.status === expected) return { ok: true };
+            return {
+                ok: false,
+                error: `unexpected status ${res.status}, expected ${expected}`
+            };
+        }
+        // Default: any 2xx is healthy
+        if (res.status >= 200 && res.status < 300) return { ok: true };
+        return { ok: false, error: `non-2xx status ${res.status}` };
+    } catch (err) {
+        const msg =
+            err instanceof Error
+                ? err.name === "AbortError"
+                    ? `timeout after ${timeoutMs}ms`
+                    : err.message
+                : String(err);
+        return { ok: false, error: msg };
+    } finally {
+        clearTimeout(timer);
+    }
+}
+
+async function probeTcp(
+    hostname: string,
+    port: number,
+    timeoutS: number
+): Promise<{ ok: boolean; error?: string }> {
+    const timeoutMs = (timeoutS || DEFAULT_TIMEOUT_S) * 1000;
+    return new Promise((resolve) => {
+        const socket = new net.Socket();
+        let settled = false;
+        const finish = (ok: boolean, error?: string) => {
+            if (settled) return;
+            settled = true;
+            try {
+                socket.destroy();
+            } catch {}
+            resolve({ ok, error });
+        };
+        socket.setTimeout(timeoutMs);
+        socket.once("connect", () => finish(true));
+        socket.once("timeout", () => finish(false, `timeout after ${timeoutMs}ms`));
+        socket.once("error", (err) => finish(false, err.message));
+        try {
+            socket.connect(port, hostname);
+        } catch (err) {
+            finish(false, (err as Error).message);
+        }
+    });
+}
+
+async function runOneCheck(
+    hc: typeof targetHealthCheck.$inferSelect & { targetIp: string | null; targetPort: number | null }
+): Promise<void> {
+    const state = runState.get(hc.targetHealthCheckId)!;
+    if (state.inFlight) return;
+    state.inFlight = true;
+
+    try {
+        // Resolve hostname/port: explicit hc fields win, otherwise fall back
+        // to the target's ip/port so users don't have to duplicate them.
+        const hostname = hc.hcHostname || hc.targetIp;
+        const port = hc.hcPort || hc.targetPort;
+        const mode = (hc.hcMode || "http").toLowerCase();
+
+        if (!hostname || !port) {
+            logger.debug(
+                `Local healthcheck ${hc.targetHealthCheckId} missing hostname/port, skipping`
+            );
+            scheduleNext(hc, state, /*healthy*/ false);
+            return;
+        }
+
+        const result =
+            mode === "tcp"
+                ? await probeTcp(hostname, port, hc.hcTimeout || DEFAULT_TIMEOUT_S)
+                : await probeHttp(hc, hostname, port);
+
+        const healthyThreshold = Math.max(1, hc.hcHealthyThreshold || 1);
+        const unhealthyThreshold = Math.max(1, hc.hcUnhealthyThreshold || 1);
+
+        if (result.ok) {
+            state.consecutiveHealthy++;
+            state.consecutiveUnhealthy = 0;
+        } else {
+            state.consecutiveUnhealthy++;
+            state.consecutiveHealthy = 0;
+            logger.debug(
+                `Local healthcheck ${hc.targetHealthCheckId} probe failed: ${result.error}`
+            );
+        }
+
+        let nextStatus: "healthy" | "unhealthy" | null = null;
+        if (state.consecutiveHealthy >= healthyThreshold) {
+            nextStatus = "healthy";
+        } else if (state.consecutiveUnhealthy >= unhealthyThreshold) {
+            nextStatus = "unhealthy";
+        }
+
+        if (nextStatus && nextStatus !== state.lastStatus) {
+            await applyStatusChange(hc, nextStatus);
+            state.lastStatus = nextStatus;
+        }
+
+        scheduleNext(hc, state, result.ok);
+    } catch (err) {
+        logger.error(
+            `Local healthcheck ${hc.targetHealthCheckId} unexpected error`,
+            { error: err }
+        );
+        scheduleNext(hc, state, false);
+    } finally {
+        state.inFlight = false;
+    }
+}
+
+function scheduleNext(
+    hc: typeof targetHealthCheck.$inferSelect,
+    state: RunState,
+    healthy: boolean
+) {
+    const interval = healthy
+        ? hc.hcInterval || DEFAULT_INTERVAL_S
+        : hc.hcUnhealthyInterval || hc.hcInterval || DEFAULT_INTERVAL_S;
+    state.nextRunAtMs = Date.now() + interval * 1000;
+}
+
+async function applyStatusChange(
+    hc: typeof targetHealthCheck.$inferSelect,
+    nextStatus: "healthy" | "unhealthy"
+) {
+    await db.transaction(async (trx: any) => {
+        await trx
+            .update(targetHealthCheck)
+            .set({ hcHealth: nextStatus })
+            .where(
+                eq(
+                    targetHealthCheck.targetHealthCheckId,
+                    hc.targetHealthCheckId
+                )
+            );
+
+        if (nextStatus === "unhealthy") {
+            await fireHealthCheckUnhealthyAlert(
+                hc.orgId,
+                hc.targetHealthCheckId,
+                hc.name ?? undefined,
+                hc.targetId,
+                undefined,
+                true,
+                trx
+            );
+        } else {
+            await fireHealthCheckHealthyAlert(
+                hc.orgId,
+                hc.targetHealthCheckId,
+                hc.name ?? undefined,
+                hc.targetId,
+                undefined,
+                true,
+                trx
+            );
+        }
+    });
+
+    logger.debug(
+        `Local healthcheck ${hc.targetHealthCheckId} transitioned to ${nextStatus}`
+    );
+}
+
+async function tick() {
+    try {
+        // Pull the active set of healthchecks bound to local sites. We use
+        // primaryDb so freshly-edited checks are picked up on the next tick.
+        const rows = await primaryDb
+            .select({
+                targetHealthCheckId: targetHealthCheck.targetHealthCheckId,
+                targetId: targetHealthCheck.targetId,
+                orgId: targetHealthCheck.orgId,
+                siteId: targetHealthCheck.siteId,
+                name: targetHealthCheck.name,
+                hcEnabled: targetHealthCheck.hcEnabled,
+                hcPath: targetHealthCheck.hcPath,
+                hcScheme: targetHealthCheck.hcScheme,
+                hcMode: targetHealthCheck.hcMode,
+                hcHostname: targetHealthCheck.hcHostname,
+                hcPort: targetHealthCheck.hcPort,
+                hcInterval: targetHealthCheck.hcInterval,
+                hcUnhealthyInterval: targetHealthCheck.hcUnhealthyInterval,
+                hcTimeout: targetHealthCheck.hcTimeout,
+                hcHeaders: targetHealthCheck.hcHeaders,
+                hcFollowRedirects: targetHealthCheck.hcFollowRedirects,
+                hcMethod: targetHealthCheck.hcMethod,
+                hcStatus: targetHealthCheck.hcStatus,
+                hcHealth: targetHealthCheck.hcHealth,
+                hcTlsServerName: targetHealthCheck.hcTlsServerName,
+                hcHealthyThreshold: targetHealthCheck.hcHealthyThreshold,
+                hcUnhealthyThreshold: targetHealthCheck.hcUnhealthyThreshold,
+                targetIp: targets.ip,
+                targetPort: targets.port,
+                siteType: sites.type
+            })
+            .from(targetHealthCheck)
+            .innerJoin(sites, eq(sites.siteId, targetHealthCheck.siteId))
+            .leftJoin(
+                targets,
+                eq(targets.targetId, targetHealthCheck.targetId)
+            )
+            .where(
+                and(
+                    eq(sites.type, "local"),
+                    eq(targetHealthCheck.hcEnabled, true)
+                )
+            );
+
+        // Garbage-collect state for checks that no longer exist or were disabled.
+        const live = new Set(rows.map((r: { targetHealthCheckId: number }) => r.targetHealthCheckId));
+        for (const id of runState.keys()) {
+            if (!live.has(id)) runState.delete(id);
+        }
+
+        const now = Date.now();
+        for (const hc of rows) {
+            let state = runState.get(hc.targetHealthCheckId);
+            if (!state) {
+                state = {
+                    nextRunAtMs: 0, // run immediately on first observation
+                    consecutiveHealthy: 0,
+                    consecutiveUnhealthy: 0,
+                    lastStatus:
+                        (hc.hcHealth as "unknown" | "healthy" | "unhealthy") ||
+                        "unknown",
+                    inFlight: false
+                };
+                runState.set(hc.targetHealthCheckId, state);
+            }
+
+            if (state.inFlight) continue;
+            if (state.nextRunAtMs > now) continue;
+
+            // Fire and forget; runOneCheck guards against overlap via inFlight.
+            void runOneCheck(hc as any);
+        }
+    } catch (err) {
+        logger.error("Error in local healthcheck tick", { error: err });
+    }
+}
+
+export const startLocalHealthChecker = (): void => {
+    if (localHealthCheckerInterval) return;
+    localHealthCheckerInterval = setInterval(tick, LOCAL_HC_TICK_MS);
+    logger.debug("Started local healthcheck poller");
+};
+
+export const stopLocalHealthChecker = (): void => {
+    if (localHealthCheckerInterval) {
+        clearInterval(localHealthCheckerInterval);
+        localHealthCheckerInterval = null;
+        runState.clear();
+        logger.info("Stopped local healthcheck poller");
+    }
+};

--- a/server/routers/target/updateTarget.ts
+++ b/server/routers/target/updateTarget.ts
@@ -209,17 +209,22 @@ export async function updateTarget(
 
             // When health check is disabled, reset hcHealth to "unknown"
             // to prevent previously unhealthy targets from being excluded.
-            // Also when the site is not a newt, set hcHealth to "unknown".
-            // If hcEnabled is being turned on (was false, now true), set to "unhealthy"
-            // so the target must pass a health check before being considered healthy.
+            // Otherwise (newt or local sites that we now poll server-side):
+            // if hcEnabled is being turned on (was false, now true), set to
+            // "unhealthy" so the target must pass a health check before
+            // being considered healthy. For wireguard sites we still force
+            // "unknown" since nothing probes them.
             const hcEnabledTurnedOn =
                 parsedBody.data.hcEnabled === true && existingHc.hcEnabled === false;
+
+            const siteCanProbe =
+                site.type === "newt" || site.type === "local";
 
             let hcHealthValue: "unknown" | "healthy" | "unhealthy" | undefined;
             if (
                 parsedBody.data.hcEnabled === false ||
                 parsedBody.data.hcEnabled === null ||
-                site.type !== "newt"
+                !siteCanProbe
             ) {
                 hcHealthValue = "unknown";
             } else if (hcEnabledTurnedOn) {

--- a/server/routers/ws/messageHandlers.ts
+++ b/server/routers/ws/messageHandlers.ts
@@ -23,6 +23,7 @@ import {
     handleOlmServerInitAddPeerHandshake
 } from "../olm";
 import { handleHealthcheckStatusMessage } from "../target";
+import { startLocalHealthChecker } from "../target/localHealthChecker";
 import { handleRoundTripMessage } from "./handleRoundTripMessage";
 import { MessageHandler } from "./types";
 
@@ -55,3 +56,8 @@ if (build != "saas") {
     startOlmOfflineChecker(); // this is to handle the offline check for olms
     startNewtOfflineChecker(); // this is to handle the offline check for newts
 }
+
+// Local sites have no Newt agent to run probes for them, so the server
+// itself polls their healthchecks. Safe to run in every build because it
+// no-ops when there are no enabled local healthchecks.
+startLocalHealthChecker();

--- a/src/app/[orgId]/settings/resources/proxy/[niceId]/proxy/page.tsx
+++ b/src/app/[orgId]/settings/resources/proxy/[niceId]/proxy/page.tsx
@@ -357,7 +357,7 @@ function ProxyResourceTargetsForm({
 
                    return (
                     <div className="flex items-center justify-center w-full">
-                        {row.original.siteType === "newt" ? (
+                        {row.original.siteType === "newt" || row.original.siteType === "local" ? (
                             <Button
                                 variant="outline"
                                 className="flex items-center gap-2 w-full text-left cursor-pointer"

--- a/src/app/[orgId]/settings/resources/proxy/create/page.tsx
+++ b/src/app/[orgId]/settings/resources/proxy/create/page.tsx
@@ -709,7 +709,7 @@ export default function Page() {
 
                    return (
                     <div className="flex items-center justify-center w-full">
-                        {row.original.siteType === "newt" ? (
+                        {row.original.siteType === "newt" || row.original.siteType === "local" ? (
                             <Button
                                 variant="outline"
                                 className="flex items-center gap-2 w-full text-left cursor-pointer"


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description
This change adds healthcheck support for local sites in Pangolin.

## How to test?

 You need a Pangolin instance with at least one Local site configured — a site where the target is directly reachable by the Pangolin server over the network (not tunnelled through Newt).

Test 1: Healthcheck turns healthy

1. Go to a resource attached to a local site, open the proxy settings, and click the healthcheck button on a target
2. Configure a simple HTTP check pointing at a running service (e.g. GET / expecting 200)
3. Enable it and save
4. Within a few seconds the target should transition from Unknown → Healthy
5. The resource card should also reflect Healthy

Test 2: Healthcheck detects a failure

1. With the healthcheck running and showing Healthy, stop or block the target service
2. Within one polling interval the target should transition to Unhealthy
3. Restart the service — it should return to Healthy

Test 3: TCP mode

Repeat tests 1 and 2 using TCP mode instead of HTTP to verify the TCP probe path works independently

Test 4: Config options

- Set a custom interval (e.g. 10s) and verify the polling frequency changes
- Set an unhealthy interval (e.g. 60s) and verify it polls less aggressively once unhealthy
- Set a healthy/unhealthy threshold > 1 and verify the target doesn't flip status until that many consecutive results are seen

Test 5: WireGuard sites are unaffected

On a WireGuard site, verify the healthcheck button still does not appear and no probing happens

Test 6: Newt sites are unaffected

On a Newt site, verify healthchecks still work exactly as before — the Newt agent should still be doing the probing, not the server

Test 7: Enable/disable toggle
    
Disable an active healthcheck and verify the status resets to Unknown and polling stops. Re-enable it and verify it resumes from Unknown → Unhealthy → Healthy