### PR TITLE
fix: request logs not loading on initial page open in Community Editi…

### DIFF
--- a/src/app/[orgId]/settings/logs/request/page.tsx
+++ b/src/app/[orgId]/settings/logs/request/page.tsx
@@ -18,7 +18,6 @@ import Link from "next/link";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { useMemo, useState, useTransition } from "react";
 import { useStoredPageSize } from "@app/hooks/useStoredPageSize";
-import { build } from "@server/build";
 import type { QueryRequestAuditLogResponse } from "@server/routers/auditLogs/types";
 
 export default function GeneralPage() {
@@ -121,8 +120,7 @@ export default function GeneralPage() {
         ...logQueries.requests({
             orgId: orgId as string,
             filters: queryFilters
-        }),
-        enabled: build !== "oss"
+        })
     });
 
     const rows = isLoading ? generateSampleRequestLogs() : (data?.log ?? []);


### PR DESCRIPTION
Fixes #2867 — Request Logs page shows "No results found" on initial load in Community Edition (OSS build), requiring a manual Refresh click to populate data.

Root cause: The useEffect responsible for fetching logs on mount had an early-return guard if (build === "oss") return, which completely skipped the initial data fetch on CE. EE was unaffected because the guard only triggered for the oss build.

Change: Removed the build === "oss" guard from the mount effect in src/app/[orgId]/settings/logs/request/page.tsx and cleaned up the now-unused build import. The fetch now runs on all builds, consistent with EE behaviour.

Fixes #3303