### PR TITLE
Return error response for stale hole-punch rejection

### DIFF
--- a/server/routers/olm/error.ts
+++ b/server/routers/olm/error.ts
@@ -86,6 +86,11 @@ export const OlmErrorCodes = {
     TERMINATED_BLOCKED: {
         code: "TERMINATED_BLOCKED",
         message: "This session was terminated because access was blocked."
+    },
+    STALE_HOLE_PUNCH: {
+        code: "STALE_HOLE_PUNCH",
+        message:
+            "Hole punch is stale. Ensure the server is reachable on the configured UDP port."
     }
 } as const;
 

--- a/server/routers/olm/handleOlmRegisterMessage.ts
+++ b/server/routers/olm/handleOlmRegisterMessage.ts
@@ -306,12 +306,12 @@ export const handleOlmRegisterMessage: MessageHandler = async (context) => {
 
     // this prevents us from accepting a register from an olm that has not hole punched yet.
     // the olm will pump the register so we can keep checking
-    // TODO: I still think there is a better way to do this rather than locking it out here but ???
     if (now - (client.lastHolePunch || 0) > 5 && sitesCount > 0) {
         logger.warn(
             `[handleOlmRegisterMessage] Client last hole punch is too old and we have sites to send; skipping this register. The client is failing to hole punch and identify its network address with the server. Can the client reach the server on UDP port ${config.getRawConfig().gerbil.clients_start_port}?`,
             { orgId: client.orgId }
         );
+        sendOlmError(OlmErrorCodes.STALE_HOLE_PUNCH, olm.olmId);
         return;
     }
 


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

### Preface

This PR was developed with Claude Code (claude-opus-4-6). I identified the bug through live debugging of a broken Olm tunnel after a Pangolin server restart, traced the root cause through the code, and directed the fix. Claude wrote the patch. I reviewed and validated all changes.

## Description

When `handleOlmRegisterMessage` rejects a registration because `lastHolePunch` is stale (more than 5 seconds old and the client has sites to receive), it performs a bare `return` with no response to the client. The client has no way to know its registration was rejected or why, so it retries blindly until it exhausts its retry budget (20 attempts at 2-second intervals), then gives up silently.

This is particularly problematic during server restarts: the server's in-memory `lastHolePunch` timestamps reset, so the first registration attempt after reconnect is always rejected. Combined with the Olm re-registration bug (fosrl/olm#123), this creates a double failure where the client either never re-registers or re-registers into a silent rejection loop.

**Fix:** Send an `olm/error` response with a new `STALE_HOLE_PUNCH` error code before returning. This uses the existing `sendOlmError` pattern that other rejection paths in the same function already use. The Olm client's `handleOlmError` handler will log the error and surface it via the API server status endpoint, giving users visibility into the failure.

Related issues: #2951, #2901, #2318, #2343, #3041, #1526

Companion PR: fosrl/olm#123

## How to test?

1. Connect an Olm client with at least one site configured.
2. Restart the Pangolin server.
3. Watch Olm client logs after reconnect.
4. **Before fix:** Client retries registration 20 times with no feedback, then silently gives up. Server logs warn about stale hole punch but client sees nothing.
5. **After fix:** Client receives `STALE_HOLE_PUNCH` error and logs it. The error is visible in the Olm status API.
