### PR TITLE
Fix broken toast on private resource delete failure

### DIFF
--- a/src/components/PrivateResourcesTable.tsx
+++ b/src/components/PrivateResourcesTable.tsx
@@ -186,11 +186,11 @@ export default function PrivateResourcesTable({
                 });
             });
         } catch (e) {
-            console.error(t("resourceErrorDelete"), e);
+            console.error(t("resourceErrorDelte"), e);
             toast({
                 variant: "destructive",
                 title: t("resourceErrorDelte"),
-                description: formatAxiosError(e, t("v"))
+                description: formatAxiosError(e, t("resourceErrorDelte"))
             });
         }
     };


### PR DESCRIPTION
## What

The delete-error handler in `PrivateResourcesTable.tsx` referenced two i18n keys that don't exist in the message catalog, so a failed private-resource deletion showed the user broken output:

```ts
console.error(t("resourceErrorDelete"), e);        // key is "resourceErrorDelte" in the catalog
toast({
    variant: "destructive",
    title: t("resourceErrorDelte"),                 // ok
    description: formatAxiosError(e, t("v"))         // "v" is a leftover placeholder key
});
```

- `t("resourceErrorDelete")` (with the extra `e`) isn't in `messages/en-US.json` - the catalog key is `resourceErrorDelte` - so the console line logged the raw key string instead of the message.
- `formatAxiosError(e, t("v"))` passed a bogus `"v"` key as the fallback title, so the toast description fell back to the literal string `v` when the API error had no message.

## Fix

Point both calls at the existing `resourceErrorDelte` key. This matches the delete handlers in `PublicResourcesTable.tsx` and `ResourcePoliciesTable.tsx`, which already use `t("resourceErrorDelte")` for the console line, title, and description.

```ts
console.error(t("resourceErrorDelte"), e);
toast({
    variant: "destructive",
    title: t("resourceErrorDelte"),
    description: formatAxiosError(e, t("resourceErrorDelte"))
});
```

## Notes

- No changes to `messages/*.json`. The existing (misspelled) `resourceErrorDelte` key is used across the codebase; renaming it would be a separate, larger change and would orphan the existing Crowdin translations, so this PR intentionally leaves the catalog untouched.
- eslint and prettier pass on the changed file.

## CLA

By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.