### PR TITLE
Upgrade cosign installer to v4.1.2 and pin cosign version

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -415,7 +415,9 @@ jobs:
 
             - name: Install cosign
               # cosign is used to sign container images using keyless (OIDC) signing
-              uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+              uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.2
+              with:
+                cosign-release: v3.0.6
 
             - name: Sign (GHCR, keyless)
               # Sign each GHCR image by digest using keyless (OIDC) signing via Sigstore/Rekor.

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -415,7 +415,7 @@ jobs:
 
             - name: Install cosign
               # cosign is used to sign container images using keyless (OIDC) signing
-              uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.2
+              uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
               with:
                 cosign-release: v3.0.6
 


### PR DESCRIPTION
## Description

Updates the Cosign installer workflow usage and explicitly pins the installed Cosign binary to `v3.0.6`.

## Why

Cosign versions below `3.0.6` are affected by CVE-2026-39395. While this workflow was not explicitly pinned to an older vulnerable Cosign binary, the installed Cosign version was implicit and therefore less deterministic.

## Changes

- Updates `sigstore/cosign-installer` to `v4.1.2` https://github.com/sigstore/cosign-installer/releases/tag/v4.1.2
- Adds an explicit `cosign-release: v3.0.6`
- Keeps the workflow behavior unchanged apart from using the fixed Cosign version

## References

- CVE: https://www.suse.com/security/cve/CVE-2026-39395.html
- Cosign installer usage: https://github.com/sigstore/cosign-installer#usage
