### PR TITLE
Enable compression in Traefik by default

### DIFF
--- a/config/traefik/dynamic_config.yml
+++ b/config/traefik/dynamic_config.yml
@@ -7,6 +7,8 @@ http:
     redirect-to-https:
       redirectScheme:
         scheme: https
+    compress:
+      compress: {}
 
   routers:
     # HTTP to HTTPS redirect router
@@ -18,6 +20,7 @@ http:
       middlewares:
         - redirect-to-https
         - badger
+        - compress
 
     # Next.js router (handles everything except API and WebSocket paths)
     next-router:
@@ -27,6 +30,7 @@ http:
         - websecure
       middlewares:
         - badger
+        - compress
       tls:
         certResolver: letsencrypt
 
@@ -38,6 +42,7 @@ http:
         - websecure
       middlewares:
         - badger
+        - compress
       tls:
         certResolver: letsencrypt
 

--- a/config/traefik/traefik_config.yml
+++ b/config/traefik/traefik_config.yml
@@ -46,6 +46,8 @@ entryPoints:
       encodedCharacters:
         allowEncodedSlash: true
         allowEncodedQuestionMark: true
+      middlewares:
+        - compress@file
 
 serversTransport:
   insecureSkipVerify: true

--- a/install/config/traefik/dynamic_config.yml
+++ b/install/config/traefik/dynamic_config.yml
@@ -7,6 +7,8 @@ http:
     redirect-to-https:
       redirectScheme:
         scheme: https
+    compress:
+      compress: {}
 
   routers:
     # HTTP to HTTPS redirect router

--- a/install/config/traefik/dynamic_config.yml
+++ b/install/config/traefik/dynamic_config.yml
@@ -20,6 +20,7 @@ http:
       middlewares:
         - redirect-to-https
         - badger
+        - compress
 
     # Next.js router (handles everything except API and WebSocket paths)
     next-router:
@@ -29,6 +30,7 @@ http:
         - websecure
       middlewares:
         - badger
+        - compress
       tls:
         certResolver: letsencrypt
 
@@ -40,6 +42,7 @@ http:
         - websecure
       middlewares:
         - badger
+        - compress
       tls:
         certResolver: letsencrypt
 
@@ -51,6 +54,7 @@ http:
         - websecure
       middlewares:
         - badger
+        - compress
       tls:
         certResolver: letsencrypt
 

--- a/install/config/traefik/traefik_config.yml
+++ b/install/config/traefik/traefik_config.yml
@@ -48,6 +48,8 @@ entryPoints:
       encodedCharacters:
         allowEncodedSlash: true
         allowEncodedQuestionMark: true
+      middlewares:
+        - compress@file
 
 serversTransport:
   insecureSkipVerify: true


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description
Enable the compress middleware by default for all http requests. (defaults are fine supporting modern zstd and falls back to gzip)

FYI: This is what I am running on my Pangolin... and mostly exists for reference depending on what path the dev team wants to head.

Update: That 250ms to 200ms is a nice drop as well.... 

## How to test?

