### PR TITLE
Fix V1 target fallback for non-semver Newt versions

### DIFF
--- a/server/routers/client/targets.ts
+++ b/server/routers/client/targets.ts
@@ -26,16 +26,19 @@ export async function convertTargetsIfNessicary(
         throw new Error(`No newt found for id: ${newtId}`);
     }
 
-    // check the semver
-    if (
-        newt.version &&
-        !semver.satisfies(newt.version, NEWT_V2_TARGETS_VERSION)
-    ) {
+    // check the semver - only fall back to V1 for known old versions
+    if (newt.version && semver.valid(newt.version)) {
+        if (!semver.satisfies(newt.version, NEWT_V2_TARGETS_VERSION)) {
+            logger.debug(
+                `Newt version ${newt.version} does not support targets v2, falling back to v1`
+            );
+            targets = convertSubnetProxyTargetsV2ToV1(
+                targets as SubnetProxyTargetV2[]
+            );
+        }
+    } else if (newt.version) {
         logger.debug(
-            `addTargets Newt version ${newt.version} does not support targets v2 falling back`
-        );
-        targets = convertSubnetProxyTargetsV2ToV1(
-            targets as SubnetProxyTargetV2[]
+            `Newt version "${newt.version}" is not valid semver, sending v2 targets`
         );
     }
 
@@ -94,22 +97,21 @@ export async function updateTargets(
         return;
     }
 
-    // check the semver
-    if (
-        newt.version &&
-        !semver.satisfies(newt.version, NEWT_V2_TARGETS_VERSION)
-    ) {
-        logger.debug(
-            `addTargets Newt version ${newt.version} does not support targets v2 falling back`
-        );
-        targets = {
-            oldTargets: convertSubnetProxyTargetsV2ToV1(
-                targets.oldTargets as SubnetProxyTargetV2[]
-            ),
-            newTargets: convertSubnetProxyTargetsV2ToV1(
-                targets.newTargets as SubnetProxyTargetV2[]
-            )
-        };
+    // check the semver - only fall back to V1 for known old versions
+    if (newt.version && semver.valid(newt.version)) {
+        if (!semver.satisfies(newt.version, NEWT_V2_TARGETS_VERSION)) {
+            logger.debug(
+                `Newt version ${newt.version} does not support targets v2, falling back to v1`
+            );
+            targets = {
+                oldTargets: convertSubnetProxyTargetsV2ToV1(
+                    targets.oldTargets as SubnetProxyTargetV2[]
+                ),
+                newTargets: convertSubnetProxyTargetsV2ToV1(
+                    targets.newTargets as SubnetProxyTargetV2[]
+                )
+            };
+        }
     }
 
     await sendToClient(


### PR DESCRIPTION
## Summary

- `convertTargetsIfNessicary()` falls back to V1 targets when `semver.satisfies()` returns false for the Newt's reported version
- `semver.satisfies()` returns false for **any non-semver string** (e.g., custom build tags like `"dev"`, `"patched"`, `"nightly"`)
- V1 conversion via `convertSubnetProxyTargetsV2ToV1()` strips `httpTargets` and only preserves `rewriteTo`, which is empty/undefined for HTTP-mode resources
- This makes all HTTP-mode private resources unreachable: Newt's TCP handler falls through to raw DNAT with an empty destination, causing connection timeouts

The fix adds a `semver.valid()` guard so the V1 fallback only triggers for versions that are valid semver AND below `1.10.3`. Non-semver version strings are treated as V2-capable, since genuinely old Newt versions always reported real semver versions.

Both call sites in `convertTargetsIfNessicary()` and `updateTargets()` are updated.

## Test plan

- [ ] Deploy Newt with a non-semver version string (e.g., `"dev"`) and verify HTTP-mode resources are reachable
- [ ] Verify Newt with version `1.10.2` still receives V1 targets (backwards compat preserved)
- [ ] Verify Newt with version `1.10.3`+ receives V2 targets (existing behavior unchanged)
- [ ] Verify Newt with no version set receives V2 targets (existing behavior unchanged)