### PR TITLE
Fix: log access depends on the wrong org log retention settings field

### DIFF
--- a/server/private/lib/logAccessAudit.ts
+++ b/server/private/lib/logAccessAudit.ts
@@ -28,7 +28,7 @@ async function getAccessDays(orgId: string): Promise<number> {
 
     const [org] = await db
         .select({
-            settingsLogRetentionDaysAction: orgs.settingsLogRetentionDaysAction
+            settingsLogRetentionDaysAccess: orgs.settingsLogRetentionDaysAccess
         })
         .from(orgs)
         .where(eq(orgs.orgId, orgId))
@@ -41,11 +41,11 @@ async function getAccessDays(orgId: string): Promise<number> {
     // store the result in cache
     await cache.set(
         `org_${orgId}_accessDays`,
-        org.settingsLogRetentionDaysAction,
+        org.settingsLogRetentionDaysAccess,
         300
     );
 
-    return org.settingsLogRetentionDaysAction;
+    return org.settingsLogRetentionDaysAccess;
 }
 
 export async function cleanUpOldLogs(orgId: string, retentionDays: number) {


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Summary

When logging attempts at accessing a resource, the logger function checks for a retention days settings, however it checked for `Admin action log retention days` instead of `Authentication log retention`.

## Screenshot

We can now see Resource Access logs:

<img width="2960" height="2122" alt="image" src="https://github.com/user-attachments/assets/241f2984-5603-40e2-910e-4327342eb909" />




