### PR TITLE
fix(logs): refresh default end time

### DIFF
--- a/src/app/[orgId]/settings/logs/access/page.tsx
+++ b/src/app/[orgId]/settings/logs/access/page.tsx
@@ -280,10 +280,14 @@ export default function GeneralPage() {
         console.log("Data refreshed");
         setIsRefreshing(true);
         try {
+            const endDate = searchParams.get("end")
+                ? dateRange.endDate
+                : { date: new Date() };
+            setDateRange((current) => ({ ...current, endDate }));
             // Refresh data with current date range and pagination
             await queryDateTime(
                 dateRange.startDate,
-                dateRange.endDate,
+                endDate,
                 currentPage,
                 pageSize
             );

--- a/src/app/[orgId]/settings/logs/action/page.tsx
+++ b/src/app/[orgId]/settings/logs/action/page.tsx
@@ -266,10 +266,14 @@ export default function GeneralPage() {
         console.log("Data refreshed");
         setIsRefreshing(true);
         try {
+            const endDate = searchParams.get("end")
+                ? dateRange.endDate
+                : { date: new Date() };
+            setDateRange((current) => ({ ...current, endDate }));
             // Refresh data with current date range and pagination
             await queryDateTime(
                 dateRange.startDate,
-                dateRange.endDate,
+                endDate,
                 currentPage,
                 pageSize
             );

--- a/src/app/[orgId]/settings/logs/connection/page.tsx
+++ b/src/app/[orgId]/settings/logs/connection/page.tsx
@@ -306,10 +306,14 @@ export default function ConnectionLogsPage() {
         console.log("Data refreshed");
         setIsRefreshing(true);
         try {
+            const endDate = searchParams.get("end")
+                ? dateRange.endDate
+                : { date: new Date() };
+            setDateRange((current) => ({ ...current, endDate }));
             // Refresh data with current date range and pagination
             await queryDateTime(
                 dateRange.startDate,
-                dateRange.endDate,
+                endDate,
                 currentPage,
                 pageSize
             );

--- a/src/app/[orgId]/settings/logs/request/page.tsx
+++ b/src/app/[orgId]/settings/logs/request/page.tsx
@@ -281,10 +281,14 @@ export default function GeneralPage() {
         console.log("Data refreshed");
         setIsRefreshing(true);
         try {
+            const endDate = searchParams.get("end")
+                ? dateRange.endDate
+                : { date: new Date() };
+            setDateRange((current) => ({ ...current, endDate }));
             // Refresh data with current date range and pagination
             await queryDateTime(
                 dateRange.startDate,
-                dateRange.endDate,
+                endDate,
                 currentPage,
                 pageSize
             );


### PR DESCRIPTION
## Summary
- advances the log query end time to the current time when refreshing the default live range
- preserves an explicit end time when the user has selected one in the URL
- applies the behavior consistently across request, access, action, and connection log pages

## Why
The log pages initialize their default end time to now, but the refresh action reused that stale timestamp. For a user watching logs with the default range, refresh could keep querying the old upper bound instead of including newly written rows.

## Verification
- git diff --check
- attempted npm run dev:check, but this checkout has no node_modules installed and npx tried to install the unrelated tsc package instead of using a local TypeScript compiler