### PR TITLE
fix(badger): inject Remote-Groups header for downstream RBAC

### DIFF
--- a/server/routers/badger/verifySession.ts
+++ b/server/routers/badger/verifySession.ts
@@ -71,6 +71,7 @@ type BasicUserData = {
     email: string | null;
     name: string | null;
     role: string | null;
+    groups?: string;
 };
 
 export type VerifyUserResponse = {
@@ -988,7 +989,8 @@ async function isUserAllowedToAccessResource(
             username: user.username,
             email: user.email,
             name: user.name,
-            role: userOrgRoles.map((r) => r.roleName).join(", ")
+            role: userOrgRoles.map((r) => r.roleName).join(", "),
+            groups: userOrgRoles.map((r) => r.roleName).join(",")
         };
     }
 
@@ -1003,7 +1005,8 @@ async function isUserAllowedToAccessResource(
             username: user.username,
             email: user.email,
             name: user.name,
-            role: userOrgRoles.map((r) => r.roleName).join(", ")
+            role: userOrgRoles.map((r) => r.roleName).join(", "),
+            groups: userOrgRoles.map((r) => r.roleName).join(",")
         };
     }
 


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

### Preface

This PR was developed with AI assistance. I drove the direction and tested everything, but the AI did the actual coding. I reviewed, tested, and validated all changes.

## Description

This PR addresses a missing RBAC feature in the Badger middleware.

Currently, `Remote-Groups` isn't passed to the proxy. I added `groups` to `BasicUserData` and mapped the user's roles to a comma-separated string in `isUserAllowedToAccessResource`. Badger now natively injects this header for downstream apps to use for RBAC, mirroring how `Remote-Role` is already handled.

## How to test?

Log in, access a protected resource, and check the downstream headers. `Remote-Groups` should be populated with the user's roles.
