### PR TITLE
Wire up test runner and run unit tests in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Test with tsc
         run: npx tsc --noEmit
 
+      - name: Run unit tests
+        run: npm test
+
       - name: Start app in background
         run: nohup npm run dev &
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
         "start": "ENVIRONMENT=prod node dist/migrations.mjs && ENVIRONMENT=prod NODE_ENV=development node --enable-source-maps dist/server.mjs",
         "email": "email dev --dir server/emails/templates --port 3005",
         "build:cli": "node esbuild.mjs -e cli/index.ts -o dist/cli.mjs",
+        "test": "tsx test/run.ts",
         "format:check": "prettier --check .",
         "format": "prettier --write ."
     },

--- a/server/lib/ip.test.ts
+++ b/server/lib/ip.test.ts
@@ -1,5 +1,5 @@
 import { cidrToRange, findNextAvailableCidr } from "./ip";
-import { assertEquals } from "@test/assert";
+import { assertEquals, assertThrows } from "@test/assert";
 
 // Test cases
 function testFindNextAvailableCidr() {
@@ -43,22 +43,29 @@ function testFindNextAvailableCidr() {
         const result = findNextAvailableCidr(existing, 30, "10.0.0.0/8");
         assertEquals(result, "10.0.0.0/30", "Empty existing test failed");
     }
-    // // Test 4: IPv6 allocation
-    // {
-    //     const existing = ["2001:db8::/32", "2001:db8:1::/32"];
-    //     const result = findNextAvailableCidr(existing, 32, "2001:db8::/16");
-    //     assertEquals(result, "2001:db8:2::/32", "Basic IPv6 allocation failed");
-    // }
+    // Test 4a: Basic IPv6 allocation (gap after two adjacent /48 blocks)
+    {
+        const existing = ["2001:db8::/48", "2001:db8:1::/48"];
+        const result = findNextAvailableCidr(existing, 48, "2001:db8::/32");
+        assertEquals(result, "2001:db8:2::/48", "Basic IPv6 allocation failed");
+    }
 
-    // // Test 5: Mixed IP versions
-    // {
-    //     const existing = ["10.0.0.0/16", "2001:db8::/32"];
-    //     assertThrows(
-    //         () => findNextAvailableCidr(existing, 16),
-    //         "All CIDRs must be of the same IP version",
-    //         "Mixed IP versions test failed"
-    //     );
-    // }
+    // Test 4b: IPv6 with no available space
+    {
+        const existing = ["2001:db8::/32"];
+        const result = findNextAvailableCidr(existing, 32, "2001:db8::/32");
+        assertEquals(result, null, "IPv6 no available space test failed");
+    }
+
+    // Test 5: Mixed IP versions
+    {
+        const existing = ["10.0.0.0/16", "2001:db8::/32"];
+        assertThrows(
+            () => findNextAvailableCidr(existing, 16),
+            "All CIDRs must be of the same IP version",
+            "Mixed IP versions test failed"
+        );
+    }
 
     // Test 6: Empty input
     {
@@ -91,51 +98,65 @@ function testFindNextAvailableCidr() {
     console.log("All findNextAvailableCidr tests passed!");
 }
 
-// function testCidrToRange() {
-//     console.log("Running cidrToRange tests...");
+function testCidrToRange() {
+    console.log("Running cidrToRange tests...");
 
-//     // Test 1: Basic IPv4 conversion
-//     {
-//         const result = cidrToRange("192.168.0.0/24");
-//         assertEqualsObj(result, {
-//             start: BigInt("3232235520"),
-//             end: BigInt("3232235775")
-//         }, "Basic IPv4 conversion failed");
-//     }
+    // Test 1: Basic IPv4 conversion
+    {
+        const result = cidrToRange("192.168.0.0/24");
+        assertEquals(
+            result.start,
+            BigInt("3232235520"),
+            "Basic IPv4 conversion start failed"
+        );
+        assertEquals(
+            result.end,
+            BigInt("3232235775"),
+            "Basic IPv4 conversion end failed"
+        );
+    }
 
-//     // Test 2: IPv6 conversion
-//     {
-//         const result = cidrToRange("2001:db8::/32");
-//         assertEqualsObj(result, {
-//             start: BigInt("42540766411282592856903984951653826560"),
-//             end: BigInt("42540766411282592875350729025363378175")
-//         }, "IPv6 conversion failed");
-//     }
+    // Test 2: IPv6 conversion
+    {
+        const result = cidrToRange("2001:db8::/32");
+        // 2001:db8:: as a 128-bit integer (RFC 3849 documentation prefix)
+        assertEquals(
+            result.start,
+            BigInt("42540766411282592856903984951653826560"),
+            "IPv6 network address conversion failed"
+        );
+        // A /32 block spans 2^96 addresses
+        assertEquals(
+            result.end - result.start + BigInt(1),
+            BigInt(1) << BigInt(96),
+            "IPv6 /32 block size failed"
+        );
+    }
 
-//     // Test 3: Invalid prefix length
-//     {
-//         assertThrows(
-//             () => cidrToRange("192.168.0.0/33"),
-//             "Invalid prefix length for IPv4",
-//             "Invalid IPv4 prefix test failed"
-//         );
-//     }
+    // Test 3: Invalid prefix length
+    {
+        assertThrows(
+            () => cidrToRange("192.168.0.0/33"),
+            "Invalid prefix length for IPv4",
+            "Invalid IPv4 prefix test failed"
+        );
+    }
 
-//     // Test 4: Invalid IPv6 prefix
-//     {
-//         assertThrows(
-//             () => cidrToRange("2001:db8::/129"),
-//             "Invalid prefix length for IPv6",
-//             "Invalid IPv6 prefix test failed"
-//         );
-//     }
+    // Test 4: Invalid IPv6 prefix
+    {
+        assertThrows(
+            () => cidrToRange("2001:db8::/129"),
+            "Invalid prefix length for IPv6",
+            "Invalid IPv6 prefix test failed"
+        );
+    }
 
-//     console.log("All cidrToRange tests passed!");
-// }
+    console.log("All cidrToRange tests passed!");
+}
 
 // Run all tests
 try {
-    // testCidrToRange();
+    testCidrToRange();
     testFindNextAvailableCidr();
     console.log("All tests passed successfully!");
 } catch (error) {

--- a/test/run.ts
+++ b/test/run.ts
@@ -9,12 +9,25 @@
 
 import { spawnSync } from "node:child_process";
 import { globSync } from "node:fs";
+import { build } from "@server/build";
 
 const EXCLUDED_DIRS = ["node_modules", "dist", ".next", "init"];
 
-const testFiles = globSync("**/*.test.ts", {
-    exclude: (path) => EXCLUDED_DIRS.some((dir) => path.split(/[\\/]/).includes(dir))
-}).sort();
+// server/private holds commercial-licensed code. Its tests run only in the
+// enterprise and saas builds, not in the OSS build.
+function isExcluded(file: string): boolean {
+    const normalized = file.replace(/\\/g, "/");
+    const segments = normalized.split("/");
+    if (EXCLUDED_DIRS.some((dir) => segments.includes(dir))) {
+        return true;
+    }
+    if (build === "oss" && normalized.startsWith("server/private/")) {
+        return true;
+    }
+    return false;
+}
+
+const testFiles = globSync("**/*.test.ts", { exclude: isExcluded }).sort();
 
 if (testFiles.length === 0) {
     console.error("No *.test.ts files found.");

--- a/test/run.ts
+++ b/test/run.ts
@@ -1,0 +1,49 @@
+// Test runner.
+//
+// Discovers every *.test.ts file in the repo and runs each one in its own
+// child process. The test files are standalone scripts that print their
+// progress and exit with a non-zero code on failure (see test/assert.ts),
+// so process isolation keeps a process.exit() or thrown error in one file
+// from aborting the rest of the suite. Results are aggregated here and the
+// runner exits non-zero if any file failed.
+
+import { spawnSync } from "node:child_process";
+import { globSync } from "node:fs";
+
+const EXCLUDED_DIRS = ["node_modules", "dist", ".next", "init"];
+
+const testFiles = globSync("**/*.test.ts", {
+    exclude: (path) => EXCLUDED_DIRS.some((dir) => path.split(/[\\/]/).includes(dir))
+}).sort();
+
+if (testFiles.length === 0) {
+    console.error("No *.test.ts files found.");
+    process.exit(1);
+}
+
+console.log(`Running ${testFiles.length} test file(s)...\n`);
+
+const failed: string[] = [];
+
+for (const file of testFiles) {
+    console.log(`\n──────── ${file} ────────`);
+    const result = spawnSync(process.execPath, ["--import", "tsx", file], {
+        stdio: "inherit"
+    });
+    if (result.status !== 0) {
+        failed.push(file);
+    }
+}
+
+console.log(`\n────────────────────────────`);
+console.log(`Passed: ${testFiles.length - failed.length}/${testFiles.length}`);
+
+if (failed.length > 0) {
+    console.error(`\nFailed test files:`);
+    for (const file of failed) {
+        console.error(`  - ${file}`);
+    }
+    process.exit(1);
+}
+
+console.log("All test files passed.");


### PR DESCRIPTION
## What

The repo already has several `*.test.ts` files (using the custom `test/assert.ts` harness), but nothing actually runs them:

- there is no `test` npm script,
- `make test` only launches the Docker image, and
- the `test.yml` workflow only runs `tsc --noEmit` plus a curl smoke check.

So these tests can silently break without anyone noticing. This PR wires them up, and turning them on immediately surfaced a set of dead IPv6 tests in `ip.test.ts` that are fixed here.

## Changes

- **`test/run.ts`** - a small runner that discovers every `*.test.ts` file via Node's built-in `fs.globSync` and runs each one in its own `node --import tsx` child process. The test files are standalone scripts that call `process.exit()` / throw on failure, so per-file process isolation keeps one failure from aborting the rest of the suite. The runner aggregates results and exits non-zero if any file fails. No new dependencies (`tsx` is already a devDependency).
- **`package.json`** - adds `"test": "tsx test/run.ts"`.
- **`.github/workflows/test.yml`** - adds a `Run unit tests` step (`npm test`) after the existing `tsc` step in the `test` job, reusing its existing DB/build setup.
- **`server/lib/ip.test.ts`** - adds real IPv6 coverage. The IPv6 cases here were previously commented out and could not have run as written (see below).

## The dead IPv6 tests in `ip.test.ts`

While wiring up the runner I found the commented-out IPv6 tests would not pass as written:

- `testCidrToRange` used `assertEqualsObj`, which `JSON.stringify`s its arguments and **throws on `BigInt`** - so the entire block was dead code.
- The commented IPv6 conversion expected an `end` spanning `2^64` addresses rather than `2^96`, i.e. a `/64` instead of the `/32` under test.
- The commented `findNextAvailableCidr` IPv6 case used `2001:db8::/32` and `2001:db8:1::/32`, which **both mask down to the same network**, and expected `2001:db8:2::/32` from a `/16` search that actually returns `2001::/32`.

This PR re-enables `testCidrToRange` (comparing `start`/`end` as `BigInt`, and asserting the `/32` spans `2^96`) and adds correct IPv6 cases to `findNextAvailableCidr`: a gap allocation across two distinct `/48` blocks (`-> 2001:db8:2::/48`), a no-space case, and the mixed-version guard. The implementation in `ip.ts` was already correct; only the tests were wrong.

## Build awareness

`server/private` is licensed under the Fossorial Commercial License rather than AGPLv3. The runner is build-aware (matching the `build === "oss"` checks used elsewhere in the codebase): the OSS build skips `server/private` tests, while the enterprise and saas builds run them. So `npm test` is clean for OSS contributors out of the box.