### PR TITLE
Auto-create roles referenced in blueprints

### DIFF
--- a/server/lib/blueprints/clientResources.ts
+++ b/server/lib/blueprints/clientResources.ts
@@ -3,6 +3,7 @@ import {
     clientSiteResources,
     domains,
     orgDomains,
+    roleActions,
     roles,
     roleSiteResources,
     Site,
@@ -19,6 +20,7 @@ import { sites } from "@server/db";
 import { eq, and, ne, inArray, or, isNotNull } from "drizzle-orm";
 import { Config } from "./types";
 import logger from "@server/logger";
+import { defaultRoleAllowedActions } from "@server/routers/role/createRole";
 import { getNextAvailableAliasAddress } from "../ip";
 import { createCertificate } from "#dynamic/routers/certificates/createCertificate";
 
@@ -335,8 +337,7 @@ export async function updateClientResources(
             }
 
             if (resourceData.roles.length > 0) {
-                // Re-add specified roles but we need to get the roleIds from the role name in the array
-                const rolesToUpdate = await trx
+                const existingRoles = await trx
                     .select()
                     .from(roles)
                     .where(
@@ -346,7 +347,28 @@ export async function updateClientResources(
                         )
                     );
 
-                const roleIds = rolesToUpdate.map((role) => role.roleId);
+                const foundNames = new Set(existingRoles.map((r) => r.name));
+                const missingNames = resourceData.roles.filter(
+                    (n) => !foundNames.has(n)
+                );
+
+                for (const name of missingNames) {
+                    const [created] = await trx
+                        .insert(roles)
+                        .values({ name, orgId })
+                        .returning();
+                    await trx.insert(roleActions).values(
+                        defaultRoleAllowedActions.map((action) => ({
+                            roleId: created.roleId,
+                            actionId: action,
+                            orgId
+                        }))
+                    );
+                    existingRoles.push(created);
+                    logger.info(`Auto-created role "${name}" in org ${orgId} from blueprint`);
+                }
+
+                const roleIds = existingRoles.map((role) => role.roleId);
 
                 await trx
                     .insert(roleSiteResources)
@@ -447,8 +469,7 @@ export async function updateClientResources(
             });
 
             if (resourceData.roles.length > 0) {
-                // get roleIds from role names
-                const rolesToUpdate = await trx
+                const existingRoles = await trx
                     .select()
                     .from(roles)
                     .where(
@@ -458,7 +479,28 @@ export async function updateClientResources(
                         )
                     );
 
-                const roleIds = rolesToUpdate.map((role) => role.roleId);
+                const foundNames = new Set(existingRoles.map((r) => r.name));
+                const missingNames = resourceData.roles.filter(
+                    (n) => !foundNames.has(n)
+                );
+
+                for (const name of missingNames) {
+                    const [created] = await trx
+                        .insert(roles)
+                        .values({ name, orgId })
+                        .returning();
+                    await trx.insert(roleActions).values(
+                        defaultRoleAllowedActions.map((action) => ({
+                            roleId: created.roleId,
+                            actionId: action,
+                            orgId
+                        }))
+                    );
+                    existingRoles.push(created);
+                    logger.info(`Auto-created role "${name}" in org ${orgId} from blueprint`);
+                }
+
+                const roleIds = existingRoles.map((role) => role.roleId);
 
                 await trx
                     .insert(roleSiteResources)

--- a/server/lib/blueprints/proxyResources.ts
+++ b/server/lib/blueprints/proxyResources.ts
@@ -8,6 +8,7 @@ import {
     resourcePincode,
     resourceRules,
     resourceWhitelist,
+    roleActions,
     roleResources,
     roles,
     Target,
@@ -36,6 +37,7 @@ import { isValidRegionId } from "@server/db/regions";
 import { isLicensedOrSubscribed } from "#dynamic/lib/isLicencedOrSubscribed";
 import { fireHealthCheckUnknownAlert } from "#dynamic/lib/alerts";
 import { tierMatrix } from "../billing/tierMatrix";
+import { defaultRoleAllowedActions } from "@server/routers/role/createRole";
 
 export type ProxyResourcesResults = {
     proxyResource: Resource;
@@ -922,14 +924,26 @@ async function syncRoleResources(
         .where(eq(roleResources.resourceId, resourceId));
 
     for (const roleName of ssoRoles) {
-        const [role] = await trx
+        let [role] = await trx
             .select()
             .from(roles)
             .where(and(eq(roles.name, roleName), eq(roles.orgId, orgId)))
             .limit(1);
 
         if (!role) {
-            throw new Error(`Role not found: ${roleName} in org ${orgId}`);
+            const [created] = await trx
+                .insert(roles)
+                .values({ name: roleName, orgId })
+                .returning();
+            await trx.insert(roleActions).values(
+                defaultRoleAllowedActions.map((action) => ({
+                    roleId: created.roleId,
+                    actionId: action,
+                    orgId
+                }))
+            );
+            role = created;
+            logger.info(`Auto-created role "${roleName}" in org ${orgId} from blueprint`);
         }
 
         if (role.isAdmin) {


### PR DESCRIPTION
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

### Preface

This PR was developed with Claude Code (claude-opus-4-6). I drove the direction and tested everything, but Claude did all of the actual coding. I reviewed, tested, and validated all changes.

## Description

When a blueprint references a role that doesn't exist yet, create it automatically instead of failing or silently dropping the association.

- Proxy resource blueprints (`sso-roles`) previously threw `Role not found`, blocking the entire blueprint apply. Now auto-creates the role.
- Client resource blueprints (`roles`) previously ran a `WHERE IN` query and silently ignored any role names that didn't match. Now auto-creates missing roles before associating them.
- Auto-created roles receive the three default permissions: `getOrg`, `getResource`, `listResources`.

Blueprints are the declarative source of truth for resource configuration. Requiring roles to be pre-created through the UI before they can be referenced in a blueprint breaks the declarative workflow and adds a manual step that's easy to forget. This is especially relevant when integrating with an external IdP where SSO group-to-role mappings should just work on first apply.

## How to test?

- Apply a blueprint with `sso-roles` referencing a role that does not exist. Verify the role is created with default permissions and the resource association succeeds.
- Apply a blueprint with `roles` (client resource) referencing a role that does not exist, for both new and existing resources. Verify the same.
- Apply a blueprint referencing a role that already exists. Verify no duplicate is created and the existing role is associated normally.
- Verify auto-created roles appear in the admin UI with the correct permissions.