### PR TITLE
fix(audit-logs): route request audit log reads through logsDb

### DIFF
--- a/server/routers/auditLogs/queryRequestAnalytics.ts
+++ b/server/routers/auditLogs/queryRequestAnalytics.ts
@@ -1,4 +1,4 @@
-import { logsDb, requestAuditLog, driver, primaryLogsDb } from "@server/db";
+import { logsDb, requestAuditLog, driver } from "@server/db";
 import { registry } from "@server/openApi";
 import { NextFunction } from "express";
 import { Request, Response } from "express";
@@ -74,12 +74,12 @@ async function query(query: Q) {
         );
     }
 
-    const [all] = await primaryLogsDb
+    const [all] = await logsDb
         .select({ total: count() })
         .from(requestAuditLog)
         .where(baseConditions);
 
-    const [blocked] = await primaryLogsDb
+    const [blocked] = await logsDb
         .select({ total: count() })
         .from(requestAuditLog)
         .where(and(baseConditions, eq(requestAuditLog.action, false)));
@@ -90,7 +90,7 @@ async function query(query: Q) {
 
     const DISTINCT_LIMIT = 500;
 
-    const requestsPerCountry = await primaryLogsDb
+    const requestsPerCountry = await logsDb
         .selectDistinct({
             code: requestAuditLog.location,
             count: totalQ
@@ -118,7 +118,7 @@ async function query(query: Q) {
     const booleanTrue = driver === "pg" ? sql`true` : sql`1`;
     const booleanFalse = driver === "pg" ? sql`false` : sql`0`;
 
-    const requestsPerDay = await primaryLogsDb
+    const requestsPerDay = await logsDb
         .select({
             day: groupByDayFunction.as("day"),
             allowedCount:

--- a/server/routers/auditLogs/queryRequestAuditLog.ts
+++ b/server/routers/auditLogs/queryRequestAuditLog.ts
@@ -1,4 +1,4 @@
-import { logsDb, primaryLogsDb, requestAuditLog, resources, siteResources, db, primaryDb } from "@server/db";
+import { logsDb, requestAuditLog, resources, siteResources, db, primaryDb } from "@server/db";
 import { registry } from "@server/openApi";
 import { NextFunction } from "express";
 import { Request, Response } from "express";
@@ -110,7 +110,7 @@ function getWhere(data: Q) {
 }
 
 export function queryRequest(data: Q) {
-    return primaryLogsDb
+    return logsDb
         .select({
             id: requestAuditLog.id,
                 timestamp: requestAuditLog.timestamp,
@@ -211,7 +211,7 @@ async function enrichWithResourceDetails(logs: Awaited<ReturnType<typeof queryRe
 }
 
 export function countRequestQuery(data: Q) {
-    const countQuery = primaryLogsDb
+    const countQuery = logsDb
         .select({ count: count() })
         .from(requestAuditLog)
         .where(getWhere(data));
@@ -254,34 +254,34 @@ async function queryUniqueFilterAttributes(
         uniqueResources,
         uniqueSiteResources
     ] = await Promise.all([
-        primaryLogsDb
+        logsDb
             .selectDistinct({ actor: requestAuditLog.actor })
             .from(requestAuditLog)
             .where(baseConditions)
             .limit(DISTINCT_LIMIT + 1),
-        primaryLogsDb
+        logsDb
             .selectDistinct({ locations: requestAuditLog.location })
             .from(requestAuditLog)
             .where(baseConditions)
             .limit(DISTINCT_LIMIT + 1),
-        primaryLogsDb
+        logsDb
             .selectDistinct({ hosts: requestAuditLog.host })
             .from(requestAuditLog)
             .where(baseConditions)
             .limit(DISTINCT_LIMIT + 1),
-        primaryLogsDb
+        logsDb
             .selectDistinct({ paths: requestAuditLog.path })
             .from(requestAuditLog)
             .where(baseConditions)
             .limit(DISTINCT_LIMIT + 1),
-        primaryLogsDb
+        logsDb
             .selectDistinct({
                 id: requestAuditLog.resourceId
             })
             .from(requestAuditLog)
             .where(baseConditions)
             .limit(DISTINCT_LIMIT + 1),
-        primaryLogsDb
+        logsDb
             .selectDistinct({
                 id: requestAuditLog.siteResourceId
             })


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description

Route the read paths in `server/routers/auditLogs/queryRequestAuditLog.ts` and `server/routers/auditLogs/queryRequestAnalytics.ts` through `logsDb` instead of `primaryLogsDb`, matching the existing private audit log routes (`queryActionAuditLog`, `queryAccessAuditLog`, `queryConnectionAuditLog` all already use `logsDb`).

In Postgres deployments configured with read replicas via `withReplicas` (`server/db/pg/logsDriver.ts`), this lets high-volume audit log reads use the replica pool instead of contending with writes on the primary. No-op on SQLite where `logsDb === primaryDb`.

### Why not also rewrite the facet queries?

While here, I benchmarked a candidate rewrite for the `// TODO: SOMEONE PLEASE OPTIMIZE THIS!!!!!` at `queryRequestAuditLog.ts:246`. Replacing the six parallel \`selectDistinct\` queries with a single \`UNION ALL\` over six \`GROUP BY ... LIMIT 500\` arms is **48-61% slower** on SQLite at 100k / 300k / 1M rows (20 runs per impl per size):

| Size | OLD \`SELECT DISTINCT LIMIT 501\` | \`UNION ALL\` rewrite | 6 × \`Promise.all\` \`GROUP BY\` |
|---|---:|---:|---:|
| 100k | 103.5 ms | 153.4 ms (+48.1%) | 153.6 ms (+48.3%) |
| 300k | 629.7 ms | 1015.1 ms (+61.2%) | 972.6 ms (+54.4%) |
| 1M   | 3152.1 ms | 4821.9 ms (+53.0%) | 4825.9 ms (+53.1%) |

\`EXPLAIN QUERY PLAN\` shows each grouped arm does \`USE TEMP B-TREE FOR GROUP BY\` — every distinct value is materialized before \`LIMIT\` truncates. The current DISTINCT+LIMIT short-circuits via hash dedup with early exit, which wins for the low-cardinality dropdown shape this endpoint produces. The long-term fix is likely a materialized facets table refreshed by a background job, not a query-shape rewrite.

## How to test?

1. \`npx tsc --noEmit\` — no new errors introduced in the changed files (same pre-existing error count before and after).
2. Manual check on an OSS SQLite stack: load \`/[orgId]/settings/logs/request\` in the dashboard; confirm the response shape (logs, pagination, filter dropdowns) is unchanged.
3. SaaS verification: in a Postgres deployment with \`postgres_logs.replicas\` configured, observe that requests to \`GET /org/{orgId}/logs/request\` route through the replica pool instead of incrementing query counters on the primary log DB.