### PR TITLE
fix(newt): update Helm install credentials and client flag handling

### DIFF
--- a/src/components/newt-install-commands.tsx
+++ b/src/components/newt-install-commands.tsx
@@ -52,6 +52,10 @@ export function NewtSiteInstallCommands({
     const acceptClientsEnv = !acceptClients
         ? "\n      - DISABLE_CLIENTS=true"
         : "";
+    const acceptClientsHelmValue = acceptClients
+        ? ` \\
+      --set newtInstances[0].acceptClients=true`
+        : "";
 
     const commandList: Record<Platform, Record<string, CommandItem[]>> = {
         linux: {
@@ -162,13 +166,18 @@ sudo systemctl enable --now newt`
             "Helm Chart": [
                 `helm repo add fossorial https://charts.fossorial.io`,
                 `helm repo update fossorial`,
-                `helm install newt fossorial/newt \\
-    --create-namespace \\
-    --set newtInstances[0].name="main-tunnel" \\
-    --set newtInstances[0].enabled=true \\
-    --set-string newtInstances[0].auth.keys.endpointKey="${endpoint}" \\
-    --set-string newtInstances[0].auth.keys.idKey="${id}" \\
-    --set-string newtInstances[0].auth.keys.secretKey="${secret}"`
+                `kubectl create namespace newt --dry-run=client -o yaml | kubectl apply -f -`,
+                `kubectl create secret generic newt-main-tunnel-auth \\
+   -n newt \\
+  --from-literal=PANGOLIN_ENDPOINT="${endpoint}" \\
+  --from-literal=NEWT_ID="${id}" \\
+  --from-literal=NEWT_SECRET="${secret}" \\
+  --dry-run=client -o yaml | kubectl apply -f -`,
+                `helm upgrade --install newt fossorial/newt \\
+  -n newt \\
+  --set newtInstances[0].name="main-tunnel" \\
+  --set newtInstances[0].enabled=true \\
+  --set-string newtInstances[0].auth.existingSecretName="newt-main-tunnel-auth"${acceptClientsHelmValue}`
             ]
         },
         podman: {


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description (Copilot generated)

This pull request updates the Helm installation instructions for Newt to improve Kubernetes compatibility and secret management. The changes focus on creating required namespaces and secrets using `kubectl` before running the Helm command, and updating how authentication and client acceptance options are handled.

**Helm installation improvements:**

* Added a `kubectl create namespace` command to ensure the `newt` namespace exists before installation.
* Added a `kubectl create secret generic` command to create the `newt-main-tunnel-auth` secret with required credentials, replacing direct value injection via Helm.
* Updated the Helm install command to use `helm upgrade --install` with `-n newt` and reference the pre-created secret via `--set-string newtInstances[0].auth.existingSecretName="newt-main-tunnel-auth"`.
* Modified the handling of the `acceptClients` option: now appends `--set newtInstances[0].acceptClients=true` to the Helm command only if clients are accepted. [[1]](diffhunk://#diff-22cc84b941ab6521a88da1afb0533704a7257d772fd3907847ce3850f31803c4R55-R58) [[2]](diffhunk://#diff-22cc84b941ab6521a88da1afb0533704a7257d772fd3907847ce3850f31803c4L165-R180)

## How to test?

