### PR TITLE
Fix default IdP validation rejecting server-wide identity providers

### DIFF
--- a/server/lib/idp/canOrgUseIdp.ts
+++ b/server/lib/idp/canOrgUseIdp.ts
@@ -1,0 +1,33 @@
+import { db, idp, idpOrg } from "@server/db";
+import { and, eq } from "drizzle-orm";
+import { build } from "@server/build";
+
+/**
+ * Checks whether an identity provider can be used for resource auth in the
+ * given org. When IdPs are org-scoped (SaaS build or identity_provider_mode
+ * set to "org"), the IdP must be linked to the org. Otherwise any server-wide
+ * IdP is valid, matching the IdPs offered on the resource login page.
+ */
+export async function canOrgUseIdp(
+    idpId: number,
+    orgId: string
+): Promise<boolean> {
+    const [provider] = await db
+        .select()
+        .from(idp)
+        .leftJoin(
+            idpOrg,
+            and(eq(idpOrg.idpId, idp.idpId), eq(idpOrg.orgId, orgId))
+        )
+        .where(eq(idp.idpId, idpId))
+        .limit(1);
+
+    if (!provider) {
+        return false;
+    }
+
+    const orgScopedIdps =
+        build === "saas" || process.env.IDENTITY_PROVIDER_MODE === "org";
+
+    return !orgScopedIdps || provider.idpOrg !== null;
+}

--- a/server/private/routers/policy/createResourcePolicy.ts
+++ b/server/private/routers/policy/createResourcePolicy.ts
@@ -14,8 +14,6 @@
 import { hashPassword } from "@server/auth/password";
 import {
     db,
-    idp,
-    idpOrg,
     orgs,
     resourcePolicies,
     resourcePolicyHeaderAuth,
@@ -31,6 +29,7 @@ import {
     type ResourcePolicy
 } from "@server/db";
 import { getUniqueResourcePolicyName } from "@server/db/names";
+import { canOrgUseIdp } from "@server/lib/idp/canOrgUseIdp";
 import response from "@server/lib/response";
 import {
     getResourceRuleValueValidationError,
@@ -204,14 +203,7 @@ export async function createResourcePolicy(
 
         // Check if Identity provider in `skipToIdpId` exists
         if (skipToIdpId) {
-            const [provider] = await db
-                .select()
-                .from(idp)
-                .innerJoin(idpOrg, eq(idpOrg.idpId, idp.idpId))
-                .where(and(eq(idp.idpId, skipToIdpId), eq(idpOrg.orgId, orgId)))
-                .limit(1);
-
-            if (!provider) {
+            if (!(await canOrgUseIdp(skipToIdpId, orgId))) {
                 return next(
                     createHttpError(
                         HttpCode.INTERNAL_SERVER_ERROR,

--- a/server/routers/policy/setResourcePolicyAccessControl.ts
+++ b/server/routers/policy/setResourcePolicyAccessControl.ts
@@ -2,14 +2,13 @@ import { Request, Response, NextFunction } from "express";
 import { z } from "zod";
 import {
     db,
-    idp,
-    idpOrg,
     resourcePolicies,
     rolePolicies,
     roles,
     userOrgs,
     users
 } from "@server/db";
+import { canOrgUseIdp } from "@server/lib/idp/canOrgUseIdp";
 import { userPolicies } from "@server/db";
 import response from "@server/lib/response";
 import HttpCode from "@server/types/HttpCode";
@@ -104,16 +103,7 @@ export async function setResourcePolicyAccessControl(
 
         // Check if Identity provider in `skipToIdpId` exists
         if (idpId) {
-            const [provider] = await db
-                .select()
-                .from(idp)
-                .innerJoin(idpOrg, eq(idpOrg.idpId, idp.idpId))
-                .where(
-                    and(eq(idp.idpId, idpId), eq(idpOrg.orgId, policy.orgId))
-                )
-                .limit(1);
-
-            if (!provider) {
+            if (!(await canOrgUseIdp(idpId, policy.orgId))) {
                 return next(
                     createHttpError(
                         HttpCode.INTERNAL_SERVER_ERROR,


### PR DESCRIPTION
```
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.
```

Fixes #3290

## What

Setting a default identity provider (Platform SSO) on a resource's Authentication tab fails with `Identity provider not found in this organization` on Community Edition / self-host since 1.19. As noted in the issue thread, hitting Save Settings on any Auth tab that has a default IdP set reproduces it.

## Why

`setResourcePolicyAccessControl` validates `skipToIdpId` with an inner join on `idpOrg`, so it only accepts IdPs that have an org link row. But server-wide IdPs created through the server admin panel (`createOidcIdp`) never get an `idpOrg` row - only org-scoped IdPs do (SaaS build or `identity_provider_mode: org`). The check shipped with the resource policies rework in 1.19, which is why this appeared after upgrading from 1.18.

The resource login page itself has the correct rule: it offers org-scoped IdPs when `build === "saas" || identityProviderMode === "org"`, and otherwise offers every server-wide IdP from `/idp`. So any server-wide IdP is genuinely usable as a skip-to IdP on self-host - the save-time validation was just stricter than the runtime behavior.

## How

- Added `canOrgUseIdp(idpId, orgId)` in `server/lib/idp/canOrgUseIdp.ts`: left-joins the org link and only requires it when IdPs are org-scoped (SaaS build or `IDENTITY_PROVIDER_MODE === "org"`, matching how other OSS routes read the mode). Otherwise any existing IdP passes.
- Used it in `setResourcePolicyAccessControl` (OSS) and `createResourcePolicy` (private), which had the same inner-join check duplicated.

Behavior is unchanged for SaaS / org-scoped mode: the org link is still required there.

## Testing

- `tsc --noEmit` passes on both the oss and enterprise configurations.
- Traced both affected routes plus the login page IdP resolution to confirm the validation now matches what the auth flow accepts at runtime.
