### PR TITLE
Add in-app documentation shortcuts

### DIFF
--- a/src/components/LayoutSidebar.tsx
+++ b/src/components/LayoutSidebar.tsx
@@ -19,7 +19,13 @@ import { approvalQueries } from "@app/lib/queries";
 import { build } from "@server/build";
 import { useQuery } from "@tanstack/react-query";
 import { ListUserOrgsResponse } from "@server/routers/org";
-import { ArrowRight, ExternalLink, PanelRightOpen, Server } from "lucide-react";
+import {
+    ArrowRight,
+    BookOpen,
+    ExternalLink,
+    PanelRightOpen,
+    Server
+} from "lucide-react";
 import { useTranslations } from "next-intl";
 import dynamic from "next/dynamic";
 import Link from "next/link";
@@ -43,6 +49,8 @@ interface LayoutSidebarProps {
     defaultSidebarCollapsed: boolean;
     hasCookiePreference: boolean;
 }
+
+const DOCS_HREF = "https://docs.pangolin.net/";
 
 export function LayoutSidebar({
     orgId,
@@ -270,9 +278,42 @@ export function LayoutSidebar({
                         />
                     </div>
                 )}
+                {isSidebarCollapsed && (
+                    <div className="px-4">
+                        <TooltipProvider>
+                            <Tooltip>
+                                <TooltipTrigger asChild>
+                                    <Link
+                                        href={DOCS_HREF}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        className="flex h-8 w-8 items-center justify-center rounded-md border border-border text-muted-foreground transition-colors hover:text-foreground hover:bg-sidebar-accent dark:hover:bg-sidebar-accent/50"
+                                        aria-label="Open documentation"
+                                    >
+                                        <BookOpen className="h-4 w-4" />
+                                    </Link>
+                                </TooltipTrigger>
+                                <TooltipContent side="right" sideOffset={8}>
+                                    <p>Documentation</p>
+                                </TooltipContent>
+                            </Tooltip>
+                        </TooltipProvider>
+                    </div>
+                )}
 
                 {!isSidebarCollapsed && (
                     <div className="px-4 space-y-2 pb-4">
+                        <div className="text-xs text-muted-foreground text-left">
+                            <Link
+                                href={DOCS_HREF}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="flex items-center justify-start gap-1"
+                            >
+                                Documentation
+                                <ExternalLink size={12} />
+                            </Link>
+                        </div>
                         {loadFooterLinks() ? (
                             <>
                                 {loadFooterLinks()!.map((link, index) => (

--- a/src/components/SidebarSupportButton.tsx
+++ b/src/components/SidebarSupportButton.tsx
@@ -4,7 +4,7 @@ import React, { useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
-import { MessageCircle, CheckCircle2 } from "lucide-react";
+import { BookOpen, CheckCircle2, MessageCircle } from "lucide-react";
 import { useUserContext } from "@app/hooks/useUserContext";
 import { useEnvContext } from "@app/hooks/useEnvContext";
 import { createApiClient, formatAxiosError } from "@app/lib/api";
@@ -33,6 +33,9 @@ import {
     FormMessage
 } from "@app/components/ui/form";
 import { useTranslations } from "next-intl";
+import Link from "next/link";
+
+const DOCS_HREF = "https://docs.pangolin.net/";
 
 type SupportFormValues = {
     subject: string;
@@ -147,9 +150,20 @@ export function SidebarSupportButton({
                     </PopoverTrigger>
                 )}
                 <PopoverContent className="w-80" align="start">
-                    <p className="text-sm text-muted-foreground">
-                        {t("supportNotAvailableDescription")}
-                    </p>
+                    <div className="space-y-3">
+                        <p className="text-sm text-muted-foreground">
+                            {t("supportNotAvailableDescription")}
+                        </p>
+                        <Link
+                            href={DOCS_HREF}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="inline-flex items-center gap-2 text-sm text-primary hover:underline"
+                        >
+                            <BookOpen className="h-4 w-4" />
+                            Documentation
+                        </Link>
+                    </div>
                 </PopoverContent>
             </Popover>
         );
@@ -205,6 +219,15 @@ export function SidebarSupportButton({
                         <p className="text-sm text-muted-foreground text-center">
                             {t("supportWillContact")}
                         </p>
+                        <Link
+                            href={DOCS_HREF}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="inline-flex items-center gap-2 text-sm text-primary hover:underline"
+                        >
+                            <BookOpen className="h-4 w-4" />
+                            Documentation
+                        </Link>
                     </div>
                 ) : (
                     <Form {...form}>
@@ -263,6 +286,18 @@ export function SidebarSupportButton({
                                     </FormItem>
                                 )}
                             />
+
+                            <div className="rounded-md border border-border/60 bg-muted/40 px-3 py-2 text-sm text-muted-foreground">
+                                <Link
+                                    href={DOCS_HREF}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="inline-flex items-center gap-2 text-primary hover:underline"
+                                >
+                                    <BookOpen className="h-4 w-4" />
+                                    Documentation
+                                </Link>
+                            </div>
 
                             <div className="flex justify-end gap-2">
                                 <Button


### PR DESCRIPTION
## Summary

This draft PR starts addressing #2724 by adding clearer documentation entry points inside the app.

## What I changed

- add a persistent documentation shortcut in the sidebar footer so users can reach the docs from anywhere in the app
- add a documentation shortcut inside the support popover, including the fallback state when support requests are unavailable
- keep the change limited to shared UI components so it improves discoverability without introducing page-specific doc mappings yet

## Plan

If this direction looks good, the next follow-up would be to add page-specific doc links for the highest-friction settings flows rather than scattering generic help text everywhere at once.

## Validation

- ran `npm exec --yes prettier -- --check src/components/LayoutSidebar.tsx src/components/SidebarSupportButton.tsx`
