### PR TITLE
docs: add Sealos deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Pangolin is an open-source, identity-based remote access platform built on WireG
 - Get started for free with [Pangolin Cloud](https://app.pangolin.net/).
 - Or, check out the [quick install guide](https://docs.pangolin.net/self-host/quick-install) for how to self-host Pangolin.
   - Install from the [DigitalOcean marketplace](https://marketplace.digitalocean.com/apps/pangolin-ce-1?refcode=edf0480eeb81) for a one-click pre-configured installer.
+  - Deploy the [Pangolin control plane on Sealos](https://sealos.io/products/app-store/pangolin) with a one-click template; connect an external Gerbil node for tunnel traffic.
 
 <img src="public/screenshots/hero.png" alt="Pangolin" width="100%" />
 


### PR DESCRIPTION
## Community Contribution License Agreement

By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description

This PR adds a Sealos deployment option next to the existing self-hosting links in the README.

The wording identifies this as a Pangolin control-plane deployment and tells users to connect an external Gerbil node for tunnel traffic. The change is limited to one documentation line and leaves the default installation flow unchanged.

## How to test?

- Sealos template: https://sealos.io/products/app-store/pangolin
- Pangolin image: `docker.io/fosrl/pangolin:1.15.2`
- Tested deployment: 2026-08-05
- Browser smoke covered initial setup, sign-in, and representative navigation.
- Runtime configuration uses persistent storage, and the server secret is generated during deployment.
- Runtime log scans ended with zero active failures, and all verification resources were cleaned up.
- The deployment link returns HTTP 200.

## Maintenance

I can help maintain this deployment path and follow up if the Sealos template or README entry needs updates.
