### PR TITLE
fix: redirect to original resource URL after SSO login with expired session 

### DIFF
--- a/src/app/auth/resource/[resourceGuid]/page.tsx
+++ b/src/app/auth/resource/[resourceGuid]/page.tsx
@@ -126,8 +126,13 @@ export default async function ResourceAuthPage(props: {
         } catch (e) {}
     }
 
+    // postAuthPath is a resource-level default landing path. Only apply it
+    // when no ?redirect= deep-path was supplied by the original request.
+    // If searchParams.redirect has already set a specific URL we must honour
+    // it — overriding it here is what caused users to be sent to the wrong
+    // page after SSO login when their Pangolin session had expired.
     const normalizedPostAuthPath = normalizePostAuthPath(authInfo.postAuthPath);
-    if (normalizedPostAuthPath) {
+    if (normalizedPostAuthPath && !searchParams.redirect) {
         redirectUrl = new URL(authInfo.url).origin + normalizedPostAuthPath;
     }
 

--- a/src/components/ResourceAuthPortal.tsx
+++ b/src/components/ResourceAuthPortal.tsx
@@ -300,7 +300,6 @@ export default function ResourceAuthPortal(props: ResourceAuthPortalProps) {
         let isAllowed = false;
         try {
             const response = await resourceAccessProxy(props.resource.id);
-            console.log("response", response);
             if (response.error) {
                 setAccessDenied(true);
             } else {
@@ -311,8 +310,14 @@ export default function ResourceAuthPortal(props: ResourceAuthPortalProps) {
         }
 
         if (isAllowed) {
-            // window.location.href = props.redirect;
-            router.refresh();
+            // Use a full page reload so the browser issues a fresh request to
+            // this URL (which still carries the ?redirect= query parameter).
+            // The server then performs the SSO token exchange and issues a
+            // server-side redirect() to the original deep-path URL.
+            // router.refresh() alone does NOT reliably follow server-side
+            // redirect() calls in the Next.js App Router, causing users to
+            // land on the Pangolin panel instead of the desired resource.
+            window.location.reload();
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes #3365

When a user's session expired and they attempted to access a deep link of an SSO-protected resource, they were incorrectly redirected to the dashboard/panel after logging back in instead of their original destination URL.

## Root Cause

Two separate issues caused the redirect context to be lost:

1. **`router.refresh()` does not follow server redirects:** In `ResourceAuthPortal.tsx`, after successfully authenticating via SSO, the client called `router.refresh()`. In Next.js App Router, this performs a client-side component re-fetch but does not trigger full-page browser navigation or follow server-side `redirect()` calls returned during re-rendering. This left the user stuck on the auth portal page, eventually defaulting to the dashboard panel.
2. **`postAuthPath` overriding target URL:** In `src/app/auth/resource/[resourceGuid]/page.tsx`, if a resource had a custom `postAuthPath` configured, it unconditionally overrode the `searchParams.redirect` target URL, always redirecting users to the default post-auth path rather than their requested deep link.

## Changes

### 1. `src/components/ResourceAuthPortal.tsx`
- Replaced `router.refresh()` with `window.location.reload()`. This forces a full browser reload, maintaining the query parameters (including `?redirect=...`). The server then processes the request, performs the SSO token exchange, and successfully issues a 302 redirect that the browser follows to the deep link.
- Removed a stray debug `console.log`.

### 2. `src/app/auth/resource/[resourceGuid]/page.tsx`
- Modified the logic to only apply `postAuthPath` if there is no `?redirect=` parameter present in the request. The user's requested deep link now has priority, and the `postAuthPath` acts as a fallback.

## Testing

1. Access an SSO-protected resource deep link with an expired session or in an incognito window: `https://app.company.org/some/deep/path`.
2. Enter credentials and complete the login (including MFA if configured).
3. Confirm that you are correctly redirected back to `https://app.company.org/some/deep/path` and not the main Pangolin panel.
