### PR TITLE
Fix: resolve batch certificates for NS & Wildcard domains 

### DIFF
--- a/server/private/routers/certificates/getBatchedCertificates.ts
+++ b/server/private/routers/certificates/getBatchedCertificates.ts
@@ -73,16 +73,19 @@ async function query(orgId: string, domainList: string[]) {
         .where(and(inArray(certificates.domain, domainList)));
 
     // All non resolved domain certificates might be `ns` or `wildcard`,
-    // which means exact domain certificates do not
-    const nonAvailableCertificates = existingCertificates
-        .filter((cert) => !domainList.includes(cert.domain))
-        .map((cert) => cert.domain);
+    // which means exact domain certificates do not exist
+    const foundDomains = new Set(
+        existingCertificates.map((cert) => cert.domain)
+    );
+    const domainsWithMissingCertificates = domainList.filter(
+        (domain) => !foundDomains.has(domain)
+    );
 
-    if (nonAvailableCertificates.length > 0) {
+    if (domainsWithMissingCertificates.length > 0) {
         const domainLevelDownSet = new Set<string>();
         const wildcardDomainSet = new Set<string>();
 
-        for (const domain of nonAvailableCertificates) {
+        for (const domain of domainsWithMissingCertificates) {
             const domainLevelDown = domain.split(".").slice(1).join(".");
             const wildcardPrefixed = `*.${domainLevelDown}`;
             domainLevelDownSet.add(domainLevelDown);
@@ -131,6 +134,7 @@ async function query(orgId: string, domainList: string[]) {
     for (const domain of domainList) {
         const domainLevelDown = domain.split(".").slice(1).join(".");
         const wildcardPrefixed = `*.${domainLevelDown}`;
+
         certificateMap[domain] =
             existingCertificates.find(
                 (cert) =>

--- a/server/private/routers/certificates/getBatchedCertificates.ts
+++ b/server/private/routers/certificates/getBatchedCertificates.ts
@@ -46,7 +46,7 @@ const getCertificateQuerySchema = z.object({
 
 async function query(orgId: string, domainList: string[]) {
     // Try to get CNAME certificates first
-    let existingCertificates = await db
+    const existingCertificates = await db
         .select({
             certId: certificates.certId,
             domain: certificates.domain,

--- a/src/hooks/useCertificate.ts
+++ b/src/hooks/useCertificate.ts
@@ -111,7 +111,8 @@ export function useCertificate({
     let certError: string | null = null;
     if (restartCert.isError) {
         certError = "Failed to restart";
-    } else if (isError) {
+    } else if (isError || initialCertValue === null) {
+        // Null value means failed to get the certificate
         certError = "Failed";
     }
 

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -1,4 +1,10 @@
+import type { LauncherQueryFilters } from "@app/lib/launcherSearchParams";
+import { buildLauncherSearchParams } from "@app/lib/launcherSearchParams";
 import { build } from "@server/build";
+import {
+    StatusHistoryResponse,
+    type BatchedStatusHistoryResponse
+} from "@server/lib/statusHistory";
 import type { ListAlertRulesResponse } from "@server/routers/alertRule/types";
 import type { QueryRequestAnalyticsResponse } from "@server/routers/auditLogs";
 import type {
@@ -7,6 +13,7 @@ import type {
     QueryConnectionAuditLogResponse,
     QueryRequestAuditLogResponse
 } from "@server/routers/auditLogs/types";
+import type { GetCertificateResponse } from "@server/routers/certificates/types";
 import type {
     ListClientsResponse,
     ListUserDevicesResponse
@@ -16,15 +23,30 @@ import type {
     ListDomainsResponse
 } from "@server/routers/domain";
 import type { GetDomainResponse } from "@server/routers/domain/getDomain";
+import { ListHealthChecksResponse } from "@server/routers/healthChecks/types";
+import type { ListOrgLabelsResponse } from "@server/routers/labels/types";
 import type {
-    GetResourceWhitelistResponse,
+    LauncherResource,
+    ListLauncherGroupsResponse,
+    ListLauncherLabelsResponse,
+    ListLauncherResourcesResponse,
+    ListLauncherScaleResponse,
+    ListLauncherSitesResponse,
+    ListLauncherViewsResponse
+} from "@server/routers/launcher/types";
+import type { GetResourcePolicyResponse } from "@server/routers/policy";
+import type {
     GetResourcePoliciesResponse,
+    GetResourceWhitelistResponse,
     ListResourceNamesResponse,
-    ListResourcesResponse,
     ListResourceRolesResponse,
     ListResourceRulesResponse,
+    ListResourcesResponse,
     ListResourceUsersResponse
 } from "@server/routers/resource";
+import type { GetResourceResponse } from "@server/routers/resource/getResource";
+import type { GetResourceAuthInfoResponse } from "@server/routers/resource/getResourceAuthInfo";
+import type { ListResourcePoliciesResponse } from "@server/routers/resource/types";
 import type { ListRolesResponse } from "@server/routers/role";
 import type { ListSitesResponse } from "@server/routers/site";
 import type {
@@ -33,6 +55,7 @@ import type {
     ListSiteResourceRolesResponse,
     ListSiteResourceUsersResponse
 } from "@server/routers/siteResource";
+import type { GetSiteResourceResponse } from "@server/routers/siteResource/getSiteResource";
 import type { ListTargetsResponse } from "@server/routers/target";
 import type { ListUsersResponse } from "@server/routers/user";
 import type ResponseT from "@server/types/Response";
@@ -42,37 +65,12 @@ import {
     queryOptions
 } from "@tanstack/react-query";
 import { isAxiosError, type AxiosResponse } from "axios";
-import z, { meta } from "zod";
+import z from "zod";
 import { remote } from "./api";
 import { durationToMs } from "./durationToMs";
-import type { ListOrgLabelsResponse } from "@server/routers/labels/types";
-import { ListHealthChecksResponse } from "@server/routers/healthChecks/types";
-import {
-    StatusHistoryResponse,
-    type BatchedStatusHistoryResponse
-} from "@server/lib/statusHistory";
-import type { ListResourcePoliciesResponse } from "@server/routers/resource/types";
-import type { GetResourcePolicyResponse } from "@server/routers/policy";
-import type {
-    ListLauncherGroupsResponse,
-    ListLauncherLabelsResponse,
-    ListLauncherResourcesResponse,
-    ListLauncherScaleResponse,
-    ListLauncherSitesResponse,
-    ListLauncherViewsResponse,
-    LauncherListQuery,
-    LauncherResource,
-    LauncherViewConfig
-} from "@server/routers/launcher/types";
-import type { GetResourceResponse } from "@server/routers/resource/getResource";
-import type { GetResourceAuthInfoResponse } from "@server/routers/resource/getResourceAuthInfo";
-import type { GetSiteResourceResponse } from "@server/routers/siteResource/getSiteResource";
-import type { LauncherQueryFilters } from "@app/lib/launcherSearchParams";
-import { buildLauncherSearchParams } from "@app/lib/launcherSearchParams";
-import type { GetCertificateResponse } from "@server/routers/certificates/types";
 
-export type { LauncherQueryFilters } from "@app/lib/launcherSearchParams";
 export { buildLauncherSearchParams } from "@app/lib/launcherSearchParams";
+export type { LauncherQueryFilters } from "@app/lib/launcherSearchParams";
 
 export type ProductUpdate = {
     link: string | null;


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Summary 

- Introduced in #3469 : 
   My logic to get certificates for NS & wildcard certificates was flawed, I first get the certificates for exact domains, then I check if there are domains with missing certificates (wildcard & NS certificates are not matched on the exact name), then look if there are matching wildcard certificates  or NS certificates for the domains left. The flaw was that, with my logic, the domains with missing certs would always be empty. 


## How to test?

Go to resources > public, all certificates should appear at once.

