### PR TITLE
fix: include client_id in token exchange POST body for OIDC providers (#3536)

### DIFF
--- a/server/lib/idp/oauth2Client.ts
+++ b/server/lib/idp/oauth2Client.ts
@@ -1,0 +1,114 @@
+import * as arctic from "arctic";
+
+export class PangolinOAuth2Client extends arctic.OAuth2Client {
+    private _clientPassword: string | null;
+    private _redirectURI: string | null;
+
+    constructor(
+        clientId: string,
+        clientPassword: string | null,
+        redirectURI: string | null
+    ) {
+        super(clientId, clientPassword, redirectURI);
+        this._clientPassword = clientPassword;
+        this._redirectURI = redirectURI;
+    }
+
+    override async validateAuthorizationCode(
+        tokenEndpoint: string,
+        code: string,
+        codeVerifier: string | null
+    ): Promise<arctic.OAuth2Tokens> {
+        if (this._clientPassword === null) {
+            return super.validateAuthorizationCode(
+                tokenEndpoint,
+                code,
+                codeVerifier
+            );
+        }
+
+        const body = new URLSearchParams();
+        body.set("grant_type", "authorization_code");
+        body.set("code", code);
+        if (this._redirectURI !== null) {
+            body.set("redirect_uri", this._redirectURI);
+        }
+        if (codeVerifier !== null) {
+            body.set("code_verifier", codeVerifier);
+        }
+        body.set("client_id", this.clientId);
+
+        const request = new Request(tokenEndpoint, {
+            method: "POST",
+            body: new TextEncoder().encode(body.toString())
+        });
+        request.headers.set(
+            "Content-Type",
+            "application/x-www-form-urlencoded"
+        );
+        request.headers.set("Accept", "application/json");
+        request.headers.set("User-Agent", "arctic");
+
+        const bytes = new TextEncoder().encode(
+            `${this.clientId}:${this._clientPassword}`
+        );
+        const base64 = Buffer.from(bytes).toString("base64");
+        request.headers.set("Authorization", `Basic ${base64}`);
+
+        const response = await fetch(request);
+        if (response.status === 400 || response.status === 401) {
+            let data: unknown;
+            try {
+                data = await response.json();
+            } catch {
+                throw new arctic.UnexpectedResponseError(response.status);
+            }
+            if (typeof data !== "object" || data === null) {
+                throw new arctic.UnexpectedErrorResponseBodyError(
+                    response.status,
+                    data
+                );
+            }
+            if ("error" in data && typeof data.error === "string") {
+                throw new arctic.OAuth2RequestError(
+                    data.error,
+                    "error_description" in data &&
+                    typeof data.error_description === "string"
+                        ? data.error_description
+                        : null,
+                    "error_uri" in data && typeof data.error_uri === "string"
+                        ? data.error_uri
+                        : null,
+                    "state" in data && typeof data.state === "string"
+                        ? data.state
+                        : null
+                );
+            }
+            throw new arctic.UnexpectedErrorResponseBodyError(
+                response.status,
+                data
+            );
+        }
+
+        if (response.status === 200) {
+            let data: unknown;
+            try {
+                data = await response.json();
+            } catch {
+                throw new arctic.UnexpectedResponseError(response.status);
+            }
+            if (typeof data !== "object" || data === null) {
+                throw new arctic.UnexpectedErrorResponseBodyError(
+                    response.status,
+                    data
+                );
+            }
+            return new arctic.OAuth2Tokens(data as Record<string, unknown>);
+        }
+
+        if (response.body !== null) {
+            await response.body.cancel();
+        }
+        throw new arctic.UnexpectedResponseError(response.status);
+    }
+}

--- a/server/routers/idp/generateOidcUrl.ts
+++ b/server/routers/idp/generateOidcUrl.ts
@@ -17,6 +17,8 @@ import { build } from "@server/build";
 import { isSubscribed } from "#dynamic/lib/isSubscribed";
 import { tierMatrix } from "@server/lib/billing/tierMatrix";
 
+import { PangolinOAuth2Client } from "@server/lib/idp/oauth2Client";
+
 const paramsSchema = z
     .object({
         idpId: z.coerce.number<number>()
@@ -154,7 +156,7 @@ export async function generateOidcUrl(
             decryptedClientSecret,
             redirectUrl
         });
-        const client = new arctic.OAuth2Client(
+        const client = new PangolinOAuth2Client(
             decryptedClientId,
             decryptedClientSecret,
             redirectUrl

--- a/server/routers/idp/validateOidcCallback.ts
+++ b/server/routers/idp/validateOidcCallback.ts
@@ -40,6 +40,7 @@ import { isLicensedOrSubscribed } from "#dynamic/lib/isLicencedOrSubscribed";
 import { tierMatrix } from "@server/lib/billing/tierMatrix";
 import { assignUserToOrg, removeUserFromOrg } from "@server/lib/userOrg";
 import { unwrapRoleMapping } from "@app/lib/idpRoleMapping";
+import { PangolinOAuth2Client } from "@server/lib/idp/oauth2Client";
 
 const ensureTrailingSlash = (url: string): string => {
     return url;
@@ -138,7 +139,7 @@ export async function validateOidcCallback(
             undefined,
             loginPageId
         );
-        const client = new arctic.OAuth2Client(
+        const client = new PangolinOAuth2Client(
             decryptedClientId,
             decryptedClientSecret,
             redirectUrl


### PR DESCRIPTION
Fixes #3536 where OIDC token exchange (\POST /application/o/token/\) fails with Authentik and strict OIDC providers because \client_id\ is omitted from the request body when HTTP Basic client authentication is used.

### Changes
- Created \PangolinOAuth2Client\ extending \rctic.OAuth2Client\ to ensure \client_id\ is included in the \pplication/x-www-form-urlencoded\ POST body during token exchange while preserving \Authorization: Basic\ header authentication for confidential clients (RFC 6749 Section 3.2.1 / OpenID Connect Core 1.0 Section 3.1.3.1).
- Updated \generateOidcUrl.ts\ and \alidateOidcCallback.ts\ to use \PangolinOAuth2Client\.