### PR TITLE
fix: make tag input wrap around instead of scrolling

### DIFF
--- a/src/components/multi-select/multi-select-tag-input.tsx
+++ b/src/components/multi-select/multi-select-tag-input.tsx
@@ -61,7 +61,9 @@ export function MultiSelectTagInput<T extends TagValue>({
                                 )}
                                 onClick={(e) => e.stopPropagation()}
                             >
-                                {option.text}
+                                <span className="max-w-40 text-ellipsis overflow-hidden">
+                                    {option.text}
+                                </span>
                                 <button
                                     className="p-0.5 flex-none cursor-pointer"
                                     type="button"

--- a/src/components/multi-select/multi-select-tag-input.tsx
+++ b/src/components/multi-select/multi-select-tag-input.tsx
@@ -41,7 +41,7 @@ export function MultiSelectTagInput<T extends TagValue>({
                             variant: "outline"
                         }),
                         "justify-between w-full inline-flex",
-                        "text-muted-foreground pl-1.5 cursor-text",
+                        "text-muted-foreground pl-1.5 cursor-text h-auto py-1",
                         "hover:bg-transparent hover:text-muted-foreground",
                         props.disabled && "pointer-events-none opacity-50"
                     )}
@@ -49,7 +49,7 @@ export function MultiSelectTagInput<T extends TagValue>({
                     <span
                         className={cn(
                             "inline-flex items-center gap-1",
-                            "overflow-x-auto"
+                            "overflow-x-auto flex-wrap h-auto"
                         )}
                     >
                         {props.value.map((option) => (


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Summary

- Make tag input flex wrap
- Limit tag width to 160px

## Screenshot

|  Before | After  | 
|---|---|
| <img width="1284" height="183" alt="image" src="https://github.com/user-attachments/assets/c7e029de-2f09-4a6d-ad1d-5b51586d17fb" /> |  <img width="1566" height="908" alt="image" src="https://github.com/user-attachments/assets/3fc61525-b17a-4870-a32e-ea5c7375052a" />  |
