### PR TITLE
fix labels dropdown flicker if no changes applied

### DIFF
--- a/src/hooks/useOptimisticLabels.ts
+++ b/src/hooks/useOptimisticLabels.ts
@@ -95,7 +95,10 @@ export function useOptimisticLabels({
     }
 
     async function refresh() {
-        router.refresh();
+        // Only refresh if the labels have been modified
+        if (pendingActions.length > 0) {
+            router.refresh();
+        }
         setPendingActions([]);
     }
 


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Summary

- Fix the dropdown labels flickering when the user quickly toggle the dropdown, 
   it might still flicker if the user has updated the labels but that one is very complicated to 
   reproduce and it doesn't occur that often

## Screenshots

|  Name | Screenshot  | 
|---|---|
| Before | <video src="https://github.com/user-attachments/assets/0614a04e-3c61-4f5c-91b3-2bfbf285bddf"></video> | 
| After |<video src="https://github.com/user-attachments/assets/15367d90-0548-4f96-8c52-221854079267"></video> |
