### PR TITLE
fix: Add DELETE /idp/{idpId} to integration API

### DIFF
--- a/server/routers/integration.ts
+++ b/server/routers/integration.ts
@@ -16,7 +16,6 @@ import {
     verifyApiKey,
     verifyApiKeyOrgAccess,
     verifyApiKeyHasAction,
-    verifyApiKeyCanSetUserOrgRoles,
     verifyApiKeySiteAccess,
     verifyApiKeyResourceAccess,
     verifyApiKeyTargetAccess,
@@ -891,6 +890,13 @@ authenticated.get(
     verifyApiKeyIsRoot,
     verifyApiKeyHasAction(ActionsEnum.getIdp),
     idp.getIdp
+);
+
+authenticated.delete(
+    "/idp/:idpId",
+    verifyApiKeyIsRoot,
+    verifyApiKeyHasAction(ActionsEnum.deleteIdp),
+    idp.deleteIdp
 );
 
 authenticated.put(


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description

The `DELETE` api endpoint for global IDPs was not available in the integration API. When I would try to delete one from the Swagger UI, I would receive a 404. This change adds it to the integration API.

## How to test?

1. Ensure that the integration API is turned on.
2. Create a global IDP either through the UI or swagger.
3. Take note of the IDP ID.
4. Use Swagger to delete the global IDP with the ID retrieved in the last step.
5. The IDP should be deleted and the API endpoint returns a 200.