### PR TITLE
feat(audit-logs): cache request audit log filter facets

### DIFF
--- a/server/routers/auditLogs/queryRequestAuditLog.ts
+++ b/server/routers/auditLogs/queryRequestAuditLog.ts
@@ -12,6 +12,7 @@ import { QueryRequestAuditLogResponse } from "@server/routers/auditLogs/types";
 import response from "@server/lib/response";
 import logger from "@server/logger";
 import { getSevenDaysAgo } from "@app/lib/getSevenDaysAgo";
+import { regionalCache as cache } from "#dynamic/lib/cache";
 
 export const queryAccessAuditLogsQuery = z.object({
     // iso string just validate its a parseable date
@@ -230,11 +231,52 @@ registry.registerPath({
     responses: {}
 });
 
+const FACETS_CACHE_TTL_SECONDS = 60;
+const FACETS_CACHE_KEY_BUCKET_SECONDS = 60;
+const FACETS_CACHE_KEY_VERSION = "v1";
+
+type FacetsResult = {
+    actors: string[];
+    resources: Array<{ id: number; name: string | null }>;
+    locations: string[];
+    hosts: string[];
+    paths: string[];
+};
+
+// Bucket timestamps to FACETS_CACHE_KEY_BUCKET_SECONDS boundaries so
+// dashboard refreshes within the same minute hit cache. Combined with the
+// 60s TTL, this means facet dropdowns are approximate to within ~60s, not
+// strictly fresh. The version segment guards against future shape changes.
+function buildFacetsCacheKey(
+    orgId: string,
+    timeStart: number,
+    timeEnd: number
+): string {
+    const startBucket =
+        Math.floor(timeStart / FACETS_CACHE_KEY_BUCKET_SECONDS) *
+        FACETS_CACHE_KEY_BUCKET_SECONDS;
+    const endBucket =
+        Math.floor(timeEnd / FACETS_CACHE_KEY_BUCKET_SECONDS) *
+        FACETS_CACHE_KEY_BUCKET_SECONDS;
+    return `cache:audit-log-facets:${FACETS_CACHE_KEY_VERSION}:${orgId}:${startBucket}:${endBucket}`;
+}
+
 async function queryUniqueFilterAttributes(
     timeStart: number,
     timeEnd: number,
     orgId: string
-) {
+): Promise<FacetsResult> {
+    const cacheKey = buildFacetsCacheKey(orgId, timeStart, timeEnd);
+
+    // Cache read - never fail the request on cache error.
+    let cached: FacetsResult | undefined;
+    try {
+        cached = await cache.get<FacetsResult>(cacheKey);
+    } catch (err) {
+        logger.warn(`Facets cache get failed for ${cacheKey}`, err);
+    }
+    if (cached !== undefined) return cached;
+
     const baseConditions = and(
         gt(requestAuditLog.timestamp, timeStart),
         lt(requestAuditLog.timestamp, timeEnd),
@@ -349,7 +391,7 @@ async function queryUniqueFilterAttributes(
         ];
     }
 
-    return {
+    const result: FacetsResult = {
         actors: uniqueActors
             .map((row) => row.actor)
             .filter((actor): actor is string => actor !== null),
@@ -364,6 +406,14 @@ async function queryUniqueFilterAttributes(
             .map((row) => row.paths)
             .filter((path): path is string => path !== null)
     };
+
+    // Cache write - never fail the request on cache error.
+    try {
+        await cache.set(cacheKey, result, FACETS_CACHE_TTL_SECONDS);
+    } catch (err) {
+        logger.warn(`Facets cache set failed for ${cacheKey}`, err);
+    }
+    return result;
 }
 
 export async function queryRequestAuditLogs(


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description

Followup to #3148. As discussed in that thread, this adds a cache-aside to `queryUniqueFilterAttributes` so that dashboard refreshes within the same minute don't re-run the six `selectDistinct` queries that populate the audit log filter dropdowns.

Implementation:
- **Import**: `regionalCache as cache` from `#dynamic/lib/cache`, matching the dynamic pattern from d1fb2e19.
- **Cache key**: `cache:audit-log-facets:v1:{orgId}:{timeStartBucket}:{timeEndBucket}`, with timestamps bucketed to 60s boundaries so refresh-within-the-minute hits cache. The `v1` segment guards against future shape changes.
- **TTL**: 60s, per "Lets try 60?" in #3148.
- **Failure isolation**: get/set errors are caught and logged via `logger.warn`; the request never 500s on cache failure.
- **Combined effect**: facet dropdowns become approximate to within ~60s. The six underlying queries are unchanged - the prior bench in #3148 showed their current `SELECT DISTINCT LIMIT 501` shape already short-circuits via hash dedup with early exit, so a query rewrite would have regressed.

Branch note: this PR is based on `dev`, so the file still references `primaryLogsDb` rather than `logsDb`. #3148's routing fix landed on `main`; the changes are independent and will compose cleanly when the branches sync.

## How to test?

1. `npx tsc --noEmit` — no new errors in the changed file (22 pre-existing errors counted before and after).
2. Manual smoke on an OSS-SQLite stack: load `/[orgId]/settings/logs/request` in the dashboard, then refresh within 60 seconds. Confirm filter dropdowns populate identically on both requests and that DB query counters don't double. Avoid testing across minute boundaries — bucket rollover would look like a miss.
3. SaaS verification (optional): with `enable_redis: true`, confirm `cache.getCurrentBackend()` returns `"redis"` for the facet keys.