### PR TITLE
Add unique index on roles (orgId, name)

### DIFF
--- a/server/db/pg/schema/schema.ts
+++ b/server/db/pg/schema/schema.ts
@@ -11,6 +11,7 @@ import {
     serial,
     text,
     unique,
+    uniqueIndex,
     varchar
 } from "drizzle-orm/pg-core";
 
@@ -443,7 +444,9 @@ export const roles = pgTable("roles", {
     sshSudoCommands: text("sshSudoCommands").default("[]"),
     sshCreateHomeDir: boolean("sshCreateHomeDir").default(true),
     sshUnixGroups: text("sshUnixGroups").default("[]")
-});
+},
+    (t) => [uniqueIndex("idx_roles_orgId_name").on(t.orgId, t.name)]
+);
 
 export const userOrgRoles = pgTable(
     "userOrgRoles",

--- a/server/db/sqlite/schema/schema.ts
+++ b/server/db/sqlite/schema/schema.ts
@@ -6,7 +6,8 @@ import {
     primaryKey,
     sqliteTable,
     text,
-    unique
+    unique,
+    uniqueIndex
 } from "drizzle-orm/sqlite-core";
 
 export const domains = sqliteTable("domains", {
@@ -759,7 +760,9 @@ export const roles = sqliteTable("roles", {
         true
     ),
     sshUnixGroups: text("sshUnixGroups").default("[]")
-});
+},
+    (t) => [uniqueIndex("idx_roles_orgId_name").on(t.orgId, t.name)]
+);
 
 export const userOrgRoles = sqliteTable(
     "userOrgRoles",

--- a/server/setup/migrationsPg.ts
+++ b/server/setup/migrationsPg.ts
@@ -24,6 +24,7 @@ import m15 from "./scriptsPg/1.16.0";
 import m16 from "./scriptsPg/1.17.0";
 import m17 from "./scriptsPg/1.18.0";
 import m18 from "./scriptsPg/1.18.3";
+import m19 from "./scriptsPg/1.19.0";
 
 // THIS CANNOT IMPORT ANYTHING FROM THE SERVER
 // EXCEPT FOR THE DATABASE AND THE SCHEMA
@@ -47,7 +48,8 @@ const migrations = [
     { version: "1.16.0", run: m15 },
     { version: "1.17.0", run: m16 },
     { version: "1.18.0", run: m17 },
-    { version: "1.18.3", run: m18 }
+    { version: "1.18.3", run: m18 },
+    { version: "1.19.0", run: m19 }
     // Add new migrations here as they are created
 ] as {
     version: string;

--- a/server/setup/migrationsSqlite.ts
+++ b/server/setup/migrationsSqlite.ts
@@ -42,6 +42,7 @@ import m36 from "./scriptsSqlite/1.16.0";
 import m37 from "./scriptsSqlite/1.17.0";
 import m38 from "./scriptsSqlite/1.18.0";
 import m39 from "./scriptsSqlite/1.18.3";
+import m40 from "./scriptsSqlite/1.19.0";
 
 // THIS CANNOT IMPORT ANYTHING FROM THE SERVER
 // EXCEPT FOR THE DATABASE AND THE SCHEMA
@@ -81,7 +82,8 @@ const migrations = [
     { version: "1.16.0", run: m36 },
     { version: "1.17.0", run: m37 },
     { version: "1.18.0", run: m38 },
-    { version: "1.18.3", run: m39 }
+    { version: "1.18.3", run: m39 },
+    { version: "1.19.0", run: m40 }
     // Add new migrations here as they are created
 ] as const;
 

--- a/server/setup/scriptsPg/1.19.0.ts
+++ b/server/setup/scriptsPg/1.19.0.ts
@@ -1,0 +1,170 @@
+import { db } from "@server/db/pg/driver";
+import { sql } from "drizzle-orm";
+
+const version = "1.19.0";
+
+export default async function migration() {
+    console.log(`Running setup script ${version}...`);
+
+    try {
+        await db.transaction(async (tx) => {
+            const dupsQuery = await tx.execute(sql`
+                SELECT "orgId", "name", MIN("roleId")::integer AS "keepId",
+                       array_agg("roleId") AS "allIds"
+                FROM "roles"
+                GROUP BY "orgId", "name"
+                HAVING COUNT(*) > 1
+            `);
+
+            const duplicateGroups = dupsQuery.rows as {
+                orgId: string;
+                name: string;
+                keepId: number;
+                allIds: number[];
+            }[];
+
+            console.log(
+                `Found ${duplicateGroups.length} duplicate role group(s) to merge`
+            );
+
+            for (const group of duplicateGroups) {
+                const keepId = Number(group.keepId);
+                const removeIds = group.allIds
+                    .map(Number)
+                    .filter((id) => id !== keepId);
+
+                if (removeIds.length === 0) continue;
+
+                // Check for isAdmin divergence
+                const adminCheck = await tx.execute(sql`
+                    SELECT DISTINCT "isAdmin" FROM "roles"
+                    WHERE "roleId" = ANY(${group.allIds})
+                `);
+                const adminValues = adminCheck.rows.map((r: any) => r.isAdmin);
+                if (adminValues.length > 1) {
+                    console.warn(
+                        `WARNING: Duplicate roles "${group.name}" in org ${group.orgId} have differing isAdmin values. Keeper roleId ${keepId} will be used.`
+                    );
+                }
+
+                // userOrgRoles: has UNIQUE(userId, orgId, roleId)
+                await tx.execute(sql`
+                    DELETE FROM "userOrgRoles" d
+                    WHERE d."roleId" = ANY(${removeIds})
+                      AND EXISTS (
+                          SELECT 1 FROM "userOrgRoles" k
+                          WHERE k."userId" = d."userId"
+                            AND k."orgId" = d."orgId"
+                            AND k."roleId" = ${keepId}
+                      )
+                `);
+                await tx.execute(sql`
+                    UPDATE "userOrgRoles" SET "roleId" = ${keepId}
+                    WHERE "roleId" = ANY(${removeIds})
+                `);
+
+                // userInviteRoles: has PK(inviteId, roleId)
+                await tx.execute(sql`
+                    DELETE FROM "userInviteRoles" d
+                    WHERE d."roleId" = ANY(${removeIds})
+                      AND EXISTS (
+                          SELECT 1 FROM "userInviteRoles" k
+                          WHERE k."inviteId" = d."inviteId"
+                            AND k."roleId" = ${keepId}
+                      )
+                `);
+                await tx.execute(sql`
+                    UPDATE "userInviteRoles" SET "roleId" = ${keepId}
+                    WHERE "roleId" = ANY(${removeIds})
+                `);
+
+                // Tables without unique constraints: update then deduplicate
+                // Scoped to keepId only to avoid collapsing unrelated rows
+                await tx.execute(sql`
+                    UPDATE "roleSiteResources" SET "roleId" = ${keepId}
+                    WHERE "roleId" = ANY(${removeIds})
+                `);
+                await tx.execute(sql`
+                    DELETE FROM "roleSiteResources" a
+                    USING "roleSiteResources" b
+                    WHERE a.ctid > b.ctid
+                      AND a."roleId" = b."roleId"
+                      AND a."siteResourceId" = b."siteResourceId"
+                      AND a."roleId" = ${keepId}
+                `);
+
+                await tx.execute(sql`
+                    UPDATE "roleActions" SET "roleId" = ${keepId}
+                    WHERE "roleId" = ANY(${removeIds})
+                `);
+                await tx.execute(sql`
+                    DELETE FROM "roleActions" a
+                    USING "roleActions" b
+                    WHERE a.ctid > b.ctid
+                      AND a."roleId" = b."roleId"
+                      AND a."actionId" = b."actionId"
+                      AND a."orgId" = b."orgId"
+                      AND a."roleId" = ${keepId}
+                `);
+
+                await tx.execute(sql`
+                    UPDATE "roleSites" SET "roleId" = ${keepId}
+                    WHERE "roleId" = ANY(${removeIds})
+                `);
+                await tx.execute(sql`
+                    DELETE FROM "roleSites" a
+                    USING "roleSites" b
+                    WHERE a.ctid > b.ctid
+                      AND a."roleId" = b."roleId"
+                      AND a."siteId" = b."siteId"
+                      AND a."roleId" = ${keepId}
+                `);
+
+                await tx.execute(sql`
+                    UPDATE "roleResources" SET "roleId" = ${keepId}
+                    WHERE "roleId" = ANY(${removeIds})
+                `);
+                await tx.execute(sql`
+                    DELETE FROM "roleResources" a
+                    USING "roleResources" b
+                    WHERE a.ctid > b.ctid
+                      AND a."roleId" = b."roleId"
+                      AND a."resourceId" = b."resourceId"
+                      AND a."roleId" = ${keepId}
+                `);
+
+                await tx.execute(sql`
+                    UPDATE "roleClients" SET "roleId" = ${keepId}
+                    WHERE "roleId" = ANY(${removeIds})
+                `);
+                await tx.execute(sql`
+                    DELETE FROM "roleClients" a
+                    USING "roleClients" b
+                    WHERE a.ctid > b.ctid
+                      AND a."roleId" = b."roleId"
+                      AND a."clientId" = b."clientId"
+                      AND a."roleId" = ${keepId}
+                `);
+
+                await tx.execute(sql`
+                    DELETE FROM "roles" WHERE "roleId" = ANY(${removeIds})
+                `);
+
+                console.log(
+                    `Merged ${removeIds.length} duplicate(s) of role "${group.name}" in org ${group.orgId} into roleId ${keepId}`
+                );
+            }
+
+            await tx.execute(sql`
+                CREATE UNIQUE INDEX IF NOT EXISTS "idx_roles_orgId_name" ON "roles" ("orgId", "name")
+            `);
+        });
+
+        console.log("Migrated database");
+    } catch (e) {
+        console.error("Unable to migrate database:", e);
+        throw e;
+    }
+
+    console.log(`${version} migration complete`);
+}

--- a/server/setup/scriptsSqlite/1.19.0.ts
+++ b/server/setup/scriptsSqlite/1.19.0.ts
@@ -1,0 +1,184 @@
+import { APP_PATH } from "@server/lib/consts";
+import Database from "better-sqlite3";
+import path from "path";
+
+const version = "1.19.0";
+
+export default async function migration() {
+    console.log(`Running setup script ${version}...`);
+
+    const location = path.join(APP_PATH, "db", "db.sqlite");
+    const db = new Database(location);
+
+    try {
+        db.pragma("foreign_keys = OFF");
+
+        db.transaction(() => {
+            const duplicateGroups = db
+                .prepare(
+                    `SELECT "orgId", "name", MIN("roleId") AS "keepId",
+                            GROUP_CONCAT("roleId") AS "allIds"
+                     FROM "roles"
+                     GROUP BY "orgId", "name"
+                     HAVING COUNT(*) > 1`
+                )
+                .all() as {
+                orgId: string;
+                name: string;
+                keepId: number;
+                allIds: string;
+            }[];
+
+            console.log(
+                `Found ${duplicateGroups.length} duplicate role group(s) to merge`
+            );
+
+            for (const group of duplicateGroups) {
+                const keepId = Number(group.keepId);
+                const removeIds = group.allIds
+                    .split(",")
+                    .map(Number)
+                    .filter((id) => id !== keepId);
+
+                if (removeIds.length === 0) continue;
+
+                const placeholders = removeIds.map(() => "?").join(",");
+
+                // Check for isAdmin divergence
+                const allIds = [keepId, ...removeIds];
+                const allPlaceholders = allIds.map(() => "?").join(",");
+                const adminValues = db
+                    .prepare(
+                        `SELECT DISTINCT "isAdmin" FROM "roles"
+                         WHERE "roleId" IN (${allPlaceholders})`
+                    )
+                    .all(...allIds) as { isAdmin: number | null }[];
+                if (adminValues.length > 1) {
+                    console.warn(
+                        `WARNING: Duplicate roles "${group.name}" in org ${group.orgId} have differing isAdmin values. Keeper roleId ${keepId} will be used.`
+                    );
+                }
+
+                // userOrgRoles: has UNIQUE(userId, orgId, roleId)
+                db.prepare(
+                    `DELETE FROM "userOrgRoles"
+                     WHERE "roleId" IN (${placeholders})
+                       AND EXISTS (
+                           SELECT 1 FROM "userOrgRoles" k
+                           WHERE k."userId" = "userOrgRoles"."userId"
+                             AND k."orgId" = "userOrgRoles"."orgId"
+                             AND k."roleId" = ?
+                       )`
+                ).run(...removeIds, keepId);
+                db.prepare(
+                    `UPDATE "userOrgRoles" SET "roleId" = ?
+                     WHERE "roleId" IN (${placeholders})`
+                ).run(keepId, ...removeIds);
+
+                // userInviteRoles: has PK(inviteId, roleId)
+                db.prepare(
+                    `DELETE FROM "userInviteRoles"
+                     WHERE "roleId" IN (${placeholders})
+                       AND EXISTS (
+                           SELECT 1 FROM "userInviteRoles" k
+                           WHERE k."inviteId" = "userInviteRoles"."inviteId"
+                             AND k."roleId" = ?
+                       )`
+                ).run(...removeIds, keepId);
+                db.prepare(
+                    `UPDATE "userInviteRoles" SET "roleId" = ?
+                     WHERE "roleId" IN (${placeholders})`
+                ).run(keepId, ...removeIds);
+
+                // Tables without unique constraints: update then deduplicate
+                // Scoped to keepId only to avoid collapsing unrelated rows
+                db.prepare(
+                    `UPDATE "roleSiteResources" SET "roleId" = ?
+                     WHERE "roleId" IN (${placeholders})`
+                ).run(keepId, ...removeIds);
+                db.prepare(
+                    `DELETE FROM "roleSiteResources"
+                     WHERE rowid NOT IN (
+                         SELECT MIN(rowid) FROM "roleSiteResources"
+                         WHERE "roleId" = ?
+                         GROUP BY "roleId", "siteResourceId"
+                     ) AND "roleId" = ?`
+                ).run(keepId, keepId);
+
+                db.prepare(
+                    `UPDATE "roleActions" SET "roleId" = ?
+                     WHERE "roleId" IN (${placeholders})`
+                ).run(keepId, ...removeIds);
+                db.prepare(
+                    `DELETE FROM "roleActions"
+                     WHERE rowid NOT IN (
+                         SELECT MIN(rowid) FROM "roleActions"
+                         WHERE "roleId" = ?
+                         GROUP BY "roleId", "actionId", "orgId"
+                     ) AND "roleId" = ?`
+                ).run(keepId, keepId);
+
+                db.prepare(
+                    `UPDATE "roleSites" SET "roleId" = ?
+                     WHERE "roleId" IN (${placeholders})`
+                ).run(keepId, ...removeIds);
+                db.prepare(
+                    `DELETE FROM "roleSites"
+                     WHERE rowid NOT IN (
+                         SELECT MIN(rowid) FROM "roleSites"
+                         WHERE "roleId" = ?
+                         GROUP BY "roleId", "siteId"
+                     ) AND "roleId" = ?`
+                ).run(keepId, keepId);
+
+                db.prepare(
+                    `UPDATE "roleResources" SET "roleId" = ?
+                     WHERE "roleId" IN (${placeholders})`
+                ).run(keepId, ...removeIds);
+                db.prepare(
+                    `DELETE FROM "roleResources"
+                     WHERE rowid NOT IN (
+                         SELECT MIN(rowid) FROM "roleResources"
+                         WHERE "roleId" = ?
+                         GROUP BY "roleId", "resourceId"
+                     ) AND "roleId" = ?`
+                ).run(keepId, keepId);
+
+                db.prepare(
+                    `UPDATE "roleClients" SET "roleId" = ?
+                     WHERE "roleId" IN (${placeholders})`
+                ).run(keepId, ...removeIds);
+                db.prepare(
+                    `DELETE FROM "roleClients"
+                     WHERE rowid NOT IN (
+                         SELECT MIN(rowid) FROM "roleClients"
+                         WHERE "roleId" = ?
+                         GROUP BY "roleId", "clientId"
+                     ) AND "roleId" = ?`
+                ).run(keepId, keepId);
+
+                db.prepare(
+                    `DELETE FROM "roles" WHERE "roleId" IN (${placeholders})`
+                ).run(...removeIds);
+
+                console.log(
+                    `Merged ${removeIds.length} duplicate(s) of role "${group.name}" in org ${group.orgId} into roleId ${keepId}`
+                );
+            }
+
+            db.prepare(
+                `CREATE UNIQUE INDEX IF NOT EXISTS "idx_roles_orgId_name" ON "roles" ("orgId", "name")`
+            ).run();
+        })();
+
+        console.log("Migrated database");
+    } catch (e) {
+        console.error("Failed to migrate db:", e);
+        throw e;
+    } finally {
+        db.pragma("foreign_keys = ON");
+        db.close();
+    }
+
+    console.log(`${version} migration complete`);
+}


### PR DESCRIPTION
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

### Preface

This PR was developed with Claude Code (claude-opus-4-6). The migration logic, edge case handling, and scoped dedup approach went through multiple review rounds (11 agents across 2 passes) that caught several bugs that would have caused data loss in production, including a type coercion bug where postgres returns `MIN()` as a string instead of an integer, and a connection pool race where raw `BEGIN`/`COMMIT` doesn't pin a connection. Both PostgreSQL and SQLite migrations were tested against real databases with intentionally messy data (triple duplicates, PK conflicts, legitimate duplicate rows in FK tables that need to survive). I reviewed, tested, and validated all changes.

## Description

The `roles` table has no unique constraint on `(orgId, name)`. Multiple code paths use a select-then-insert pattern that can produce duplicate rows under concurrent requests: the `createRole` API handler and the blueprint auto-create logic in #2980.

This adds a versioned migration (1.19.0, both PG and SQLite) that cleans up any existing duplicates before creating the index. For each duplicate group (same orgId + name), the migration keeps the lowest roleId and repoints all foreign key references from the duplicates to the survivor across the 7 tables that reference `roles.roleId` (userOrgRoles, roleSiteResources, roleActions, roleSites, roleResources, userInviteRoles, roleClients). Any rows that become identical after the repoint are deduplicated. The duplicate roles are then deleted and the unique index is created.

Schema files are updated to declare the `uniqueIndex` so Drizzle stays in sync with what the migration creates.

## How to test?

- Deploy against a database with duplicate roles (same orgId + name). Verify duplicates are merged, the lowest roleId survives, and all FK references are repointed.
- Verify no orphan references remain in any of the 7 FK tables.
- Verify legitimate duplicate rows in FK tables for unrelated roles are not collapsed.
- Attempt to insert a duplicate role (same orgId + name). Verify it is rejected.
- Insert a role with the same name in a different org. Verify it succeeds.