### PR TITLE
Fix resource rule value validation

### DIFF
--- a/server/routers/resource/createResourceRule.ts
+++ b/server/routers/resource/createResourceRule.ts
@@ -9,16 +9,14 @@ import createHttpError from "http-errors";
 import logger from "@server/logger";
 import { fromError } from "zod-validation-error";
 import {
-    isValidCIDR,
-    isValidIP,
-    isValidUrlGlobPattern
+    getResourceRuleValueValidationError,
+    RESOURCE_RULE_MATCH_TYPES
 } from "@server/lib/validators";
 import { OpenAPITags, registry } from "@server/openApi";
-import { isValidRegionId } from "@server/db/regions";
 
 const createResourceRuleSchema = z.strictObject({
     action: z.enum(["ACCEPT", "DROP", "PASS"]),
-    match: z.enum(["CIDR", "IP", "PATH", "COUNTRY", "ASN", "REGION"]),
+    match: z.enum(RESOURCE_RULE_MATCH_TYPES),
     value: z.string().min(1),
     priority: z.int(),
     enabled: z.boolean().optional()
@@ -118,39 +116,12 @@ export async function createResourceRule(
             );
         }
 
-        if (match === "CIDR") {
-            if (!isValidCIDR(value)) {
-                return next(
-                    createHttpError(
-                        HttpCode.BAD_REQUEST,
-                        "Invalid CIDR provided"
-                    )
-                );
-            }
-        } else if (match === "IP") {
-            if (!isValidIP(value)) {
-                return next(
-                    createHttpError(HttpCode.BAD_REQUEST, "Invalid IP provided")
-                );
-            }
-        } else if (match === "PATH") {
-            if (!isValidUrlGlobPattern(value)) {
-                return next(
-                    createHttpError(
-                        HttpCode.BAD_REQUEST,
-                        "Invalid URL glob pattern provided"
-                    )
-                );
-            }
-        } else if (match === "REGION") {
-            if (!isValidRegionId(value)) {
-                return next(
-                    createHttpError(
-                        HttpCode.BAD_REQUEST,
-                        "Invalid region ID provided"
-                    )
-                );
-            }
+        const validationError = getResourceRuleValueValidationError(
+            match,
+            value
+        );
+        if (validationError) {
+            return next(createHttpError(HttpCode.BAD_REQUEST, validationError));
         }
 
         // Create the new resource rule

--- a/server/routers/resource/updateResourceRule.ts
+++ b/server/routers/resource/updateResourceRule.ts
@@ -9,12 +9,11 @@ import createHttpError from "http-errors";
 import logger from "@server/logger";
 import { fromError } from "zod-validation-error";
 import {
-    isValidCIDR,
-    isValidIP,
-    isValidUrlGlobPattern
+    getResourceRuleValueValidationError,
+    RESOURCE_RULE_MATCH_TYPES,
+    type ResourceRuleMatchType
 } from "@server/lib/validators";
 import { OpenAPITags, registry } from "@server/openApi";
-import { isValidRegionId } from "@server/db/regions";
 
 // Define Zod schema for request parameters validation
 const updateResourceRuleParamsSchema = z.strictObject({
@@ -22,15 +21,7 @@ const updateResourceRuleParamsSchema = z.strictObject({
     resourceId: z.coerce.number().int().positive()
 });
 
-const resourceRuleMatchSchema = z.enum([
-    "CIDR",
-    "IP",
-    "PATH",
-    "COUNTRY",
-    "COUNTRY_IS_NOT",
-    "ASN",
-    "REGION"
-]);
+const resourceRuleMatchSchema = z.enum(RESOURCE_RULE_MATCH_TYPES);
 
 // Define Zod schema for request body validation
 const updateResourceRuleSchema = z
@@ -140,14 +131,7 @@ export async function updateResourceRule(
             resource.resourcePolicyId === null &&
             resource.defaultResourcePolicyId !== null;
 
-        let existingMatch:
-            | "CIDR"
-            | "IP"
-            | "PATH"
-            | "COUNTRY"
-            | "COUNTRY_IS_NOT"
-            | "ASN"
-            | "REGION";
+        let existingMatch: ResourceRuleMatchType;
 
         if (isInlinePolicy) {
             const policyId = resource.defaultResourcePolicyId!;
@@ -231,42 +215,14 @@ export async function updateResourceRule(
         const { value } = updateData;
 
         if (value !== undefined) {
-            if (match === "CIDR") {
-                if (!isValidCIDR(value)) {
-                    return next(
-                        createHttpError(
-                            HttpCode.BAD_REQUEST,
-                            "Invalid CIDR provided"
-                        )
-                    );
-                }
-            } else if (match === "IP") {
-                if (!isValidIP(value)) {
-                    return next(
-                        createHttpError(
-                            HttpCode.BAD_REQUEST,
-                            "Invalid IP provided"
-                        )
-                    );
-                }
-            } else if (match === "PATH") {
-                if (!isValidUrlGlobPattern(value)) {
-                    return next(
-                        createHttpError(
-                            HttpCode.BAD_REQUEST,
-                            "Invalid URL glob pattern provided"
-                        )
-                    );
-                }
-            } else if (match === "REGION") {
-                if (!isValidRegionId(value)) {
-                    return next(
-                        createHttpError(
-                            HttpCode.BAD_REQUEST,
-                            "Invalid region ID provided"
-                        )
-                    );
-                }
+            const validationError = getResourceRuleValueValidationError(
+                match,
+                value
+            );
+            if (validationError) {
+                return next(
+                    createHttpError(HttpCode.BAD_REQUEST, validationError)
+                );
             }
         }
 


### PR DESCRIPTION
﻿## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description

Fixes #3462.

Resource rule creation and update were using hand-rolled value validation that only covered `CIDR`, `IP`, `PATH`, and `REGION` rules. The shared rule validator also covers `COUNTRY`, `COUNTRY_IS_NOT`, and `ASN`, so direct API calls could persist invalid country or ASN values that the shared validation logic would reject.

This reuses the shared rule match list and value validator in both resource rule routes so backend API validation stays aligned with the existing validator behavior.

This also lets the create route accept `COUNTRY_IS_NOT`, matching the update route and the shared resource rule match list.

## Validation

- `node node_modules/prettier/bin/prettier.cjs --check server/routers/resource/createResourceRule.ts server/routers/resource/updateResourceRule.ts`
- `node node_modules/tsx/dist/cli.mjs server/lib/validators.test.ts`
- `git diff --check upstream/main...HEAD`

Note: full project TypeScript validation was attempted locally but did not complete before timeout; no diagnostics were emitted before the timeout.