### PR TITLE
fix: make validators test failures exit non-zero

### DIFF
--- a/server/lib/validators.test.ts
+++ b/server/lib/validators.test.ts
@@ -244,4 +244,5 @@ try {
     runTests();
 } catch (error) {
     console.error("Test failed:", error);
+    process.exit(1);
 }


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description

Tiny test cleanup: `validators.test.ts` logged failures but still exited `0`.

That can make a broken test look green if someone wires it into a script later. Not ideal, lol. This makes it behave like the nearby test files and exit `1` on failure.

Related: I did not find a direct issue. #2807 is broader test-suite work, this is just the small papercut.

## How to test?

Repro the bug shape:

```bash
node -e 'try { throw new Error("simulated assertion failure") } catch (error) { console.error("Test failed:", error.message) }'
```

It prints a failure but exits `0`.

Fixed behavior:

```bash
node -e 'try { throw new Error("simulated assertion failure") } catch (error) { console.error("Test failed:", error.message); process.exit(1) }'
```

It exits `1`, as expected.

Checked locally:

```bash
npm run set:oss
npm run set:sqlite
npx tsx server/lib/validators.test.ts
npx tsc --noEmit
npx prettier --check server/lib/validators.test.ts
```
