### PR TITLE
fix: blueprint apply fails with UNIQUE constraint on certificates.dom…

### DIFF
--- a/server/private/routers/certificates/createCertificate.ts
+++ b/server/private/routers/certificates/createCertificate.ts
@@ -41,35 +41,30 @@ export async function createCertificate(
         const domainLevelDown = domain.split(".").slice(1).join(".");
         const wildcardPrefixed = `*.${domainLevelDown}`;
 
+        // Search by domain value only (not domainId) because certificates.domain
+        // has a global unique constraint. A cert created under a parent domain's
+        // domainId still covers this subdomain and must not be re-inserted.
         existing = await trx
             .select()
             .from(certificates)
             .where(
-                and(
-                    eq(certificates.domainId, domainId),
-                    or(
-                        eq(certificates.domain, domain),
-                        and(
-                            eq(certificates.wildcard, true),
-                            or(
-                                eq(certificates.domain, domainLevelDown),
-                                eq(certificates.domain, wildcardPrefixed)
-                            )
+                or(
+                    eq(certificates.domain, domain),
+                    and(
+                        eq(certificates.wildcard, true),
+                        or(
+                            eq(certificates.domain, domainLevelDown),
+                            eq(certificates.domain, wildcardPrefixed)
                         )
                     )
                 )
             );
     } else {
-        // For non-NS domains, we only match exact domain names
+        // For non-NS domains, match exact domain name only
         existing = await trx
             .select()
             .from(certificates)
-            .where(
-                and(
-                    eq(certificates.domainId, domainId),
-                    eq(certificates.domain, domain) // exact match for non-NS domains
-                )
-            );
+            .where(eq(certificates.domain, domain));
     }
 
     if (existing.length > 0) {
@@ -111,5 +106,5 @@ export async function createCertificate(
         status: "pending",
         updatedAt: Math.floor(Date.now() / 1000),
         createdAt: Math.floor(Date.now() / 1000)
-    });
+    }).onConflictDoNothing();
 }


### PR DESCRIPTION
Problem
Applying a blueprint with a resource under a wildcard subdomain (e.g. *.web.domain.com) fails with:

SqliteError: UNIQUE constraint failed: certificates.domain

Resources under a top-level wildcard (e.g. *.domain.com) succeed. Only deeper wildcard domains are affected.

Root Cause
createCertificate checked for an existing cert by filtering on both domainId and domain. However, certificates.domain has a global unique constraint (not per-domainId).

When getDomainId() resolves a full-domain to a parent domain (e.g. domain.com → domainId = "domain1") instead of the more specific web.domain.com domain, the domainId used in the check doesn't match the existing cert's stored domainId. The check silently misses the cert and falls through to INSERT — which then crashes on the global unique constraint.

Fix
Removed domainId from the existing-cert WHERE clause. Since certificates.domain is globally unique, checking by domain value alone is correct and sufficient.
Added .onConflictDoNothing() to the INSERT as a safety net for any remaining edge cases.
Files Changed
server/private/routers/certificates/createCertificate.ts
Fixes
Closes #2937