### PR TITLE
Sort resource filter options in audit logs

### DIFF
--- a/server/private/routers/auditLogs/queryAccessAuditLog.ts
+++ b/server/private/routers/auditLogs/queryAccessAuditLog.ts
@@ -93,6 +93,20 @@ export const queryAccessAuditLogsCombined = queryAccessAuditLogsQuery.merge(
 );
 type Q = z.infer<typeof queryAccessAuditLogsCombined>;
 
+function sortNamedFilterOptions<T extends { id: number; name: string | null }>(
+    items: T[]
+): T[] {
+    return [...items].sort((a, b) => {
+        const nameA = a.name ?? "";
+        const nameB = b.name ?? "";
+
+        if (nameA < nameB) return -1;
+        if (nameA > nameB) return 1;
+
+        return a.id - b.id;
+    });
+}
+
 function getWhere(data: Q) {
     return and(
         gt(accessAuditLog.timestamp, data.timeStart),
@@ -308,7 +322,7 @@ async function queryUniqueFilterAttributes(
         actors: uniqueActors
             .map((row) => row.actor)
             .filter((actor): actor is string => actor !== null),
-        resources: resourcesWithNames,
+        resources: sortNamedFilterOptions(resourcesWithNames),
         locations: uniqueLocations
             .map((row) => row.locations)
             .filter((location): location is string => location !== null)

--- a/server/private/routers/auditLogs/queryConnectionAuditLog.ts
+++ b/server/private/routers/auditLogs/queryConnectionAuditLog.ts
@@ -107,6 +107,20 @@ export const queryConnectionAuditLogsCombined =
     queryConnectionAuditLogsQuery.merge(queryConnectionAuditLogsParams);
 type Q = z.infer<typeof queryConnectionAuditLogsCombined>;
 
+function sortNamedFilterOptions<T extends { id: number; name: string | null }>(
+    items: T[]
+): T[] {
+    return [...items].sort((a, b) => {
+        const nameA = a.name ?? "";
+        const nameB = b.name ?? "";
+
+        if (nameA < nameB) return -1;
+        if (nameA > nameB) return 1;
+
+        return a.id - b.id;
+    });
+}
+
 function getWhere(data: Q) {
     return and(
         gt(connectionAuditLog.startedAt, data.timeStart),
@@ -425,7 +439,7 @@ async function queryUniqueFilterAttributes(
             .map((row) => row.destAddr)
             .filter((addr): addr is string => addr !== null),
         clients: clientsWithNames,
-        resources: resourcesWithNames,
+        resources: sortNamedFilterOptions(resourcesWithNames),
         users: usersWithEmails
     };
 }

--- a/server/routers/auditLogs/queryRequestAuditLog.ts
+++ b/server/routers/auditLogs/queryRequestAuditLog.ts
@@ -86,6 +86,20 @@ export const queryRequestAuditLogsCombined = queryAccessAuditLogsQuery.merge(
 );
 type Q = z.infer<typeof queryRequestAuditLogsCombined>;
 
+function sortNamedFilterOptions<T extends { id: number; name: string | null }>(
+    items: T[]
+): T[] {
+    return [...items].sort((a, b) => {
+        const nameA = a.name ?? "";
+        const nameB = b.name ?? "";
+
+        if (nameA < nameB) return -1;
+        if (nameA > nameB) return 1;
+
+        return a.id - b.id;
+    });
+}
+
 function getWhere(data: Q) {
     return and(
         gt(requestAuditLog.timestamp, data.timeStart),
@@ -353,7 +367,7 @@ async function queryUniqueFilterAttributes(
         actors: uniqueActors
             .map((row) => row.actor)
             .filter((actor): actor is string => actor !== null),
-        resources: resourcesWithNames,
+        resources: sortNamedFilterOptions(resourcesWithNames),
         locations: uniqueLocations
             .map((row) => row.locations)
             .filter((location): location is string => location !== null),


### PR DESCRIPTION
## Description

Fixes #3086.

The resource filter dropdown in the HTTP request log was using the order returned by the audit-log filter attributes API. That API collected distinct resource IDs from log rows, fetched resource names, and returned the merged result without sorting. As a result, the dropdown order could appear ID-based, log-order-based, or otherwise inconsistent with the public resources view.

This change sorts resource filter options by resource name before returning them from the audit log APIs. It also applies the same ordering to access and connection log resource filters so similar dropdowns stay consistent.


