### PR TITLE
Fix: Update external.ts windowMs rate limit for milliseconds

### DIFF
--- a/server/routers/external.ts
+++ b/server/routers/external.ts
@@ -1156,7 +1156,7 @@ export const authRouter = Router();
 unauthenticated.use("/auth", authRouter);
 authRouter.use(
     rateLimit({
-        windowMs: config.getRawConfig().rate_limits.auth.window_minutes,
+        windowMs: config.getRawConfig().rate_limits.auth.window_minutes * 60 * 1000,
         max: config.getRawConfig().rate_limits.auth.max_requests,
         keyGenerator: (req) =>
             `authRouterGlobal:${ipKeyGenerator(req.ip || "")}:${req.path}`,


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description
This matches the `server/apiServer.ts` pattern.

windowMs is milliseconds... window_minutes is minutes... so the external rate limit was 1ms.

## How to test?

