### PR TITLE
fix(policy): add multi-country support and fix rule evaluation for COUNTRY_IS_NOT rules (#3432)

### DIFF
--- a/server/lib/blueprints/types.ts
+++ b/server/lib/blueprints/types.ts
@@ -135,8 +135,14 @@ export const RuleSchema = z
                 if (!hasMaxmindCountryDb) {
                     return false;
                 }
-                // Check if it's a valid 2-letter country code or "ALL"
-                return /^[A-Z]{2}$/.test(rule.value) || rule.value === "ALL";
+                const codes = rule.value
+                    .split(",")
+                    .map((c) => c.trim().toUpperCase())
+                    .filter(Boolean);
+                return (
+                    codes.length > 0 &&
+                    codes.every((c) => /^[A-Z]{2}$/.test(c) || c === "ALL")
+                );
             }
             return true;
         },

--- a/server/lib/validators.test.ts
+++ b/server/lib/validators.test.ts
@@ -276,6 +276,38 @@ function runTests() {
         "Invalid ASN should return an error"
     );
 
+    // Country validation tests
+    assertEquals(
+        getResourceRuleValueValidationError("COUNTRY", "US"),
+        null,
+        "Single country code should be valid"
+    );
+    assertEquals(
+        getResourceRuleValueValidationError("COUNTRY", "US, CA, MX"),
+        null,
+        "Comma-separated list of country codes should be valid"
+    );
+    assertEquals(
+        getResourceRuleValueValidationError("COUNTRY_IS_NOT", "US,CA"),
+        null,
+        "Comma-separated list of country codes for COUNTRY_IS_NOT should be valid"
+    );
+    assertEquals(
+        getResourceRuleValueValidationError("COUNTRY", "ALL"),
+        null,
+        "ALL country selector should be valid"
+    );
+    assertEquals(
+        getResourceRuleValueValidationError("COUNTRY", "INVALID_CODE"),
+        "Invalid country code provided",
+        "Invalid country code should return error"
+    );
+    assertEquals(
+        getResourceRuleValueValidationError("COUNTRY", "US, INVALID_CODE"),
+        "Invalid country code provided",
+        "Mixed valid and invalid country code should return error"
+    );
+
     console.log("All tests passed!");
 }
 

--- a/server/lib/validators.ts
+++ b/server/lib/validators.ts
@@ -97,10 +97,21 @@ export function getResourceRuleValueValidationError(
         case "REGION":
             return isValidRegionId(value) ? null : "Invalid region ID provided";
         case "COUNTRY":
-        case "COUNTRY_IS_NOT":
-            return COUNTRIES.some((country) => country.code === value)
-                ? null
-                : "Invalid country code provided";
+        case "COUNTRY_IS_NOT": {
+            const countryCodes = value
+                .split(",")
+                .map((code) => code.trim().toUpperCase())
+                .filter(Boolean);
+            if (countryCodes.length === 0) {
+                return "Invalid country code provided";
+            }
+            const allValid = countryCodes.every(
+                (code) =>
+                    code === "ALL" ||
+                    COUNTRIES.some((country) => country.code === code)
+            );
+            return allValid ? null : "Invalid country code provided";
+        }
         case "ASN":
             const normalizedValue = value.trim().toUpperCase();
             return /^AS\d+$/.test(normalizedValue) ||

--- a/server/routers/badger/verifySession.ts
+++ b/server/routers/badger/verifySession.ts
@@ -1271,7 +1271,8 @@ async function checkRules(
     // sort rules by priority in ascending order
     rules = rules.sort((a, b) => a.priority - b.priority);
 
-    for (const rule of rules) {
+    for (let i = 0; i < rules.length; i++) {
+        const rule = rules[i];
         if (!rule.enabled) {
             continue;
         }
@@ -1294,19 +1295,61 @@ async function checkRules(
             clientIp &&
             (rule.match === "COUNTRY" || rule.match === "COUNTRY_IS_NOT")
         ) {
-            // COUNTRY=ALL should not affect local/private/CGNAT addresses.
-            if (
-                rule.value.toUpperCase() === "ALL" &&
-                isLocalOrCarrierGradeNatIp(clientIp)
-            ) {
-                continue;
-            }
+            if (rule.match === "COUNTRY_IS_NOT") {
+                const combinedCountries: string[] = [];
+                let lastIndex = i;
+                for (let j = i; j < rules.length; j++) {
+                    const r = rules[j];
+                    if (
+                        r.enabled &&
+                        r.match === "COUNTRY_IS_NOT" &&
+                        r.action === rule.action
+                    ) {
+                        const codes = r.value
+                            .split(",")
+                            .map((c) => c.trim().toUpperCase())
+                            .filter(Boolean);
+                        combinedCountries.push(...codes);
+                        lastIndex = j;
+                    } else if (!r.enabled) {
+                        continue;
+                    } else {
+                        break;
+                    }
+                }
 
-            const inCountry = await isIpInGeoIP(ipCC, rule.value);
-            const matched = rule.match === "COUNTRY" ? inCountry : !inCountry;
+                if (
+                    combinedCountries.includes("ALL") &&
+                    isLocalOrCarrierGradeNatIp(clientIp)
+                ) {
+                    i = lastIndex;
+                    continue;
+                }
 
-            if (matched) {
-                return rule.action as any;
+                const inAnyCountry = await isIpInGeoIP(
+                    ipCC,
+                    combinedCountries.join(",")
+                );
+                if (!inAnyCountry) {
+                    return rule.action as any;
+                }
+                i = lastIndex;
+            } else {
+                const codes = rule.value
+                    .split(",")
+                    .map((code) => code.trim().toUpperCase())
+                    .filter(Boolean);
+                if (
+                    codes.includes("ALL") &&
+                    isLocalOrCarrierGradeNatIp(clientIp)
+                ) {
+                    continue;
+                }
+
+                const inCountry = await isIpInGeoIP(ipCC, rule.value);
+                if (inCountry) {
+                    return rule.action as any;
+                }
             }
         } else if (clientIp && rule.match == "ASN") {
             // ASN=ALL/AS0 should not affect local/private/CGNAT addresses.
@@ -1339,11 +1382,20 @@ async function isIpInGeoIP(
     ipCountryCode: string | undefined,
     checkCountryCode: string
 ): Promise<boolean> {
-    if (checkCountryCode == "ALL") {
+    if (!ipCountryCode) {
+        return false;
+    }
+
+    const codes = checkCountryCode
+        .split(",")
+        .map((code) => code.trim().toUpperCase())
+        .filter(Boolean);
+
+    if (codes.includes("ALL")) {
         return true;
     }
 
-    return ipCountryCode?.toUpperCase() === checkCountryCode.toUpperCase();
+    return codes.includes(ipCountryCode.toUpperCase());
 }
 
 function isLocalOrCarrierGradeNatIp(ip: string): boolean {

--- a/src/components/resource-policy/PolicyAccessRulesTable.tsx
+++ b/src/components/resource-policy/PolicyAccessRulesTable.tsx
@@ -501,16 +501,11 @@ export function PolicyAccessRulesTable({
                 accessorKey: "value",
                 header: () => <span className="p-3">{t("value")}</span>,
                 cell: ({ row }) => {
-                    let selectedCountry: (typeof COUNTRIES)[number] | undefined;
-                    if (
-                        (row.original.match === "COUNTRY" ||
-                            row.original.match === "COUNTRY_IS_NOT") &&
-                        row.original.value
-                    ) {
-                        selectedCountry = COUNTRIES.find(
-                            (c) => c.code === row.original.value
-                        );
-                    }
+                    const currentCodes = (row.original.value || "")
+                        .split(",")
+                        .map((c) => c.trim().toUpperCase())
+                        .filter(Boolean);
+
                     return row.original.match === "COUNTRY" ||
                         row.original.match === "COUNTRY_IS_NOT" ? (
                         <Popover>
@@ -521,23 +516,37 @@ export function PolicyAccessRulesTable({
                                     disabled={
                                         readonly || isRuleLocked(row.original)
                                     }
-                                    className="w-full min-w-0 justify-between"
+                                    className="w-full min-w-0 justify-between overflow-hidden text-left"
                                 >
-                                    {selectedCountry ? (
-                                        <>
-                                            <span>
-                                                {selectedCountry.code === "ALL"
-                                                    ? "🌍"
-                                                    : countryCodeToFlagEmoji(
-                                                          selectedCountry.code
-                                                      )}
-                                                &nbsp;&nbsp;
-                                                {selectedCountry.name} (
-                                                {selectedCountry.code})
-                                            </span>
-                                        </>
-                                    ) : (
+                                    {currentCodes.length === 0 ? (
                                         t("selectCountry")
+                                    ) : currentCodes.length === 1 ? (
+                                        (() => {
+                                            const found = COUNTRIES.find(
+                                                (c) => c.code === currentCodes[0]
+                                            );
+                                            if (!found) return t("selectCountry");
+                                            return (
+                                                <span className="truncate">
+                                                    {found.code === "ALL"
+                                                        ? "🌍"
+                                                        : countryCodeToFlagEmoji(
+                                                              found.code
+                                                          )}
+                                                    &nbsp;&nbsp;
+                                                    {found.name} ({found.code})
+                                                </span>
+                                            );
+                                        })()
+                                    ) : (
+                                        <span className="truncate">
+                                            {currentCodes.slice(0, 3).map((code) => (
+                                                <span key={code} className="mr-1">
+                                                    {countryCodeToFlagEmoji(code)}
+                                                </span>
+                                            ))}
+                                            {currentCodes.length} countries ({currentCodes.join(", ")})
+                                        </span>
                                     )}
                                     <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
                                 </Button>
@@ -552,33 +561,59 @@ export function PolicyAccessRulesTable({
                                             {t("noCountryFound")}
                                         </CommandEmpty>
                                         <CommandGroup>
-                                            {COUNTRIES.map((country) => (
-                                                <CommandItem
-                                                    key={country.code}
-                                                    value={country.name}
-                                                    onSelect={() =>
-                                                        updateRule(
-                                                            row.original.ruleId,
-                                                            {
-                                                                value: country.code
+                                            {COUNTRIES.map((country) => {
+                                                const isSelected = currentCodes.includes(
+                                                    country.code
+                                                );
+                                                return (
+                                                    <CommandItem
+                                                        key={country.code}
+                                                        value={country.name}
+                                                        onSelect={() => {
+                                                            let newCodes: string[];
+                                                            if (country.code === "ALL") {
+                                                                newCodes = ["ALL"];
+                                                            } else {
+                                                                const withoutAll = currentCodes.filter(
+                                                                    (c) => c !== "ALL"
+                                                                );
+                                                                if (withoutAll.includes(country.code)) {
+                                                                    newCodes = withoutAll.filter(
+                                                                        (c) => c !== country.code
+                                                                    );
+                                                                    if (newCodes.length === 0) {
+                                                                        newCodes = [country.code];
+                                                                    }
+                                                                } else {
+                                                                    newCodes = [
+                                                                        ...withoutAll,
+                                                                        country.code
+                                                                    ];
+                                                                }
                                                             }
-                                                        )
-                                                    }
-                                                >
-                                                    <Check
-                                                        className={`mr-2 h-4 w-4 ${row.original.value === country.code ? "opacity-100" : "opacity-0"}`}
-                                                    />
-                                                    <span>
-                                                        {country.code === "ALL"
-                                                            ? "🌍"
-                                                            : countryCodeToFlagEmoji(
-                                                                  country.code
-                                                              )}
-                                                    </span>
-                                                    {country.name} (
-                                                    {country.code})
-                                                </CommandItem>
-                                            ))}
+                                                            updateRule(
+                                                                row.original.ruleId,
+                                                                {
+                                                                    value: newCodes.join(", ")
+                                                                }
+                                                            );
+                                                        }}
+                                                    >
+                                                        <Check
+                                                            className={`mr-2 h-4 w-4 ${isSelected ? "opacity-100" : "opacity-0"}`}
+                                                        />
+                                                        <span>
+                                                            {country.code === "ALL"
+                                                                ? "🌍"
+                                                                : countryCodeToFlagEmoji(
+                                                                      country.code
+                                                                  )}
+                                                        </span>
+                                                        {country.name} (
+                                                        {country.code})
+                                                    </CommandItem>
+                                                );
+                                            })}
                                         </CommandGroup>
                                     </CommandList>
                                 </Command>

--- a/src/components/resource-policy/policy-access-rule-validation.ts
+++ b/src/components/resource-policy/policy-access-rule-validation.ts
@@ -81,7 +81,18 @@ export function createPolicyRuleValueSchema(t: TranslateFn, match: string) {
         case "COUNTRY":
         case "COUNTRY_IS_NOT":
             return required.refine(
-                (value) => COUNTRIES.some((country) => country.code === value),
+                (value) => {
+                    const countryCodes = value
+                        .split(",")
+                        .map((code) => code.trim().toUpperCase())
+                        .filter(Boolean);
+                    if (countryCodes.length === 0) return false;
+                    return countryCodes.every(
+                        (code) =>
+                            code === "ALL" ||
+                            COUNTRIES.some((country) => country.code === code)
+                    );
+                },
                 { message: t("rulesErrorInvalidCountryDescription") }
             );
         case "ASN":


### PR DESCRIPTION
## Description

Fixes #3432

### Problem
Previously:
1. `COUNTRY` and `COUNTRY_IS_NOT` access rules only accepted a single country code (or `ALL`), preventing users from configuring multi-country rules (e.g., `US, CA`).
2. When users created multiple separate `COUNTRY_IS_NOT` rules (e.g. Rule 1: `COUNTRY_IS_NOT US` -> `DROP` and Rule 2: `COUNTRY_IS_NOT CA` -> `DROP`), sequential short-circuiting rule evaluation caused all traffic to be dropped (since an IP from `US` was not `CA` and was dropped by Rule 2, and an IP from `CA` was dropped by Rule 1).

### Fix
- **Multi-Country Support**: Updated backend validators (`server/lib/validators.ts`), frontend validators (`policy-access-rule-validation.ts`), and blueprint schemas (`server/lib/blueprints/types.ts`) to accept comma-separated country codes (e.g. `US, CA, MX`).
- **Engine Rule Grouping**: Updated `isIpInGeoIP` and `checkRules` in `server/routers/badger/verifySession.ts` to parse comma-separated country lists and group consecutive `COUNTRY_IS_NOT` rules with matching actions. This evaluates them as a unified exclusion set (`IP NOT IN {US, CA}`) rather than prematurely dropping allowed countries.
- **UI Multi-Select**: Updated `PolicyAccessRulesTable.tsx` to provide a multi-select country popover UI with flag previews and summary counts.
- **Unit Tests**: Added test coverage in `server/lib/validators.test.ts` for single and multi-country rule validation.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
1. Added unit test cases for comma-separated country codes in `server/lib/validators.test.ts`.
2. Verified unit test execution via `npx tsx server/lib/validators.test.ts`.
3. Verified frontend multi-select country UI behavior and validation.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Existing and new unit tests pass locally with my changes