### PR TITLE
Fix integration API site resource lookup

### DIFF
--- a/server/routers/siteResource/getSiteResource.test.ts
+++ b/server/routers/siteResource/getSiteResource.test.ts
@@ -1,0 +1,58 @@
+import { assertEquals } from "@test/assert";
+import { getSiteResourceParamsSchema } from "./getSiteResource";
+
+function testSiteResourceIdOnlyParams() {
+    const result = getSiteResourceParamsSchema.safeParse({
+        siteResourceId: "42"
+    });
+
+    assertEquals(
+        result.success,
+        true,
+        "siteResourceId-only integration routes should pass validation"
+    );
+
+    if (result.success) {
+        assertEquals(
+            result.data.siteResourceId,
+            42,
+            "siteResourceId should be parsed as a number"
+        );
+        assertEquals(
+            result.data.orgId,
+            undefined,
+            "orgId should remain optional"
+        );
+    }
+}
+
+function testOrgScopedParamsRemainSupported() {
+    const result = getSiteResourceParamsSchema.safeParse({
+        siteResourceId: "42",
+        orgId: "org-id"
+    });
+
+    assertEquals(
+        result.success,
+        true,
+        "org-scoped routes should continue to pass validation"
+    );
+}
+
+function testInvalidSiteResourceId() {
+    const result = getSiteResourceParamsSchema.safeParse({
+        siteResourceId: "not-a-number"
+    });
+
+    assertEquals(
+        result.success,
+        false,
+        "non-numeric siteResourceIds should fail validation"
+    );
+}
+
+testSiteResourceIdOnlyParams();
+testOrgScopedParamsRemainSupported();
+testInvalidSiteResourceId();
+
+console.log("All getSiteResource parameter validation tests passed.");

--- a/server/routers/siteResource/getSiteResource.ts
+++ b/server/routers/siteResource/getSiteResource.ts
@@ -10,7 +10,7 @@ import { fromError } from "zod-validation-error";
 import logger from "@server/logger";
 import { OpenAPITags, registry } from "@server/openApi";
 
-const getSiteResourceParamsSchema = z.strictObject({
+export const getSiteResourceParamsSchema = z.strictObject({
     siteResourceId: z
         .string()
         .optional()
@@ -18,19 +18,21 @@ const getSiteResourceParamsSchema = z.strictObject({
         .pipe(z.int().positive().optional())
         .optional(),
     niceId: z.string().optional(),
-    orgId: z.string()
+    orgId: z.string().optional()
 });
 
 async function query(siteResourceId?: number, niceId?: string, orgId?: string) {
-    if (siteResourceId && orgId) {
+    if (siteResourceId) {
         const [siteResource] = await db
             .select()
             .from(siteResources)
             .where(
-                and(
-                    eq(siteResources.siteResourceId, siteResourceId),
-                    eq(siteResources.orgId, orgId)
-                )
+                orgId
+                    ? and(
+                          eq(siteResources.siteResourceId, siteResourceId),
+                          eq(siteResources.orgId, orgId)
+                      )
+                    : eq(siteResources.siteResourceId, siteResourceId)
             )
             .limit(1);
         return siteResource;
@@ -60,9 +62,7 @@ registry.registerPath({
     tags: [OpenAPITags.PrivateResourceLegacy],
     request: {
         params: z.object({
-            siteResourceId: z.number(),
-            siteId: z.number(),
-            orgId: z.string()
+            siteResourceId: z.number()
         })
     },
     responses: {
@@ -90,9 +90,7 @@ registry.registerPath({
     tags: [OpenAPITags.PrivateResource],
     request: {
         params: z.object({
-            siteResourceId: z.number(),
-            siteId: z.number(),
-            orgId: z.string()
+            siteResourceId: z.number()
         })
     },
     responses: {


### PR DESCRIPTION
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description

Fixes #2743.

The integration API route `GET /site-resource/{siteResourceId}` only provides a resource ID, but the shared request schema required an `orgId`. As a result, valid requests failed validation before the resource lookup ran.

This makes `orgId` optional for ID-based lookups while keeping it as an additional constraint for org-scoped routes. It also updates the OpenAPI definitions so they only advertise parameters that are actually present in the route.

A regression test covers the ID-only route, the existing org-scoped form, and invalid resource IDs.

For API-key and user routes, the existing access middleware still authorizes the requested resource before this handler runs. Root API keys continue through the existing root-key check and receive the normal not-found response when the resource does not exist.

## How to test?

```bash
npx tsx server/routers/siteResource/getSiteResource.test.ts
npx eslint server/routers/siteResource/getSiteResource.ts server/routers/siteResource/getSiteResource.test.ts
npx prettier --check server/routers/siteResource/getSiteResource.ts server/routers/siteResource/getSiteResource.test.ts
npx tsc --noEmit
```

All four checks pass locally.