### PR TITLE
Fix Punycode domain validation

### DIFF
--- a/server/lib/validators.test.ts
+++ b/server/lib/validators.test.ts
@@ -1,10 +1,29 @@
 import {
     getResourceRuleValueValidationError,
+    isValidDomain,
     isValidUrlGlobPattern
 } from "./validators";
 import { assertEquals } from "@test/assert";
 
 function runTests() {
+    console.log("Running domain validation tests...");
+
+    assertEquals(
+        isValidDomain("example.com"),
+        true,
+        "Standard ASCII domain should be valid"
+    );
+    assertEquals(
+        isValidDomain("xn--e1afmkfd.xn--p1ai"),
+        true,
+        "Punycode IDN domain should be valid"
+    );
+    assertEquals(
+        isValidDomain("example.invalid-tld"),
+        false,
+        "Domain with unknown TLD should be invalid"
+    );
+
     console.log("Running URL pattern validation tests...");
 
     // Test valid patterns

--- a/server/lib/validators.ts
+++ b/server/lib/validators.ts
@@ -171,9 +171,10 @@ export function isValidDomain(domain: string): boolean {
         if (!/^[a-zA-Z0-9-]+$/.test(label)) return false;
     }
 
-    // TLD should be at least 2 characters and contain only letters
+    // TLD should be at least 2 characters. Punycode TLDs can contain digits
+    // and hyphens, so validity is ultimately enforced by the TLD allowlist.
     const tld = labels[labels.length - 1];
-    if (tld.length < 2 || !/^[a-zA-Z]+$/.test(tld)) return false;
+    if (tld.length < 2) return false;
 
     // Check if TLD is in the list of valid TLDs
     if (!validTlds.includes(tld.toUpperCase())) return false;


### PR DESCRIPTION
## Summary

- Allow Punycode TLDs to pass backend domain validation when they are present in the existing TLD allowlist.
- Add regression coverage for the reported IDN domain converted to Punycode.

## Root cause

The domain creation form converts internationalized domains to Punycode before submitting them. The backend validator accepted Punycode-looking labels, but rejected the final TLD unless it contained only letters. That blocked valid TLDs such as xn--p1ai before the existing allowlist check could accept them.

## Impact

Admins can create valid IDN domains after the UI converts them to Punycode. Unknown TLDs are still rejected through the existing allowlist.

Fixes #3427

## Validation

- `/tmp/node-v22.13.1-linux-x64/bin/node ./node_modules/tsx/dist/cli.mjs server/lib/validators.test.ts`
- `/tmp/node-v22.13.1-linux-x64/bin/node ./node_modules/prettier/bin/prettier.cjs --check server/lib/validators.ts server/lib/validators.test.ts`
- `/tmp/node-v22.13.1-linux-x64/bin/node ./node_modules/typescript/bin/tsc --noEmit --pretty false`
- `git diff --check`