### PR TITLE
perf: memory and CPU remediation for small/resource-constrained instances (#2120)

### DIFF
--- a/server/db/sqlite/driver.ts
+++ b/server/db/sqlite/driver.ts
@@ -60,13 +60,7 @@ function createDb() {
     // retry loops that accumulate memory.
     sqlite.pragma("busy_timeout = 5000");
 
-    // 64 MB page cache (default 2 MB) — reduces I/O round-trips on large
-    // TraefikConfigManager JOINs that block the event loop.
-    sqlite.pragma("cache_size = -65536");
-
-    // 256 MB memory-mapped I/O — OS serves reads from page cache directly,
-    // reducing event-loop blocking.
-    sqlite.pragma("mmap_size = 268435456");
+    // removed mmap_size and cache_size pragmas due to performance issues on small instances
 
     // Wrap prepare() so every drizzle-orm statement is auto-finalized after
     // first use, preventing sqlite3_stmt accumulation between GC cycles.

--- a/server/db/sqlite/driver.ts
+++ b/server/db/sqlite/driver.ts
@@ -1,6 +1,5 @@
 import { drizzle as DrizzleSqlite } from "drizzle-orm/better-sqlite3";
 import Database from "better-sqlite3";
-import type BetterSqlite3 from "better-sqlite3";
 import * as schema from "./schema/schema";
 import path from "path";
 import fs from "fs";
@@ -11,39 +10,6 @@ export const location = path.join(APP_PATH, "db", "db.sqlite");
 export const exists = checkFileExists(location);
 
 bootstrapVolume();
-
-/**
- * Wraps better-sqlite3 Statement to call `finalize()` immediately after
- * execution, freeing native sqlite3_stmt memory deterministically instead
- * of waiting for GC. Fixes steady off-heap growth under load (#2120).
- * WARNING: Finalizes after first execution — incompatible with drizzle's
- * reusable .prepare() builders. No such usage exists in this codebase.
- */
-function autoFinalizeStatement(
-    stmt: BetterSqlite3.Statement
-): BetterSqlite3.Statement {
-    const wrapExec = <T extends (...args: any[]) => any>(fn: T): T => {
-        return function (this: any, ...args: any[]) {
-            try {
-                return fn.apply(this, args);
-            } finally {
-                try {
-                    // finalize() exists on the native Statement at runtime but
-                    // is missing from @types/better-sqlite3.
-                    (stmt as any).finalize();
-                } catch {
-                    // Already finalized — harmless
-                }
-            }
-        } as unknown as T;
-    };
-
-    stmt.run = wrapExec(stmt.run);
-    stmt.get = wrapExec(stmt.get);
-    stmt.all = wrapExec(stmt.all);
-
-    return stmt;
-}
 
 function createDb() {
     const sqlite = new Database(location);
@@ -61,13 +27,7 @@ function createDb() {
     sqlite.pragma("busy_timeout = 5000");
 
     // removed mmap_size and cache_size pragmas due to performance issues on small instances
-
-    // Wrap prepare() so every drizzle-orm statement is auto-finalized after
-    // first use, preventing sqlite3_stmt accumulation between GC cycles.
-    const originalPrepare = sqlite.prepare.bind(sqlite);
-    (sqlite as any).prepare = function autoFinalizePrepare(source: string) {
-        return autoFinalizeStatement(originalPrepare(source));
-    };
+    // No autoFinalizeStatement wrapper — better-sqlite3 finalizes via GC (#2120).
 
     return DrizzleSqlite(sqlite, {
         schema

--- a/server/lib/cleanupLogs.ts
+++ b/server/lib/cleanupLogs.ts
@@ -1,14 +1,15 @@
-import { db, orgs } from "@server/db";
+import { db, logsDb, orgs, statusHistory } from "@server/db";
 import { cleanUpOldLogs as cleanUpOldAccessLogs } from "#dynamic/lib/logAccessAudit";
 import { cleanUpOldLogs as cleanUpOldActionLogs } from "#dynamic/middlewares/logActionAudit";
 import { cleanUpOldLogs as cleanUpOldRequestLogs } from "@server/routers/badger/logRequestAudit";
 import { cleanUpOldLogs as cleanUpOldConnectionLogs } from "#dynamic/routers/newt";
-import { gt, or } from "drizzle-orm";
+import { gt, lt, or } from "drizzle-orm";
 import { cleanUpOldFingerprintSnapshots } from "@server/routers/olm/fingerprintingUtils";
 import { build } from "@server/build";
 
 export function initLogCleanupInterval() {
-    if (build == "saas") { // skip log cleanup for saas builds
+    if (build == "saas") {
+        // skip log cleanup for saas builds
         return null;
     }
     return setInterval(
@@ -75,6 +76,12 @@ export function initLogCleanupInterval() {
             }
 
             await cleanUpOldFingerprintSnapshots(365);
+
+            // Clean up old status history entries (90 days retention)
+            const statusHistoryCutoff = calculateCutoffTimestamp(90);
+            await logsDb
+                .delete(statusHistory)
+                .where(lt(statusHistory.timestamp, statusHistoryCutoff));
         },
         3 * 60 * 60 * 1000
     ); // every 3 hours

--- a/server/lib/readConfigFile.ts
+++ b/server/lib/readConfigFile.ts
@@ -238,7 +238,7 @@ export const configSchema = z
                 cert_resolver: z.string().optional().default("letsencrypt"),
                 prefer_wildcard_cert: z.boolean().optional().default(false),
                 certificates_path: z.string().default("/var/certificates"),
-                monitor_interval: z.number().default(30000),
+                monitor_interval: z.number().default(30000), // 30s — lower values increase allocation pressure from full config rebuilds
                 dynamic_cert_config_path: z
                     .string()
                     .optional()

--- a/server/lib/readConfigFile.ts
+++ b/server/lib/readConfigFile.ts
@@ -238,7 +238,7 @@ export const configSchema = z
                 cert_resolver: z.string().optional().default("letsencrypt"),
                 prefer_wildcard_cert: z.boolean().optional().default(false),
                 certificates_path: z.string().default("/var/certificates"),
-                monitor_interval: z.number().default(5000),
+                monitor_interval: z.number().default(30000),
                 dynamic_cert_config_path: z
                     .string()
                     .optional()

--- a/server/routers/client/blockClient.ts
+++ b/server/routers/client/blockClient.ts
@@ -9,7 +9,7 @@ import createHttpError from "http-errors";
 import logger from "@server/logger";
 import { fromError } from "zod-validation-error";
 import { OpenAPITags, registry } from "@server/openApi";
-import { sendTerminateClient } from "./terminate";
+import { terminateAndDisconnect } from "./terminate";
 import { OlmErrorCodes } from "../olm/error";
 
 const blockClientSchema = z.strictObject({
@@ -71,17 +71,21 @@ export async function blockClient(
         }
 
         await db.transaction(async (trx) => {
-            // Block the client
             await trx
                 .update(clients)
                 .set({ blocked: true, approvalState: "denied" })
                 .where(eq(clients.clientId, clientId));
-
-            // Send terminate signal if there's an associated OLM and it's connected
-            if (client.olmId && client.online) {
-                await sendTerminateClient(client.clientId, OlmErrorCodes.TERMINATED_BLOCKED, client.olmId);
-            }
         });
+
+        // Push termination after commit so a misbehaving OLM stops pinging
+        // immediately instead of waiting for the offline checker.
+        if (client.olmId && client.online) {
+            await terminateAndDisconnect(
+                client.clientId,
+                OlmErrorCodes.TERMINATED_BLOCKED,
+                client.olmId
+            );
+        }
 
         return response(res, {
             data: null,

--- a/server/routers/client/deleteClient.ts
+++ b/server/routers/client/deleteClient.ts
@@ -10,7 +10,7 @@ import logger from "@server/logger";
 import { fromError } from "zod-validation-error";
 import { OpenAPITags, registry } from "@server/openApi";
 import { rebuildClientAssociationsFromClient } from "@server/lib/rebuildClientAssociations";
-import { sendTerminateClient } from "./terminate";
+import { terminateAndDisconnect } from "./terminate";
 import { OlmErrorCodes } from "../olm/error";
 
 const deleteClientSchema = z.strictObject({
@@ -71,7 +71,7 @@ export async function deleteClient(
             );
         }
 
-        await db.transaction(async (trx) => {
+        const toTerminate = await db.transaction(async (trx) => {
             // Then delete the client itself
             const [deletedClient] = await trx
                 .delete(clients)
@@ -91,10 +91,20 @@ export async function deleteClient(
 
             await rebuildClientAssociationsFromClient(deletedClient, trx);
 
-            if (olm) {
-                await sendTerminateClient(deletedClient.clientId, OlmErrorCodes.TERMINATED_DELETED, olm.olmId); //  the olmId needs to be provided because it cant look it up after deletion
-            }
+            // Return termination data for after-commit handling; olmId has to
+            // be captured here because it cant be looked up after deletion.
+            return olm
+                ? { clientId: deletedClient.clientId, olmId: olm.olmId }
+                : null;
         });
+
+        if (toTerminate) {
+            await terminateAndDisconnect(
+                toTerminate.clientId,
+                OlmErrorCodes.TERMINATED_DELETED,
+                toTerminate.olmId
+            );
+        }
 
         return response(res, {
             data: null,

--- a/server/routers/client/terminate.ts
+++ b/server/routers/client/terminate.ts
@@ -1,7 +1,8 @@
-import { sendToClient } from "#dynamic/routers/ws";
+import { disconnectClient, sendToClient } from "#dynamic/routers/ws";
 import { db, olms } from "@server/db";
 import { eq } from "drizzle-orm";
 import { OlmErrorCodes } from "../olm/error";
+import logger from "@server/logger";
 
 export async function sendTerminateClient(
     clientId: number,
@@ -27,4 +28,29 @@ export async function sendTerminateClient(
             message: error.message
         }
     });
+}
+
+/**
+ * Send a terminate message to the OLM, then force-close the WebSocket
+ * after a short delay so a misbehaving or unresponsive OLM stops pinging
+ * the server. Mirrors the pattern in olm/offlineChecker.ts. Errors are
+ * logged but not rethrown — by the time this runs the DB change that
+ * motivated the disconnect has already committed.
+ */
+export async function terminateAndDisconnect(
+    clientId: number,
+    error: (typeof OlmErrorCodes)[keyof typeof OlmErrorCodes],
+    olmId: string
+): Promise<void> {
+    try {
+        await sendTerminateClient(clientId, error, olmId);
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+        await disconnectClient(olmId);
+    } catch (err) {
+        logger.error("Failed to terminate and disconnect olm", {
+            olmId,
+            clientId,
+            err
+        });
+    }
 }

--- a/server/routers/newt/handleSocketMessages.ts
+++ b/server/routers/newt/handleSocketMessages.ts
@@ -24,8 +24,8 @@ export const handleDockerStatusMessage: MessageHandler = async (context) => {
 
     if (available) {
         logger.debug(`Newt ${newt.newtId} has Docker socket access`);
-        await cache.set(`${newt.newtId}:socketPath`, socketPath, 0);
-        await cache.set(`${newt.newtId}:isAvailable`, available, 0);
+        await cache.set(`${newt.newtId}:socketPath`, socketPath, 300);
+        await cache.set(`${newt.newtId}:isAvailable`, available, 300);
     } else {
         logger.debug(`Newt ${newt.newtId} does not have Docker socket access`);
     }
@@ -54,7 +54,7 @@ export const handleDockerContainersMessage: MessageHandler = async (
     );
 
     if (containers && containers.length > 0) {
-        await cache.set(`${newt.newtId}:dockerContainers`, containers, 0);
+        await cache.set(`${newt.newtId}:dockerContainers`, containers, 300);
     } else {
         logger.debug(`Newt ${newt.newtId} does not have Docker containers`);
     }

--- a/server/routers/newt/handleSocketMessages.ts
+++ b/server/routers/newt/handleSocketMessages.ts
@@ -24,6 +24,7 @@ export const handleDockerStatusMessage: MessageHandler = async (context) => {
 
     if (available) {
         logger.debug(`Newt ${newt.newtId} has Docker socket access`);
+        // TTL 300s — avoids permanent cache accumulation from stale newts
         await cache.set(`${newt.newtId}:socketPath`, socketPath, 300);
         await cache.set(`${newt.newtId}:isAvailable`, available, 300);
     } else {
@@ -54,6 +55,7 @@ export const handleDockerContainersMessage: MessageHandler = async (
     );
 
     if (containers && containers.length > 0) {
+        // TTL 300s — avoids permanent cache accumulation from stale newts
         await cache.set(`${newt.newtId}:dockerContainers`, containers, 300);
     } else {
         logger.debug(`Newt ${newt.newtId} does not have Docker containers`);

--- a/server/routers/olm/deleteUserOlm.ts
+++ b/server/routers/olm/deleteUserOlm.ts
@@ -10,7 +10,7 @@ import { fromError } from "zod-validation-error";
 import logger from "@server/logger";
 import { OpenAPITags, registry } from "@server/openApi";
 import { rebuildClientAssociationsFromClient } from "@server/lib/rebuildClientAssociations";
-import { sendTerminateClient } from "../client/terminate";
+import { terminateAndDisconnect } from "../client/terminate";
 import { OlmErrorCodes } from "./error";
 
 const paramsSchema = z
@@ -50,7 +50,7 @@ export async function deleteUserOlm(
         const { olmId } = parsedParams.data;
 
         // Delete associated clients and the OLM in a transaction
-        await db.transaction(async (trx) => {
+        const toTerminate = await db.transaction(async (trx) => {
             // Find all clients associated with this OLM
             const associatedClients = await trx
                 .select({ clientId: clients.clientId })
@@ -75,14 +75,24 @@ export async function deleteUserOlm(
             if (deletedClient) {
                 await rebuildClientAssociationsFromClient(deletedClient, trx);
                 if (olm) {
-                    await sendTerminateClient(
-                        deletedClient.clientId,
-                        OlmErrorCodes.TERMINATED_DELETED,
-                        olm.olmId
-                    ); //  the olmId needs to be provided because it cant look it up after deletion
+                    // Return termination data; olmId has to be captured here
+                    // because it cant be looked up after deletion.
+                    return {
+                        clientId: deletedClient.clientId,
+                        olmId: olm.olmId
+                    };
                 }
             }
+            return null;
         });
+
+        if (toTerminate) {
+            await terminateAndDisconnect(
+                toTerminate.clientId,
+                OlmErrorCodes.TERMINATED_DELETED,
+                toTerminate.olmId
+            );
+        }
 
         return response(res, {
             data: null,

--- a/server/routers/olm/handleOlmPingMessage.ts
+++ b/server/routers/olm/handleOlmPingMessage.ts
@@ -12,6 +12,11 @@ import { sha256 } from "@oslojs/crypto/sha2";
 import { sendOlmSyncMessage } from "./sync";
 import { handleFingerprintInsertion } from "./fingerprintingUtils";
 
+// Throttle expensive operations (session validation, config sync, fingerprint)
+// to once every 5 minutes per OLM instead of on every single ping.
+const FULL_CHECK_INTERVAL_MS = 5 * 60 * 1000;
+const lastFullCheck: Map<string, number> = new Map();
+
 /**
  * Handles ping messages from clients and responds with pong
  */
@@ -33,100 +38,90 @@ export const handleOlmPingMessage: MessageHandler = async (context) => {
 
     const isUserDevice = olm.userId !== null && olm.userId !== undefined;
 
+    // Determine if we need to run the expensive checks this ping
+    const now = Date.now();
+    const lastCheck = lastFullCheck.get(olm.olmId) || 0;
+    const needsFullCheck = now - lastCheck >= FULL_CHECK_INTERVAL_MS;
+
     try {
-        // get the client
-        const [client] = await db
-            .select()
-            .from(clients)
-            .where(eq(clients.clientId, olm.clientId))
-            .limit(1);
+        if (needsFullCheck) {
+            // Full validation: DB lookup, session check, policy, config sync, fingerprint
+            const [client] = await db
+                .select()
+                .from(clients)
+                .where(eq(clients.clientId, olm.clientId))
+                .limit(1);
 
-        if (!client) {
-            logger.warn("Client not found for olm ping");
-            return;
-        }
-
-        if (client.blocked) {
-            // NOTE: by returning we dont update the lastPing, so the offline checker will eventually disconnect them
-            logger.debug(
-                `Blocked client ${client.clientId} attempted olm ping`
-            );
-            return;
-        }
-
-        if (olm.userId) {
-            // we need to check a user token to make sure its still valid
-            const { session: userSession, user } =
-                await validateSessionToken(userToken);
-            if (!userSession || !user) {
-                logger.warn("Invalid user session for olm ping");
-                return; // by returning here we just ignore the ping and the setInterval will force it to disconnect
-            }
-            if (user.userId !== olm.userId) {
-                logger.warn("User ID mismatch for olm ping");
-                return;
-            }
-            if (user.userId !== client.userId) {
-                logger.warn("Client user ID mismatch for olm ping");
+            if (!client) {
+                logger.warn("Client not found for olm ping");
                 return;
             }
 
-            const sessionId = encodeHexLowerCase(
-                sha256(new TextEncoder().encode(userToken))
-            );
-
-            const policyCheck = await checkOrgAccessPolicy({
-                orgId: client.orgId,
-                userId: olm.userId,
-                sessionId // this is the user token passed in the message
-            });
-
-            if (!policyCheck.allowed) {
-                logger.warn(
-                    `Olm user ${olm.userId} does not pass access policies for org ${client.orgId}: ${policyCheck.error}`
+            if (client.blocked) {
+                logger.debug(
+                    `Blocked client ${client.clientId} attempted olm ping`
                 );
                 return;
             }
+
+            if (olm.userId) {
+                const { session: userSession, user } =
+                    await validateSessionToken(userToken);
+                if (!userSession || !user) {
+                    logger.warn("Invalid user session for olm ping");
+                    return;
+                }
+                if (user.userId !== olm.userId) {
+                    logger.warn("User ID mismatch for olm ping");
+                    return;
+                }
+                if (user.userId !== client.userId) {
+                    logger.warn("Client user ID mismatch for olm ping");
+                    return;
+                }
+
+                const sessionId = encodeHexLowerCase(
+                    sha256(new TextEncoder().encode(userToken))
+                );
+
+                const policyCheck = await checkOrgAccessPolicy({
+                    orgId: client.orgId,
+                    userId: olm.userId,
+                    sessionId
+                });
+
+                if (!policyCheck.allowed) {
+                    logger.warn(
+                        `Olm user ${olm.userId} does not pass access policies for org ${client.orgId}: ${policyCheck.error}`
+                    );
+                    return;
+                }
+            }
+
+            const configVersion = await getClientConfigVersion(olm.olmId);
+
+            if (
+                message.configVersion != null &&
+                configVersion != null &&
+                configVersion != message.configVersion
+            ) {
+                logger.debug(
+                    `handleOlmPingMessage: Olm ping with outdated config version: ${message.configVersion} (current: ${configVersion})`
+                );
+                await sendOlmSyncMessage(olm, client);
+            }
+
+            if (isUserDevice) {
+                await handleFingerprintInsertion(olm, fingerprint, postures);
+            }
+
+            lastFullCheck.set(olm.olmId, now);
         }
 
-        // get the version
-        logger.debug(
-            `handleOlmPingMessage: About to get config version for olmId: ${olm.olmId}`
-        );
-        const configVersion = await getClientConfigVersion(olm.olmId);
-        logger.debug(
-            `handleOlmPingMessage: Got config version: ${configVersion} (type: ${typeof configVersion})`
-        );
-
-        if (configVersion == null || configVersion === undefined) {
-            logger.debug(
-                `handleOlmPingMessage: could not get config version from server for olmId: ${olm.olmId}`
-            );
-        }
-
-        if (
-            message.configVersion != null &&
-            configVersion != null &&
-            configVersion != message.configVersion
-        ) {
-            logger.debug(
-                `handleOlmPingMessage: Olm ping with outdated config version: ${message.configVersion} (current: ${configVersion})`
-            );
-            await sendOlmSyncMessage(olm, client);
-        }
-
-        // Record the ping in memory; it will be flushed to the database
-        // periodically by the ping accumulator (every ~10s) in a single
-        // batched UPDATE instead of one query per ping. This prevents
-        // connection pool exhaustion under load, especially with
-        // cross-region latency to the database.
+        // Always record the ping (cheap in-memory Map.set)
         recordClientPing(olm.clientId, olm.olmId, !!olm.archived);
     } catch (error) {
         logger.error("Error handling ping message", { error });
-    }
-
-    if (isUserDevice) {
-        await handleFingerprintInsertion(olm, fingerprint, postures);
     }
 
     return {

--- a/server/routers/olm/handleOlmPingMessage.ts
+++ b/server/routers/olm/handleOlmPingMessage.ts
@@ -56,14 +56,10 @@ export const handleOlmPingMessage: MessageHandler = async (context) => {
         // Fast-path: single PK SELECT on every ping. Cheap enough to run
         // unthrottled, and gating recordClientPing on the blocked check
         // preserves the offline-checker-driven disconnect path for blocked
-        // clients.
+        // clients. Selects the full row because sendOlmSyncMessage needs it
+        // on the slow-path config-mismatch branch.
         const [client] = await db
-            .select({
-                clientId: clients.clientId,
-                userId: clients.userId,
-                orgId: clients.orgId,
-                blocked: clients.blocked
-            })
+            .select()
             .from(clients)
             .where(eq(clients.clientId, olm.clientId))
             .limit(1);

--- a/server/routers/olm/handleOlmPingMessage.ts
+++ b/server/routers/olm/handleOlmPingMessage.ts
@@ -13,9 +13,19 @@ import { sendOlmSyncMessage } from "./sync";
 import { handleFingerprintInsertion } from "./fingerprintingUtils";
 
 // Throttle expensive operations (session validation, config sync, fingerprint)
-// to once every 5 minutes per OLM instead of on every single ping.
+// to once every 5 minutes per OLM. The cheap PK lookup that checks
+// `clients.blocked` still runs every ping so admin block actions take effect
+// immediately via the offline checker.
 const FULL_CHECK_INTERVAL_MS = 5 * 60 * 1000;
 const lastFullCheck: Map<string, number> = new Map();
+
+/**
+ * Drop a per-OLM throttle entry. Called from the WS close handler so the
+ * map doesn't accumulate entries for the process lifetime as OLMs churn.
+ */
+export function evictOlmPingState(olmId: string): void {
+    lastFullCheck.delete(olmId);
+}
 
 /**
  * Handles ping messages from clients and responds with pong
@@ -38,32 +48,42 @@ export const handleOlmPingMessage: MessageHandler = async (context) => {
 
     const isUserDevice = olm.userId !== null && olm.userId !== undefined;
 
-    // Determine if we need to run the expensive checks this ping
     const now = Date.now();
     const lastCheck = lastFullCheck.get(olm.olmId) || 0;
     const needsFullCheck = now - lastCheck >= FULL_CHECK_INTERVAL_MS;
 
     try {
+        // Fast-path: single PK SELECT on every ping. Cheap enough to run
+        // unthrottled, and gating recordClientPing on the blocked check
+        // preserves the offline-checker-driven disconnect path for blocked
+        // clients.
+        const [client] = await db
+            .select({
+                clientId: clients.clientId,
+                userId: clients.userId,
+                orgId: clients.orgId,
+                blocked: clients.blocked
+            })
+            .from(clients)
+            .where(eq(clients.clientId, olm.clientId))
+            .limit(1);
+
+        if (!client) {
+            logger.warn("Client not found for olm ping");
+            return;
+        }
+
+        if (client.blocked) {
+            // NOTE: by returning we dont update the lastPing, so the offline
+            // checker will eventually disconnect them.
+            logger.debug(
+                `Blocked client ${client.clientId} attempted olm ping`
+            );
+            return;
+        }
+
         if (needsFullCheck) {
-            // Full validation: DB lookup, session check, policy, config sync, fingerprint
-            const [client] = await db
-                .select()
-                .from(clients)
-                .where(eq(clients.clientId, olm.clientId))
-                .limit(1);
-
-            if (!client) {
-                logger.warn("Client not found for olm ping");
-                return;
-            }
-
-            if (client.blocked) {
-                logger.debug(
-                    `Blocked client ${client.clientId} attempted olm ping`
-                );
-                return;
-            }
-
+            // Slow-path: session validation, policy, config sync, fingerprint.
             if (olm.userId) {
                 const { session: userSession, user } =
                     await validateSessionToken(userToken);
@@ -118,7 +138,6 @@ export const handleOlmPingMessage: MessageHandler = async (context) => {
             lastFullCheck.set(olm.olmId, now);
         }
 
-        // Always record the ping (cheap in-memory Map.set)
         recordClientPing(olm.clientId, olm.olmId, !!olm.archived);
     } catch (error) {
         logger.error("Error handling ping message", { error });

--- a/server/routers/olm/handleOlmPingMessage.ts
+++ b/server/routers/olm/handleOlmPingMessage.ts
@@ -13,19 +13,9 @@ import { sendOlmSyncMessage } from "./sync";
 import { handleFingerprintInsertion } from "./fingerprintingUtils";
 
 // Throttle expensive operations (session validation, config sync, fingerprint)
-// to once every 5 minutes per OLM. The cheap PK lookup that checks
-// `clients.blocked` still runs every ping so admin block actions take effect
-// immediately via the offline checker.
+// to once every 5 minutes per OLM instead of on every single ping.
 const FULL_CHECK_INTERVAL_MS = 5 * 60 * 1000;
 const lastFullCheck: Map<string, number> = new Map();
-
-/**
- * Drop a per-OLM throttle entry. Called from the WS close handler so the
- * map doesn't accumulate entries for the process lifetime as OLMs churn.
- */
-export function evictOlmPingState(olmId: string): void {
-    lastFullCheck.delete(olmId);
-}
 
 /**
  * Handles ping messages from clients and responds with pong
@@ -48,38 +38,32 @@ export const handleOlmPingMessage: MessageHandler = async (context) => {
 
     const isUserDevice = olm.userId !== null && olm.userId !== undefined;
 
+    // Determine if we need to run the expensive checks this ping
     const now = Date.now();
     const lastCheck = lastFullCheck.get(olm.olmId) || 0;
     const needsFullCheck = now - lastCheck >= FULL_CHECK_INTERVAL_MS;
 
     try {
-        // Fast-path: single PK SELECT on every ping. Cheap enough to run
-        // unthrottled, and gating recordClientPing on the blocked check
-        // preserves the offline-checker-driven disconnect path for blocked
-        // clients. Selects the full row because sendOlmSyncMessage needs it
-        // on the slow-path config-mismatch branch.
-        const [client] = await db
-            .select()
-            .from(clients)
-            .where(eq(clients.clientId, olm.clientId))
-            .limit(1);
-
-        if (!client) {
-            logger.warn("Client not found for olm ping");
-            return;
-        }
-
-        if (client.blocked) {
-            // NOTE: by returning we dont update the lastPing, so the offline
-            // checker will eventually disconnect them.
-            logger.debug(
-                `Blocked client ${client.clientId} attempted olm ping`
-            );
-            return;
-        }
-
         if (needsFullCheck) {
-            // Slow-path: session validation, policy, config sync, fingerprint.
+            // Full validation: DB lookup, session check, policy, config sync, fingerprint
+            const [client] = await db
+                .select()
+                .from(clients)
+                .where(eq(clients.clientId, olm.clientId))
+                .limit(1);
+
+            if (!client) {
+                logger.warn("Client not found for olm ping");
+                return;
+            }
+
+            if (client.blocked) {
+                logger.debug(
+                    `Blocked client ${client.clientId} attempted olm ping`
+                );
+                return;
+            }
+
             if (olm.userId) {
                 const { session: userSession, user } =
                     await validateSessionToken(userToken);
@@ -134,6 +118,7 @@ export const handleOlmPingMessage: MessageHandler = async (context) => {
             lastFullCheck.set(olm.olmId, now);
         }
 
+        // Always record the ping (cheap in-memory Map.set)
         recordClientPing(olm.clientId, olm.olmId, !!olm.archived);
     } catch (error) {
         logger.error("Error handling ping message", { error });

--- a/server/routers/ws/ws.ts
+++ b/server/routers/ws/ws.ts
@@ -29,6 +29,7 @@ import {
     SendMessageOptions
 } from "./types";
 import { validateSessionToken } from "@server/auth/sessions/app";
+import { evictOlmPingState } from "@server/routers/olm/handleOlmPingMessage";
 
 // Subset of TokenPayload for public ws.ts (newt and olm only)
 interface PublicTokenPayload {
@@ -391,6 +392,9 @@ const setupConnection = async (
 
     ws.on("close", () => {
         removeClient(clientType, clientId, ws);
+        if (clientType === "olm") {
+            evictOlmPingState(clientId);
+        }
         logger.info(
             `Client disconnected - ${clientType.toUpperCase()} ID: ${clientId}`
         );

--- a/server/routers/ws/ws.ts
+++ b/server/routers/ws/ws.ts
@@ -29,7 +29,6 @@ import {
     SendMessageOptions
 } from "./types";
 import { validateSessionToken } from "@server/auth/sessions/app";
-import { evictOlmPingState } from "@server/routers/olm/handleOlmPingMessage";
 
 // Subset of TokenPayload for public ws.ts (newt and olm only)
 interface PublicTokenPayload {
@@ -392,9 +391,6 @@ const setupConnection = async (
 
     ws.on("close", () => {
         removeClient(clientType, clientId, ws);
-        if (clientType === "olm") {
-            evictOlmPingState(clientId);
-        }
         logger.info(
             `Client disconnected - ${clientType.toUpperCase()} ID: ${clientId}`
         );


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

  ## Summary

  Fixes #2120 — rising memory floor and CPU spikes that cause Uptime Kuma timeouts and OOM container kills on small instances. Touches the OLM ping hot
   path, audit/status log retention, Docker socket cache, Traefik config rebuild cadence, and SQLite driver setup. After this PR the same workload runs
   cleanly on a 1 GB instance.

  ## AI Disclosure

  This PR was developed with AI assistance. Models used during exploration and implementation: **Claude Opus 4.6** and **Claude Opus 4.7**. Three
  different agentic environments were tried — **Zed editor (Zed Agent)**, **OpenCode**, and **Claude Code** — with the best results coming from Claude
  Code. All changes were reviewed, tested, and validated against a real production workload before merging (see Test Environment).

  ## Test Environment

  - **Host:** AWS `t3a.micro` (2 vCPU burstable, 1 GB RAM)
  - **OS:** Ubuntu 24.04
  - **Workload:** 2 newt tunnels, 17 public resources, Uptime Kuma actively monitoring the instance
  - **Result:** 1466+ minutes uptime with stable memory baseline at the time of writing

  ## Changes

  ### 1. Throttle expensive OLM ping operations (`daafccb1`) — biggest impact

  **File:** `server/routers/olm/handleOlmPingMessage.ts`

  Before, every OLM ping ran 5–10 DB operations: full client SELECT, session validation, organization access policy check, config version lookup, and
  fingerprint insertion. Under sustained Uptime Kuma probing this was the dominant source of CPU + SQLite contention.

  Now the expensive checks run at most once every 5 minutes per OLM. Pings between checks only run the cheap in-memory `recordClientPing()`, which is
  then batch-flushed by the existing ping accumulator. This was the single biggest performance win in the PR.

  **Known behavioral side-effects.** Admin actions (block / delete / unlink) are made immediate via change #2 below. The following state changes are
  *not* push-mitigated and lag by up to ~5 minutes — by design:

  - **Natural session expiry / `invalidateSession()`** — OLM keeps tunneling for up to ~7 minutes after the session is invalid (5 min until slow-path
  detection + ~2 min offline-checker grace).
  - **Org-membership / access-policy revocation** — same ~7 min lag.
  - **`client.userId` mismatch** (edge case: client reassigned to a different user) — same lag.
  - **Config-version-mismatch fallback sync** — primary config push still happens immediately on resource/target updates via `incrementConfigVersion:
  true`. Only the ping-side fallback (for missed pushes) is delayed.
  - **Fingerprint / posture snapshots** — now recorded every 5 min instead of every ping. Affects audit visibility, not active access enforcement.

  **Other behavior changes worth noting:**

  - `lastFullCheck` Map has no eviction-on-disconnect. ~50 bytes per unique OLM, negligible for typical deployments but technically unbounded over the
  process lifetime. (Eviction was implemented in a follow-up but was bundled with the reverted commit — see Reverted section.)
  - First ping after a process restart triggers a full check for every OLM. Expect a brief CPU + DB burst at startup as many reconnects coincide.
  - Multi-node deployments don't share throttle state — each node has its own `lastFullCheck` Map.
  - `handleFingerprintInsertion()` errors are now caught and logged rather than propagated. Stability improvement; behavior change.
  - `FULL_CHECK_INTERVAL_MS = 5 * 60 * 1000` is hard-coded — not configurable.

  **Mitigation paths for deployments that need stricter enforcement:**

  - (a) Call `disconnectClient(olmId)` from your session-invalidation / org-removal paths (deferred follow-up — see `terminateAndDisconnect()` in
  `server/routers/client/terminate.ts` for the pattern).
  - (b) Shorten `FULL_CHECK_INTERVAL_MS` in `handleOlmPingMessage.ts`, accepting some CPU/memory cost back.

  ### 2. Push-based OLM termination on block/delete (`07f7151b`)

  **Files:** `server/routers/client/terminate.ts`, `blockClient.ts`, `deleteClient.ts`, `server/routers/olm/deleteUserOlm.ts`

  The throttle in change #1 introduced a side-effect: admin actions like blocking or deleting a client took up to ~7 minutes to take effect (5 min
  until the next slow-path check + 2 min offline-checker grace). Previously the offline checker handled this via `lastPing` not being updated, but with
   the throttle that mechanism no longer fired on the fast path.

  Instead of putting per-ping checks back (see Reverted section), we now push termination from the endpoints that mutate auth state. A new
  `terminateAndDisconnect(clientId, error, olmId)` helper sends the existing `olm/terminate` message, waits 1 second, then force-closes the WebSocket —
   mirroring the pattern already used by `server/routers/olm/offlineChecker.ts`. Wired into `blockClient`, `deleteClient`, and `deleteUserOlm`.
  Termination is moved outside the DB transaction so the 1-second sleep doesn't hold the SQLite write lock.

  Admin actions now take effect immediately, with zero per-ping cost.

  ### 3. Add `statusHistory` table cleanup (`7001ad8f`)

  **File:** `server/lib/cleanupLogs.ts`

  The `statusHistory` table had no cleanup mechanism and grew without bound, which is one of the contributors to the rising-floor memory pattern. Added
   a 90-day retention sweep to the existing 3-hour cleanup interval.

  ### 4. Increase TraefikConfigManager default interval 5s → 30s (`c561ba51`)

  **File:** `server/lib/readConfigFile.ts`

  Each Traefik config rebuild allocates 3–6 MB of temporary objects. At a 5-second interval on a small instance that's significant GC churn for a
  config that changes rarely. Default raised to 30s. Existing deployments with `monitor_interval` set explicitly are unaffected.

  ### 5. Add TTL to Docker container/socket cache entries (`f03d690f`)

  **File:** `server/routers/newt/handleSocketMessages.ts`

  `cache.set(..., 0)` for `socketPath`, `isAvailable`, and `dockerContainers` meant entries never expired and accumulated permanently as newts churned.
   Changed TTL to 300s (5 minutes). The cache is repopulated on demand when the UI fetches container info.

  ### 6. Remove `autoFinalizeStatement` wrapper (`16bcc552`)

  **File:** `server/db/sqlite/driver.ts`

  The wrapper was added to deterministically finalize prepared statements after each `.run() / .get() / .all()`, on the assumption that
  `better-sqlite3` was leaking statements. Investigation showed the assumption is wrong: `better-sqlite3`'s `Statement::~Statement()` destructor calls
  `sqlite3_finalize()` when the JS wrapper is garbage-collected (see C++ source). The wrapper added per-query overhead, and its
  finalize-after-first-execution behavior would have silently broken any reusable prepared statement.

  ### 7. Remove `mmap_size` and `cache_size` pragmas (`1cdd7dba`)

  **File:** `server/db/sqlite/driver.ts`

  Both pragmas were causing performance issues on small instances and were removed.

  ## Reverted changes

  We tried one approach that had to be reverted. Documenting it because the original reasoning was sound and someone may be tempted to retry.

  ### Reverted: per-ping fast-path block check (`ab7c61c4` + `1f8fddf8`, reverted in `a248a211`)

  **Why we tried it:** the throttle in change #1 delayed admin block enforcement by up to 5 minutes. The original commit added a cheap PK `SELECT` on
  `clients` to every ping so blocked clients would be caught immediately by the offline checker — adding back ~1 DB op per ping in exchange for a
  5-minute → 2-minute enforcement window. Query-count math said this was still ~85% below the leaking pre-PR baseline, and the SELECT was projected to
  just 4 columns.

  **Why we reverted:** the query-count math missed the actual leak vector. With the `autoFinalize` wrapper removed (change #6), each per-ping ad-hoc
  query allocates a native `sqlite3_stmt` that only releases on V8 GC. Drizzle doesn't cache statements automatically. On a 1 GB instance under
  sustained ping load, GC fell behind native allocation, off-heap RSS climbed, and the symptoms reappeared (Uptime Kuma timeouts, OOM kills) within
  hours of deploying.

  The proper fix turned out to be push-based termination (change #2), which has zero per-ping cost and gives faster enforcement than the per-ping check
   would have.

  **Lesson:** in this codebase, any per-ping ad-hoc DB query in the OLM ping path is suspect on small instances. If per-ping checks are ever genuinely
  needed, they must use explicitly cached prepared statements (`drizzle.prepare()`) or in-memory state with explicit invalidation — not ad-hoc queries.

  ## Operational notes

  ### WAL mode and HTTPS Request Log Retention

  WAL mode is opt-in via `ENABLE_SQLITE_WAL_MODE=true` (see `c8e7e0ee`).

  Empirically:

  - **WAL off** (default): stable on a 1 GB instance with HTTPS request log retention **disabled**.
  - **WAL off + HTTPS request log retention enabled**: write-lock contention from per-request audit log inserts cascades into event-loop stalls and
  forced restarts on small instances.
  - **WAL on + HTTPS request log retention enabled**: stable.

  **Recommendation for ≤ 1 GB deployments:** if you want HTTPS request log retention turned on, set `ENABLE_SQLITE_WAL_MODE=true`. With request logging
   off, the default (WAL off) is fine.

  WAL remains opt-in rather than default because the disable in `c8e7e0ee` was deliberate — see that commit for the rationale.

  ## Test plan

  - [x] OLM tunnels stay connected and continue to ping under load
  - [x] Admin block / delete / unlink endpoints terminate active OLM sessions immediately
  - [x] `statusHistory` retention sweep runs without errors
  - [x] Docker container/socket cache repopulates on demand after TTL expiry
  - [x] Stable memory baseline over 24+ hours on `t3a.micro` (verified 1466+ min)
  - [x] Stable behavior with HTTPS Request Log Retention enabled when `ENABLE_SQLITE_WAL_MODE=true`

