### PR TITLE
fix: allow public resource authentication settings when using shared policy (#3539)

### DIFF
--- a/server/db/queries/verifySessionQueries.ts
+++ b/server/db/queries/verifySessionQueries.ts
@@ -209,22 +209,28 @@ export async function getResourceByDomain(
     const hasSharedPolicy = result.sharedPolicy !== null;
 
     const effectivePolicyPincode = hasSharedPolicy
-        ? result.sharedPolicyPincode
+        ? (result.sharedPolicyPincode ?? result.defaultPolicyPincode ?? null)
         : (result.defaultPolicyPincode ?? null);
     const effectivePolicyPassword = hasSharedPolicy
-        ? result.sharedPolicyPassword
+        ? (result.sharedPolicyPassword ?? result.defaultPolicyPassword ?? null)
         : (result.defaultPolicyPassword ?? null);
     const effectivePolicyHeaderAuth = hasSharedPolicy
-        ? result.sharedPolicyHeaderAuth
+        ? (result.sharedPolicyHeaderAuth ?? result.defaultPolicyHeaderAuth ?? null)
         : (result.defaultPolicyHeaderAuth ?? null);
     const selectedPolicy = hasSharedPolicy
         ? result.sharedPolicy
         : result.defaultPolicy;
     const effectiveApplyRules =
         selectedPolicy?.applyRules ?? result.resources.applyRules;
-    const effectiveSSO = selectedPolicy?.sso ?? result.resources.sso;
+    const effectiveSSO =
+        (hasSharedPolicy
+            ? result.sharedPolicy?.sso || result.defaultPolicy?.sso
+            : result.defaultPolicy?.sso) ?? result.resources.sso;
     const effectiveEmailWhitelistEnabled =
-        selectedPolicy?.emailWhitelistEnabled ??
+        (hasSharedPolicy
+            ? result.sharedPolicy?.emailWhitelistEnabled ||
+              result.defaultPolicy?.emailWhitelistEnabled
+            : result.defaultPolicy?.emailWhitelistEnabled) ??
         result.resources.emailWhitelistEnabled;
 
     return {

--- a/server/private/routers/hybrid.ts
+++ b/server/private/routers/hybrid.ts
@@ -754,22 +754,34 @@ hybridRouter.get(
             const hasSharedPolicy = result.sharedPolicy !== null;
 
             const effectivePolicyPincode = hasSharedPolicy
-                ? result.sharedPolicyPincode
+                ? (result.sharedPolicyPincode ??
+                  result.defaultPolicyPincode ??
+                  null)
                 : (result.defaultPolicyPincode ?? null);
             const effectivePolicyPassword = hasSharedPolicy
-                ? result.sharedPolicyPassword
+                ? (result.sharedPolicyPassword ??
+                  result.defaultPolicyPassword ??
+                  null)
                 : (result.defaultPolicyPassword ?? null);
             const effectivePolicyHeaderAuth = hasSharedPolicy
-                ? result.sharedPolicyHeaderAuth
+                ? (result.sharedPolicyHeaderAuth ??
+                  result.defaultPolicyHeaderAuth ??
+                  null)
                 : (result.defaultPolicyHeaderAuth ?? null);
             const selectedPolicy = hasSharedPolicy
                 ? result.sharedPolicy
                 : result.defaultPolicy;
             const effectiveApplyRules =
                 selectedPolicy?.applyRules ?? result.resources.applyRules;
-            const effectiveSSO = selectedPolicy?.sso ?? result.resources.sso;
+            const effectiveSSO =
+                (hasSharedPolicy
+                    ? result.sharedPolicy?.sso || result.defaultPolicy?.sso
+                    : result.defaultPolicy?.sso) ?? result.resources.sso;
             const effectiveEmailWhitelistEnabled =
-                selectedPolicy?.emailWhitelistEnabled ??
+                (hasSharedPolicy
+                    ? result.sharedPolicy?.emailWhitelistEnabled ||
+                      result.defaultPolicy?.emailWhitelistEnabled
+                    : result.defaultPolicy?.emailWhitelistEnabled) ??
                 result.resources.emailWhitelistEnabled;
 
             const resourceWithAuth: ResourceWithAuth = {

--- a/src/components/resource-policy/PolicyAuthStackSectionEdit.tsx
+++ b/src/components/resource-policy/PolicyAuthStackSectionEdit.tsx
@@ -109,7 +109,7 @@ export function PolicyAuthStackSectionEdit({
     const api = createApiClient(useEnvContext());
 
     const isResourceOverlay = resourceId !== undefined;
-    const authReadonly = readonly || isResourceOverlay;
+    const authReadonly = Boolean(readonly);
 
     const policyRoleItems = useMemo<OverlaySelectedRole[]>(
         () =>
@@ -268,12 +268,7 @@ export function PolicyAuthStackSectionEdit({
     const [isSavingOverlay, setIsSavingOverlay] = useState(false);
 
     async function onSubmit() {
-        if (readonly && !isResourceOverlay) return;
-
-        if (isResourceOverlay) {
-            await saveResourceOverlay();
-            return;
-        }
+        if (readonly) return;
 
         const isValid = await form.trigger();
         if (!isValid) {
@@ -288,6 +283,10 @@ export function PolicyAuthStackSectionEdit({
         const payload = form.getValues();
         const requests: Array<Promise<AxiosResponse<{}> | void>> = [];
         const policyUpdates: Parameters<typeof updatePolicy>[0] = {};
+
+        if (isResourceOverlay) {
+            requests.push(saveResourceOverlay());
+        }
 
         requests.push(
             api

--- a/src/components/resource-policy/ResourcePolicyEditForm.tsx
+++ b/src/components/resource-policy/ResourcePolicyEditForm.tsx
@@ -35,8 +35,8 @@ export function ResourcePolicyEditForm({
 
     return (
         <ResourcePolicyProvider
-            policy={policies.sharedPolicy}
-            key={policies.sharedPolicy.resourcePolicyId}
+            policy={policies.defaultPolicy}
+            key={policies.defaultPolicy.resourcePolicyId}
         >
             <EditPolicyForm
                 resourceId={resource.resourceId}


### PR DESCRIPTION
Fixes #3539 where attaching a shared policy (e.g., GeoBlocking access rules) deactivated public resource authentication settings and prevented configuring authentication at the resource level.

### Changes
- Updated backend policy resolution in \erifySessionQueries.ts\ and \hybrid.ts\ to fall back to the resource's inline default policy authentication settings when the attached shared policy does not define authentication settings.
- Updated frontend \ResourcePolicyEditForm.tsx\ and \PolicyAuthStackSectionEdit.tsx\ so authentication form inputs remain editable on the resource page and save both inline authentication options and overlay user/role assignments.