### PR TITLE
Fix OSS build break: add siteId param to OSS listExitNodes

### DIFF
--- a/server/lib/exitNodes/exitNodes.ts
+++ b/server/lib/exitNodes/exitNodes.ts
@@ -19,7 +19,11 @@ export async function verifyExitNodeOrgAccess(
 export async function listExitNodes(
     orgId: string,
     filterOnline = false,
-    noCloud = false
+    noCloud = false,
+    // Accepted for parity with the enterprise implementation (used there for
+    // site-label filtering of remote exit nodes). The OSS build has no remote
+    // exit nodes, so it is unused here.
+    siteId?: number
 ) {
     // TODO: pick which nodes to send and ping better than just all of them that are not remote
     const allExitNodes = await db


### PR DESCRIPTION
## What

`listExitNodes` is resolved through the `#dynamic` path alias, which maps to different files per build:

- `tsconfig.oss.json`: `#dynamic/*` ? `./server/*` ? `server/lib/exitNodes/exitNodes.ts`
- `tsconfig.enterprise.json` / `tsconfig.saas.json`: `#dynamic/*` ? `./server/private/*` ? `server/private/lib/exitNodes/exitNodes.ts`

Commit 9c18936b ("Filter the nodes based on the preference labels") added a 4th `siteId` argument to the shared caller (`server/routers/newt/handleNewtPingRequestMessage.ts`) and to the **enterprise** implementation (which uses it to site-label-filter remote exit nodes), but not to the **OSS** implementation. Under the OSS tsconfig the call therefore fails:

```
server/routers/newt/handleNewtPingRequestMessage.ts(42,9): error TS2554: Expected 1-3 arguments, but got 4.
```

This breaks `npx tsc --noEmit` for the OSS build - the exact command the `test.yml` `Test with tsc` step runs after `npm run set:oss`. It passes for enterprise/saas (where the 4-param implementation is resolved), which is why it's easy to miss.

## Fix

Add `siteId?: number` to the OSS `listExitNodes` signature for parity with the enterprise implementation. It is unused in the OSS build (which has no remote exit nodes to label-filter); accepting it keeps the two `#dynamic` implementations interface-compatible.

## Verification

- `npx tsc --noEmit` (OSS): the error is gone (project goes from 1 error to 0).
- eslint and prettier pass on the changed file.
- No runtime behavior change in OSS (the argument was already being passed by the caller and ignored at runtime).

## CLA

By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.