### PR TITLE
fix: redirect to /auth/initial-setup after hitting auth rate limit (#…

### DIFF
--- a/server/routers/external.ts
+++ b/server/routers/external.ts
@@ -1338,6 +1338,12 @@ authenticated.get("/ws/round-trip-message/:messageId", checkRoundTripMessage);
 // Auth routes
 export const authRouter = Router();
 unauthenticated.use("/auth", authRouter);
+
+// Register setup-check BEFORE the global auth rate limiter.
+// This endpoint is called on every dashboard root page load (pure boolean
+// read, no secrets) and must not consume the auth rate-limit budget.
+authRouter.get("/initial-setup-complete", auth.initialSetupComplete);
+
 authRouter.use(
     rateLimit({
         windowMs:
@@ -1642,7 +1648,6 @@ authRouter.post("/idp/:idpId/oidc/generate-url", idp.generateOidcUrl);
 authRouter.post("/idp/:idpId/oidc/validate-callback", idp.validateOidcCallback);
 
 authRouter.put("/set-server-admin", auth.setServerAdmin);
-authRouter.get("/initial-setup-complete", auth.initialSetupComplete);
 authRouter.post("/validate-setup-token", auth.validateSetupToken);
 
 // Security Key routes

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -30,14 +30,19 @@ export default async function Page(props: {
     const getUser = cache(verifySession);
     const user = await getUser({ skipCheckVerifyEmail: true });
 
-    let complete = false;
+    let complete: boolean | null = null; // null means "unknown" (request errored)
     try {
         const setupRes = await internal.get<
             AxiosResponse<InitialSetupCompleteResponse>
         >(`/auth/initial-setup-complete`, await authCookieHeader());
         complete = setupRes.data.data.complete;
-    } catch (e) {}
-    if (!complete) {
+    } catch (e) {
+        // Swallow errors (e.g. 429 rate limit, 500, network failure).
+        // Only redirect to initial-setup when the server *confirms* setup
+        // is incomplete (complete === false). If the request itself failed we
+        // cannot tell, so fall through to the login redirect instead.
+    }
+    if (complete === false) {
         redirect("/auth/initial-setup");
     }
 


### PR DESCRIPTION
## Summary

Fixes #3408

After hitting the `rate_limits.auth` limit, reloading the dashboard root
redirected users to `/auth/initial-setup` instead of staying on the login
page — even on a fully configured instance.

## Root Cause

Two issues combined to cause the redirect:

**1. `GET /auth/initial-setup-complete` was inside the global `authRouter`
rate limiter scope.**

The `authRouter` applies a blanket rate limiter to every `/auth/*` route using
an `<IP>:<path>` key. The `/initial-setup-complete` endpoint is called on
**every dashboard root page load** (it's a pure boolean read with no secrets),
so with a low `max_requests` value it exhausted its own per-path budget after
just a few reloads and started returning `429`.

**2. The `page.tsx` root page silently swallowed the 429.**

```ts
// Before
let complete = false;
try {
    const res = await internal.get(`/auth/initial-setup-complete`, ...);
    complete = res.data.data.complete;
} catch (e) {}          // 429 discarded here
if (!complete) {        // complete is still false (default)
    redirect("/auth/initial-setup");  // fires incorrectly
}
