### PR TITLE
fix: invalid version causing crashes in the frontend

### DIFF
--- a/src/app/[orgId]/settings/clients/user/[niceId]/general/page.tsx
+++ b/src/app/[orgId]/settings/clients/user/[niceId]/general/page.tsx
@@ -195,9 +195,9 @@ export default function GeneralPage() {
         if (agent in latestPlatformVersions) {
             const agentVersion = latestPlatformVersions[agent];
 
-            updateAvailable = semver.lt(
-                client.olmVersion,
-                agentVersion.latestVersion
+            updateAvailable = Boolean(
+                semver.valid(client.olmVersion) &&
+                semver.lt(client.olmVersion, agentVersion.latestVersion)
             );
         }
     }

--- a/src/components/MachineClientsTable.tsx
+++ b/src/components/MachineClientsTable.tsx
@@ -404,9 +404,12 @@ export default function MachineClientsTable({
                         if (agent in latestPlatformVersions) {
                             const agentVersion = latestPlatformVersions[agent];
 
-                            updateAvailable = semver.lt(
-                                originalRow.olmVersion,
-                                agentVersion.latestVersion
+                            updateAvailable = Boolean(
+                                semver.valid(originalRow.olmVersion) &&
+                                semver.lt(
+                                    originalRow.olmVersion,
+                                    agentVersion.latestVersion
+                                )
                             );
                         }
                     }

--- a/src/components/SitesTable.tsx
+++ b/src/components/SitesTable.tsx
@@ -359,10 +359,12 @@ export default function SitesTable({
                 cell: ({ row }) => {
                     const originalRow = row.original;
 
-                    let updateAvailable =
+                    let updateAvailable = Boolean(
                         latestNewtVersion &&
                         originalRow.newtVersion &&
-                        semver.lt(originalRow.newtVersion, latestNewtVersion);
+                        semver.valid(originalRow.newtVersion) &&
+                        semver.lt(originalRow.newtVersion, latestNewtVersion)
+                    );
 
                     if (originalRow.type === "newt") {
                         return (

--- a/src/components/UserDevicesTable.tsx
+++ b/src/components/UserDevicesTable.tsx
@@ -588,9 +588,12 @@ export default function UserDevicesTable({
                         if (agent in latestPlatformVersions) {
                             const agentVersion = latestPlatformVersions[agent];
 
-                            updateAvailable = semver.lt(
-                                originalRow.olmVersion,
-                                agentVersion.latestVersion
+                            updateAvailable = Boolean(
+                                semver.valid(originalRow.olmVersion) &&
+                                semver.lt(
+                                    originalRow.olmVersion,
+                                    agentVersion.latestVersion
+                                )
                             );
                         }
                     }


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Summary

Fix  #3393


## Screenshots

The invalid newt version is shown correctly: 
 
<img width="1488" height="1061" alt="Screenshot 2026-07-08 at 01 45 31" src="https://github.com/user-attachments/assets/01531714-d59d-4902-b4b7-f777862c28af" />


