### PR TITLE
Fix public resource health with unknown WireGuard targets

### DIFF
--- a/server/lib/alerts/events/healthCheckEvents.ts
+++ b/server/lib/alerts/events/healthCheckEvents.ts
@@ -221,10 +221,18 @@ async function handleResource(
         )
         .where(eq(targets.resourceId, resource.resourceId));
 
+    const monitoredTargets = otherTargets.filter(
+        (t) => t.hcHealth !== "unknown"
+    );
+
     let health = "healthy";
-    const allUnknown = otherTargets.every((t) => t.hcHealth === "unknown");
-    const allHealthy = otherTargets.every((t) => t.hcHealth === "healthy");
-    const allUnhealthy = otherTargets.every((t) => t.hcHealth === "unhealthy");
+    const allUnknown = monitoredTargets.length === 0;
+    const allHealthy = monitoredTargets.every(
+        (t) => t.hcHealth === "healthy"
+    );
+    const allUnhealthy = monitoredTargets.every(
+        (t) => t.hcHealth === "unhealthy"
+    );
 
     if (allUnknown) {
         logger.debug(


### PR DESCRIPTION
## Description

Fixes #3105.

Public resources were marked as degraded when a WireGuard target was added alongside healthy Newt targets. WireGuard targets do not report target health checks, so their `hcHealth` is stored as `unknown`.

The resource health aggregation previously treated any mixed state that was not all healthy, all unhealthy, or all unknown as degraded. That made `healthy + healthy + unknown` become `degraded`.

This change ignores `unknown` target health when at least one monitored target exists. Unknown targets remain neutral in the overall resource health calculation.

Expected behavior after this change:

- `healthy + healthy + unknown` -> `healthy`
- `healthy + unhealthy + unknown` -> `degraded`
- `unhealthy + unhealthy + unknown` -> `unhealthy`
- `unknown + unknown` -> `unknown`