### PR TITLE
Fix request audit log ordering

### DIFF
--- a/server/routers/auditLogs/queryRequestAuditLog.ts
+++ b/server/routers/auditLogs/queryRequestAuditLog.ts
@@ -158,7 +158,7 @@ export function queryRequest(data: Q) {
         })
         .from(requestAuditLog)
         .where(getWhere(data))
-        .orderBy(desc(requestAuditLog.timestamp));
+        .orderBy(desc(requestAuditLog.timestamp), desc(requestAuditLog.id));
 }
 
 async function enrichWithResourceDetails(

--- a/src/app/[orgId]/settings/logs/access/page.tsx
+++ b/src/app/[orgId]/settings/logs/access/page.tsx
@@ -23,7 +23,6 @@ import { usePaidStatus } from "@app/hooks/usePaidStatus";
 import { tierMatrix } from "@server/lib/billing/tierMatrix";
 import { logQueries } from "@app/lib/queries";
 import { useQuery } from "@tanstack/react-query";
-import type { QueryAccessAuditLogResponse } from "@server/routers/auditLogs/types";
 
 export default function GeneralPage() {
     const router = useRouter();
@@ -125,7 +124,7 @@ export default function GeneralPage() {
         enabled: isPaidUser(tierMatrix.accessLogs) && build !== "oss"
     });
 
-    const rows = isLoading ? generateSampleAccessLogs() : (data?.log ?? []);
+    const rows = data?.log ?? [];
     const totalCount = data?.pagination?.total ?? 0;
     const filterAttributes = data?.filterAttributes ?? {
         actors: [],
@@ -517,51 +516,4 @@ export default function GeneralPage() {
             />
         </>
     );
-}
-
-function generateSampleAccessLogs(): QueryAccessAuditLogResponse["log"] {
-    const locations = ["US", "DE", "GB", "FR", "JP", "CA", "AU"];
-    const types = [
-        "password",
-        "pincode",
-        "login",
-        "whitelistedEmail",
-        "ssh",
-        "rdp",
-        "vnc"
-    ];
-    const actors = [
-        "alice@example.com",
-        "bob@example.com",
-        "carol@example.com",
-        null
-    ];
-
-    const now = Math.floor(Date.now() / 1000);
-    const sevenDaysAgo = now - 7 * 24 * 60 * 60;
-
-    return Array.from({ length: 10 }, (_, i) => {
-        const action = Math.random() > 0.3;
-        const actor = actors[Math.floor(Math.random() * actors.length)];
-
-        return {
-            timestamp: Math.floor(
-                sevenDaysAgo + Math.random() * (now - sevenDaysAgo)
-            ),
-            action,
-            orgId: "sample-org",
-            actorType: actor ? "user" : null,
-            actor,
-            actorId: actor ? `user-${i}` : null,
-            resourceId: Math.floor(Math.random() * 5) + 1,
-            siteResourceId: null,
-            resourceNiceId: `resource-${(i % 3) + 1}`,
-            resourceName: `Resource ${(i % 3) + 1}`,
-            ip: `${Math.floor(Math.random() * 255)}.${Math.floor(Math.random() * 255)}.${Math.floor(Math.random() * 255)}.${Math.floor(Math.random() * 255)}`,
-            location: locations[Math.floor(Math.random() * locations.length)],
-            userAgent: "Mozilla/5.0",
-            metadata: null,
-            type: types[Math.floor(Math.random() * types.length)]
-        };
-    });
 }

--- a/src/app/[orgId]/settings/logs/action/page.tsx
+++ b/src/app/[orgId]/settings/logs/action/page.tsx
@@ -13,7 +13,6 @@ import { getSevenDaysAgo } from "@app/lib/getSevenDaysAgo";
 import { logQueries } from "@app/lib/queries";
 import { build } from "@server/build";
 import { tierMatrix } from "@server/lib/billing/tierMatrix";
-import type { QueryActionAuditLogResponse } from "@server/routers/auditLogs/types";
 import { useQuery } from "@tanstack/react-query";
 import { ColumnDef } from "@tanstack/react-table";
 import axios from "axios";
@@ -113,7 +112,7 @@ export default function GeneralPage() {
         enabled: isPaidUser(tierMatrix.actionLogs) && build !== "oss"
     });
 
-    const rows = isLoading ? generateSampleActionLogs() : (data?.log ?? []);
+    const rows = data?.log ?? [];
     const totalCount = data?.pagination?.total ?? 0;
     const filterAttributes = {
         actors: data?.filterAttributes?.actors ?? []
@@ -365,40 +364,4 @@ export default function GeneralPage() {
             />
         </>
     );
-}
-
-function generateSampleActionLogs(): QueryActionAuditLogResponse["log"] {
-    const actions = [
-        "createResource",
-        "deleteResource",
-        "updateResource",
-        "createSite",
-        "deleteSite",
-        "inviteUser",
-        "removeUser"
-    ];
-    const actors = [
-        "alice@example.com",
-        "bob@example.com",
-        "carol@example.com"
-    ];
-
-    const now = Math.floor(Date.now() / 1000);
-    const sevenDaysAgo = now - 7 * 24 * 60 * 60;
-
-    return Array.from({ length: 10 }, (_, i) => {
-        const actor = actors[Math.floor(Math.random() * actors.length)];
-
-        return {
-            timestamp: Math.floor(
-                sevenDaysAgo + Math.random() * (now - sevenDaysAgo)
-            ),
-            action: actions[Math.floor(Math.random() * actions.length)],
-            orgId: "sample-org",
-            actorType: "user",
-            actor,
-            actorId: `user-${i}`,
-            metadata: null
-        };
-    });
 }

--- a/src/app/[orgId]/settings/logs/connection/page.tsx
+++ b/src/app/[orgId]/settings/logs/connection/page.tsx
@@ -15,7 +15,6 @@ import { getPrivateResourceSettingsHref } from "@app/lib/launcherResourceAdminHr
 import { logQueries } from "@app/lib/queries";
 import { build } from "@server/build";
 import { tierMatrix } from "@server/lib/billing/tierMatrix";
-import type { QueryConnectionAuditLogResponse } from "@server/routers/auditLogs/types";
 import { useQuery } from "@tanstack/react-query";
 import { ColumnDef } from "@tanstack/react-table";
 import axios from "axios";
@@ -144,7 +143,7 @@ export default function ConnectionLogsPage() {
         enabled: isPaidUser(tierMatrix.connectionLogs) && build !== "oss"
     });
 
-    const rows = isLoading ? generateSampleConnectionLogs() : (data?.log ?? []);
+    const rows = data?.log ?? [];
     const totalCount = data?.pagination?.total ?? 0;
     const filterAttributes = data?.filterAttributes ?? {
         protocols: [],
@@ -588,51 +587,4 @@ export default function ConnectionLogsPage() {
             />
         </>
     );
-}
-
-function generateSampleConnectionLogs(): QueryConnectionAuditLogResponse["log"] {
-    const protocols = ["tcp", "udp", "icmp"];
-    const destAddrs = [
-        "10.0.0.1:22",
-        "10.0.0.2:80",
-        "10.0.0.3:443",
-        "192.168.1.10:3306"
-    ];
-
-    const now = Math.floor(Date.now() / 1000);
-    const sevenDaysAgo = now - 7 * 24 * 60 * 60;
-
-    return Array.from({ length: 10 }, (_, i) => {
-        const startedAt = Math.floor(
-            sevenDaysAgo + Math.random() * (now - sevenDaysAgo)
-        );
-        const active = Math.random() > 0.3;
-
-        return {
-            sessionId: `session-${i}`,
-            siteResourceId: (i % 3) + 1,
-            orgId: "sample-org",
-            siteId: 1,
-            clientId: (i % 4) + 1,
-            clientEndpoint: `10.0.0.${i + 1}:51820`,
-            userId: i % 2 === 0 ? `user-${i}` : null,
-            sourceAddr: `192.168.1.${i + 1}:${40000 + i}`,
-            destAddr: destAddrs[Math.floor(Math.random() * destAddrs.length)],
-            protocol: protocols[Math.floor(Math.random() * protocols.length)],
-            startedAt,
-            endedAt: active
-                ? null
-                : startedAt + Math.floor(Math.random() * 3600),
-            bytesTx: active ? null : Math.floor(Math.random() * 1024 * 1024),
-            bytesRx: active ? null : Math.floor(Math.random() * 1024 * 1024),
-            resourceName: `Resource ${(i % 3) + 1}`,
-            resourceNiceId: `resource-${(i % 3) + 1}`,
-            siteName: "Sample Site",
-            siteNiceId: "sample-site",
-            clientName: `Client ${(i % 4) + 1}`,
-            clientNiceId: `client-${(i % 4) + 1}`,
-            clientType: i % 2 === 0 ? "user" : "machine",
-            userEmail: i % 2 === 0 ? `user${i}@example.com` : null
-        };
-    });
 }

--- a/src/app/[orgId]/settings/logs/request/page.tsx
+++ b/src/app/[orgId]/settings/logs/request/page.tsx
@@ -19,7 +19,6 @@ import Link from "next/link";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { useMemo, useState, useTransition } from "react";
 import { useStoredPageSize } from "@app/hooks/useStoredPageSize";
-import type { QueryRequestAuditLogResponse } from "@server/routers/auditLogs/types";
 import { ColumnFilterButton } from "@app/components/ColumnFilterButton";
 
 export default function GeneralPage() {
@@ -125,7 +124,7 @@ export default function GeneralPage() {
         })
     });
 
-    const rows = isLoading ? generateSampleRequestLogs() : (data?.log ?? []);
+    const rows = data?.log ?? [];
     const totalCount = data?.pagination?.total ?? 0;
     const filterAttributes = data?.filterAttributes ?? {
         actors: [],
@@ -686,64 +685,4 @@ export default function GeneralPage() {
             />
         </>
     );
-}
-
-function generateSampleRequestLogs(): QueryRequestAuditLogResponse["log"] {
-    const methods = ["GET", "POST", "PUT", "DELETE", "PATCH"];
-    const paths = [
-        "/api/v1/users",
-        "/dashboard",
-        "/settings",
-        "/health",
-        "/metrics"
-    ];
-    const hosts = ["app.example.com", "api.example.com", "admin.example.com"];
-    const locations = ["US", "DE", "GB", "FR", "JP", "CA", "AU"];
-    const allowedReasons = [100, 101, 102, 103, 104, 105, 106, 107, 108];
-    const deniedReasons = [201, 202, 203, 204, 205, 299];
-    const actors = [
-        "alice@example.com",
-        "bob@example.com",
-        "carol@example.com",
-        null
-    ];
-
-    const now = Math.floor(Date.now() / 1000);
-    const sevenDaysAgo = now - 7 * 24 * 60 * 60;
-
-    return Array.from({ length: 10 }, (_, i) => {
-        const action = Math.random() > 0.3;
-        const reason = action
-            ? allowedReasons[Math.floor(Math.random() * allowedReasons.length)]
-            : deniedReasons[Math.floor(Math.random() * deniedReasons.length)];
-        const actor = actors[Math.floor(Math.random() * actors.length)];
-
-        return {
-            timestamp: Math.floor(
-                sevenDaysAgo + Math.random() * (now - sevenDaysAgo)
-            ),
-            action,
-            reason,
-            orgId: "sample-org",
-            actorType: actor ? "user" : null,
-            actor,
-            actorId: actor ? `user-${i}` : null,
-            resourceId: Math.floor(Math.random() * 5) + 1,
-            siteResourceId: null,
-            resourceNiceId: `resource-${(i % 3) + 1}`,
-            resourceName: `Resource ${(i % 3) + 1}`,
-            ip: `${Math.floor(Math.random() * 255)}.${Math.floor(Math.random() * 255)}.${Math.floor(Math.random() * 255)}.${Math.floor(Math.random() * 255)}`,
-            location: locations[Math.floor(Math.random() * locations.length)],
-            userAgent: "Mozilla/5.0",
-            metadata: null,
-            headers: null,
-            query: null,
-            originalRequestURL: null,
-            scheme: "https",
-            host: hosts[Math.floor(Math.random() * hosts.length)],
-            path: paths[Math.floor(Math.random() * paths.length)],
-            method: methods[Math.floor(Math.random() * methods.length)],
-            tls: true
-        };
-    });
 }


### PR DESCRIPTION
## Summary

- Add a deterministic secondary sort for request audit logs when multiple entries share the same timestamp.
- Stop rendering generated sample rows in audit log tables while real log data is loading.

## Why

Request audit log entries store timestamps at second-level precision. Under high activity, many entries can share the same timestamp. The request log query sorted only by timestamp, so separate executions for the GUI and CSV export could return same-timestamp rows in different orders. That can make row-by-row comparisons look like the GUI mixed data even when each individual row is valid.

Request logs now sort by timestamp descending and then id descending, matching the deterministic ordering pattern already used by action, access, and connection audit log queries.

Audit log pages also now render only real API data instead of generated placeholder rows while loading.

Fixes #3458.

## Validation

- `git diff --check HEAD~1 HEAD`
- `npx prettier --check server/routers/auditLogs/queryRequestAuditLog.ts 'src/app/[orgId]/settings/logs/access/page.tsx' 'src/app/[orgId]/settings/logs/action/page.tsx' 'src/app/[orgId]/settings/logs/connection/page.tsx' 'src/app/[orgId]/settings/logs/request/page.tsx'`
- `npx tsc --noEmit --pretty false`
- Inserted a local burst of 50 same-timestamp request audit rows to verify the high-activity shape, then removed the synthetic rows afterward.