### PR TITLE
stripDuplicateSessions not actually deduping valid session cookies

### DIFF
--- a/server/middlewares/stripDuplicateSessions.ts
+++ b/server/middlewares/stripDuplicateSessions.ts
@@ -24,23 +24,42 @@ export const stripDuplicateSesions = async (
     if (sessionCookies.length > 1) {
         for (const cookie of sessionCookies) {
             const cookieValue = cookie.split("=")[1];
-            const res = await validateSessionToken(cookieValue);
-            if (res.session && res.user) {
+            const validationResult = await validateSessionToken(cookieValue);
+            if (validationResult.session && validationResult.user) {
                 validSessions.push(cookieValue);
             }
         }
 
         if (validSessions.length > 0) {
+            // Only the first valid session should survive. Note this
+            // middleware runs before cookieParser(), so req.cookies isn't
+            // populated yet here - we can't rely on overwriting it below.
+            // If we instead left every *valid* session cookie in the header
+            // (only stripping invalid ones), cookieParser() would parse a
+            // Cookie header with a repeated session key and silently keep
+            // whichever one appears last - not necessarily validSessions[0],
+            // and not something we control. So we dedupe the header itself
+            // here, keeping only the first valid session cookie and
+            // dropping every other session cookie (valid or not).
+            const winningSession = validSessions[0];
+            let keptWinningSession = false;
             const newCookieHeader = cookies.filter((cookie) => {
                 if (cookie.startsWith(`${SESSION_COOKIE_NAME}=`)) {
                     const cookieValue = cookie.split("=")[1];
-                    return validSessions.includes(cookieValue);
+                    if (cookieValue === winningSession && !keptWinningSession) {
+                        keptWinningSession = true;
+                        return true;
+                    }
+                    return false;
                 }
                 return true;
             });
             req.headers.cookie = newCookieHeader.join("; ");
+            // Defensive: if middleware ordering ever changes such that
+            // req.cookies is already populated by this point, keep it in
+            // sync too.
             if (req.cookies) {
-                req.cookies[SESSION_COOKIE_NAME] = validSessions[0];
+                req.cookies[SESSION_COOKIE_NAME] = winningSession;
             }
         }
     }


### PR DESCRIPTION
## Summary

When a request contains multiple `p_session_token` cookies and more than one token is independently valid, `stripDuplicateSessions` is expected to reduce them to a single deterministic session.

This could happen when cookies exist under different domain or path scopes, or when an older but still-valid session cookie remains alongside a newer one.

Previously, the middleware did not correctly deduplicate these valid session cookies.

## Root Cause

`stripDuplicateSessions` is registered before `cookieParser()` in both `apiServer.ts` and `internalServer.ts`:

```ts
apiServer.use(stripDuplicateSesions);
apiServer.use(cookieParser());
```

At the point `stripDuplicateSessions` runs, `req.cookies` has not yet been populated. As a result, this block is effectively dead code:

```ts
if (req.cookies) {
    req.cookies[SESSION_COOKIE_NAME] = validSessions[0];
}
```

The raw `Cookie` header was also only filtering out invalid session tokens:

```ts
return validSessions.includes(cookieValue);
```

This kept every valid session cookie in the header.

When `cookieParser()` later parsed repeated cookie names, the selected value depended on their order in the header rather than the intended `validSessions[0]`. That order may vary based on browser cookie-ordering behavior.

## Impact

This is not an authentication bypass. Every retained session is valid and belongs to the requester.

However, it is a correctness issue. A user with multiple valid session cookies could be routed to the wrong one of their own sessions, potentially resulting in confusing behavior such as appearing to be logged into the wrong account.

Because the selected session depends on cookie ordering, the issue can also appear inconsistent and be difficult to diagnose.

## Fix

Updated the raw `Cookie` header while it is already being rewritten:

* Keep only the first valid `p_session_token` cookie.
* Remove all additional session-cookie entries, whether valid or invalid.
* Ensure `cookieParser()` always receives a single unambiguous session value.

The `req.cookies` assignment remains as a defensive fallback, with a comment explaining that it does not currently run because this middleware executes before `cookieParser()`.

## Additional Cleanup

Renamed the inner `res` variable to `validationResult` to avoid shadowing the outer Express `Response` parameter.
