### PR TITLE
Add site authorization checks to target creation and update

### DIFF
--- a/server/auth/canUserAccessSite.ts
+++ b/server/auth/canUserAccessSite.ts
@@ -1,0 +1,42 @@
+import { db, roleSites, userSites } from "@server/db";
+import { and, eq, inArray } from "drizzle-orm";
+
+export async function canUserAccessSite({
+    userId,
+    siteId,
+    roleIds
+}: {
+    userId: string;
+    siteId: number;
+    roleIds: number[];
+}): Promise<boolean> {
+    const roleSiteAccess =
+        roleIds.length > 0
+            ? await db
+                  .select()
+                  .from(roleSites)
+                  .where(
+                      and(
+                          eq(roleSites.siteId, siteId),
+                          inArray(roleSites.roleId, roleIds)
+                      )
+                  )
+                  .limit(1)
+            : [];
+
+    if (roleSiteAccess.length > 0) {
+        return true;
+    }
+
+    const userSiteAccess = await db
+        .select()
+        .from(userSites)
+        .where(and(eq(userSites.userId, userId), eq(userSites.siteId, siteId)))
+        .limit(1);
+
+    if (userSiteAccess.length > 0) {
+        return true;
+    }
+
+    return false;
+}

--- a/server/routers/target/createTarget.ts
+++ b/server/routers/target/createTarget.ts
@@ -18,6 +18,7 @@ import { addTargets } from "../newt/targets";
 import { eq } from "drizzle-orm";
 import { pickPort } from "./helpers";
 import { isTargetValid } from "@server/lib/validators";
+import { canUserAccessSite } from "@server/auth/canUserAccessSite";
 import { OpenAPITags, registry } from "@server/openApi";
 import {
     fireHealthCheckHealthyAlert,
@@ -144,6 +145,33 @@ export async function createTarget(
                     `Site with ID ${siteId} not found`
                 )
             );
+        }
+
+        // Ensure the site belongs to the same organization as the resource
+        if (site.orgId !== resource.orgId) {
+            return next(
+                createHttpError(
+                    HttpCode.FORBIDDEN,
+                    "User does not have access to this site"
+                )
+            );
+        }
+
+        // For user requests, verify the user has access to the site
+        if (req.user) {
+            const siteAccess = await canUserAccessSite({
+                userId: req.user.userId,
+                siteId: site.siteId,
+                roleIds: req.userOrgRoleIds ?? []
+            });
+            if (!siteAccess) {
+                return next(
+                    createHttpError(
+                        HttpCode.FORBIDDEN,
+                        "User does not have access to this site"
+                    )
+                );
+            }
         }
 
         let newTarget: Target[] = [];

--- a/server/routers/target/updateTarget.ts
+++ b/server/routers/target/updateTarget.ts
@@ -18,6 +18,7 @@ import {
 import { pickPort } from "./helpers";
 import { isTargetValid } from "@server/lib/validators";
 import { OpenAPITags, registry } from "@server/openApi";
+import { canUserAccessSite } from "@server/auth/canUserAccessSite";
 
 const updateTargetParamsSchema = z.strictObject({
     targetId: z.string().transform(Number).pipe(z.int().positive())
@@ -155,6 +156,33 @@ export async function updateTarget(
                     `Site with ID ${siteId} not found`
                 )
             );
+        }
+
+        // Ensure the site belongs to the same organization as the resource
+        if (site.orgId !== resource.orgId) {
+            return next(
+                createHttpError(
+                    HttpCode.FORBIDDEN,
+                    "User does not have access to this site"
+                )
+            );
+        }
+
+        // For user requests, verify the user has access to the site
+        if (req.user) {
+            const siteAccess = await canUserAccessSite({
+                userId: req.user.userId,
+                siteId: site.siteId,
+                roleIds: req.userOrgRoleIds ?? []
+            });
+            if (!siteAccess) {
+                return next(
+                    createHttpError(
+                        HttpCode.FORBIDDEN,
+                        "User does not have access to this site"
+                    )
+                );
+            }
         }
 
         const { internalPort, targetIps } = await pickPort(site.siteId!, db);


### PR DESCRIPTION
This pull request strengthens site-level access control for target creation and updating by ensuring that users can only act on sites they are authorized to access. It introduces a new helper function to centralize site access logic and applies this check consistently in both the target creation and update flows.

**Access control improvements:**

* Added a new helper function `canUserAccessSite` in `server/auth/canUserAccessSite.ts` to encapsulate logic for determining if a user or their roles grant access to a specific site.
* Integrated the `canUserAccessSite` check into both `createTarget` and `updateTarget` endpoints to ensure that, for user-initiated requests, the user has explicit access to the site before proceeding. [[1]](diffhunk://#diff-6bf7e0c67e1b73ded23ead1ea16fa773c834dcdd1b31dc444e7cbc464c6bdecaR150-R176) [[2]](diffhunk://#diff-9058469b293a7f20d3a07a7ee40d1b39f70d883f8563689315218f06b7236984R161-R187)
* Added an additional check to both endpoints to verify that the site belongs to the same organization as the resource, preventing cross-organization access. [[1]](diffhunk://#diff-6bf7e0c67e1b73ded23ead1ea16fa773c834dcdd1b31dc444e7cbc464c6bdecaR150-R176) [[2]](diffhunk://#diff-9058469b293a7f20d3a07a7ee40d1b39f70d883f8563689315218f06b7236984R161-R187)

**Codebase consistency:**

* Imported the new `canUserAccessSite` helper in both `server/routers/target/createTarget.ts` and `server/routers/target/updateTarget.ts` to support the new access control logic. [[1]](diffhunk://#diff-6bf7e0c67e1b73ded23ead1ea16fa773c834dcdd1b31dc444e7cbc464c6bdecaR21) [[2]](diffhunk://#diff-9058469b293a7f20d3a07a7ee40d1b39f70d883f8563689315218f06b7236984R21)

# Note

PR Description generated by Copilot