### PR TITLE
Performance: getTraefikConfig anySitesOnline out of loop / isDomainCoveredByWildcard bypass logic on matching domains.

### DIFF
--- a/server/lib/traefik/TraefikConfigManager.ts
+++ b/server/lib/traefik/TraefikConfigManager.ts
@@ -1197,6 +1197,11 @@ export function isDomainCoveredByWildcard(
 ): boolean {
     for (const [certDomain, state] of lastLocalCertificateState) {
         if (state.exists && state.wildcard) {
+            // If it's an exact match
+            if (domain === certDomain) {
+                return true;
+            }
+
             // If stored as example.com but is wildcard, check subdomains
             if (domain.endsWith("." + certDomain)) {
                 // Check that it's only one level deep (wildcard only covers one level)

--- a/server/lib/traefik/getTraefikConfig.ts
+++ b/server/lib/traefik/getTraefikConfig.ts
@@ -469,19 +469,17 @@ export async function getTraefikConfig(
                 };
             }
 
+            // Check if any sites are online
+            // THIS IS SO THAT THERE IS SOME IMMEDIATE FEEDBACK
+            // EVEN IF THE SITES HAVE NOT UPDATED YET FROM THE
+            // RECEIVE BANDWIDTH ENDPOINT.
+
+            // TODO: HOW TO HANDLE ^^^^^^ BETTER
+            const anySitesOnline = targets.some((target) => target.site.online);
+
             config_output.http.services![serviceName] = {
                 loadBalancer: {
                     servers: (() => {
-                        // Check if any sites are online
-                        // THIS IS SO THAT THERE IS SOME IMMEDIATE FEEDBACK
-                        // EVEN IF THE SITES HAVE NOT UPDATED YET FROM THE
-                        // RECEIVE BANDWIDTH ENDPOINT.
-
-                        // TODO: HOW TO HANDLE ^^^^^^ BETTER
-                        const anySitesOnline = targets.some(
-                            (target) => target.site.online
-                        );
-
                         return (
                             targets
                                 .filter((target) => {
@@ -602,14 +600,12 @@ export async function getTraefikConfig(
 
             const ppPrefix = config.getRawConfig().traefik.pp_transport_prefix;
 
+            // Check if any sites are online
+            const anySitesOnline = targets.some((target) => target.site.online);
+
             config_output[protocol].services[serviceName] = {
                 loadBalancer: {
                     servers: (() => {
-                        // Check if any sites are online
-                        const anySitesOnline = targets.some(
-                            (target) => target.site.online
-                        );
-
                         return targets
                             .filter((target) => {
                                 if (!target.enabled) {


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description
* server/lib/traefik/getTraefikConfig.ts - move the anySitesOnline const out of the loop. Fixes redundant iterations over the target sites list.
* server/lib/traefik/TraefikConfigManager.ts - minor check that just returns true for non-complex wildcard certs.

## How to test?

