### PR TITLE
fix(sqlite): revert no-op finalize wrapper and aggressive PRAGMAs (#2120)

### DIFF
--- a/server/db/sqlite/driver.ts
+++ b/server/db/sqlite/driver.ts
@@ -1,6 +1,5 @@
 import { drizzle as DrizzleSqlite } from "drizzle-orm/better-sqlite3";
 import Database from "better-sqlite3";
-import type BetterSqlite3 from "better-sqlite3";
 import * as schema from "./schema/schema";
 import path from "path";
 import fs from "fs";
@@ -12,64 +11,31 @@ export const exists = checkFileExists(location);
 
 bootstrapVolume();
 
-/**
- * Wraps better-sqlite3 Statement to call `finalize()` immediately after
- * execution, freeing native sqlite3_stmt memory deterministically instead
- * of waiting for GC. Fixes steady off-heap growth under load (#2120).
- * WARNING: Finalizes after first execution — incompatible with drizzle's
- * reusable .prepare() builders. No such usage exists in this codebase.
- */
-function autoFinalizeStatement(
-    stmt: BetterSqlite3.Statement
-): BetterSqlite3.Statement {
-    const wrapExec = <T extends (...args: any[]) => any>(fn: T): T => {
-        return function (this: any, ...args: any[]) {
-            try {
-                return fn.apply(this, args);
-            } finally {
-                try {
-                    // finalize() exists on the native Statement at runtime but
-                    // is missing from @types/better-sqlite3.
-                    (stmt as any).finalize();
-                } catch {
-                    // Already finalized — harmless
-                }
-            }
-        } as unknown as T;
-    };
-
-    stmt.run = wrapExec(stmt.run);
-    stmt.get = wrapExec(stmt.get);
-    stmt.all = wrapExec(stmt.all);
-
-    return stmt;
-}
-
 function createDb() {
     const sqlite = new Database(location);
 
     if (process.env.ENABLE_SQLITE_WAL_MODE == "true") {
         // Enable WAL mode — allows concurrent readers + single writer, preventing
         // contention across subsystems (verifySession, Traefik, audit, ping).
+        // NOTE: journal_mode persists in the DB file once set; unsetting this
+        // env var does NOT revert an existing WAL database.
         sqlite.pragma("journal_mode = WAL");
         // NORMAL sync mode: safe with WAL, reduces write lock hold time.
         sqlite.pragma("synchronous = NORMAL");
     }
 
-    // Wait up to 5s on SQLITE_BUSY instead of failing — prevents audit log
-    // retry loops that accumulate memory.
-    sqlite.pragma("busy_timeout = 5000");
+    // No busy_timeout pragma: better-sqlite3 already arms
+    // sqlite3_busy_timeout(db, 5000) via its default `timeout` option
+    // (lib/database.js), so an explicit pragma is redundant.
 
     // Intentionally NOT setting cache_size or mmap_size: a large page cache plus
     // a multi-hundred-MB mmap region inflate RSS and cause page-cache thrashing
     // on small (~1 GB) instances. Leave SQLite on its conservative defaults.
 
-    // Wrap prepare() so every drizzle-orm statement is auto-finalized after
-    // first use, preventing sqlite3_stmt accumulation between GC cycles.
-    const originalPrepare = sqlite.prepare.bind(sqlite);
-    (sqlite as any).prepare = function autoFinalizePrepare(source: string) {
-        return autoFinalizeStatement(originalPrepare(source));
-    };
+    // Intentionally NOT wrapping prepare()/statements: better-sqlite3 finalizes
+    // sqlite3_stmt in the Statement destructor at GC, and drizzle-orm prepares a
+    // fresh statement per query (no statement cache), so statements cannot
+    // accumulate. better-sqlite3 11.x exposes no Statement.finalize() at all.
 
     return DrizzleSqlite(sqlite, {
         schema

--- a/server/db/sqlite/driver.ts
+++ b/server/db/sqlite/driver.ts
@@ -60,13 +60,9 @@ function createDb() {
     // retry loops that accumulate memory.
     sqlite.pragma("busy_timeout = 5000");
 
-    // 64 MB page cache (default 2 MB) — reduces I/O round-trips on large
-    // TraefikConfigManager JOINs that block the event loop.
-    sqlite.pragma("cache_size = -65536");
-
-    // 256 MB memory-mapped I/O — OS serves reads from page cache directly,
-    // reducing event-loop blocking.
-    sqlite.pragma("mmap_size = 268435456");
+    // Intentionally NOT setting cache_size or mmap_size: a large page cache plus
+    // a multi-hundred-MB mmap region inflate RSS and cause page-cache thrashing
+    // on small (~1 GB) instances. Leave SQLite on its conservative defaults.
 
     // Wrap prepare() so every drizzle-orm statement is auto-finalized after
     // first use, preventing sqlite3_stmt accumulation between GC cycles.


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description

### Preface
I'm a cloud engineer with experience in Python and Bash; I do not have much experience with JS/TS. This is a follow-up to my previous #2120 fix. After 3 days of A/B testing in production on a t3a.micro with Claude, the previous fix turned out to be net-negative on small instances. This PR reverts those specific changes after empirical validation. No code or comments are left over from the previous attempt.

### Summary
- Removes the `autoFinalizeStatement` `prepare()` wrapper. better-sqlite3 11.x exposes **no** `Statement.finalize()` — the wrapper threw a `TypeError` on every query (silently swallowed by its own `try`/`catch`) and freed nothing, while adding **+122% per-statement overhead**.
- Removes the explicit `busy_timeout = 5000` PRAGMA. better-sqlite3 already arms `sqlite3_busy_timeout(db, 5000)` via its default `timeout` constructor option, so the pragma is redundant.
- Removes `cache_size = -65536` (64 MB) and `mmap_size = 268435456` (256 MB) PRAGMAs. On small (~1 GB) instances they inflate RSS and cause page-cache thrashing — the exact shape that hits #2120.
- Keeps the env-gated WAL block (`journal_mode = WAL` + `synchronous = NORMAL` when `ENABLE_SQLITE_WAL_MODE=true`). `journal_mode` is sticky in the DB file, so removing the block would strand databases that opted in.

### Context
The previous fix assumed unbounded native `sqlite3_stmt` accumulation was the cause of #2120 and added a finalize-on-execute wrapper plus aggressive PRAGMA tuning. Re-investigation showed:

1. `Statement.finalize()` does not exist on better-sqlite3 11.x. Verified by logging `Statement.finalize exists: undefined` from the runner image — the wrapper's call landed in its `catch` block on every execution.
2. drizzle-orm prepares a fresh native statement per query (no statement cache), and better-sqlite3 frees `sqlite3_stmt` in the Statement destructor at GC, so statements cannot accumulate.
3. The wrapper added **+122% per-statement overhead** (3.90 → 8.66 µs/op, 200k-op in-container microbench) with no observable benefit.
4. The 64 MB page cache + 256 MB mmap region pushed RSS into territory that caused page-cache pressure on 1 GB instances, making the original symptom worse, not better.

With `ENABLE_SQLITE_WAL_MODE` unset, the driver is now runtime-identical to pre-1.18.3.

### Changes
- `server/db/sqlite/driver.ts` — remove `autoFinalizeStatement` wrapper, remove `busy_timeout`/`cache_size`/`mmap_size` PRAGMAs, keep env-gated WAL block.

### Verification
Ran the wrapper-OFF build for 3 days on a t3a.micro (1 GB / 2 vCPU) with the same traffic profile as the prior wrapper-ON deployment (normal usage, 7 day request retention, Uptime Kuma checks). Container memory stable around ~335 MB with no PRAGMA tuning. No memory growth, no event-loop stalls, no OOM. No memory limits set in compose file.

### Recommendation for small instances
Even with this fix, 1 GB of RAM is tight when host OS tasks spike alongside Pangolin's working set. I'd recommend enabling swap on instances at or below 1 GB — I added 1 GB of swap and it has been more than enough; less is likely fine. Without swap, transient OS pressure has nowhere to go and can OOM the Node process even when Pangolin itself is steady.

### How to test?
Build docker container community version using sqlite database.
1GB 2vCPU AWS t3a.micro instance.