### PR TITLE
fix: append organization CIDR prefix to auto-allocated site address (#3523)

### DIFF
--- a/server/routers/site/createSite.ts
+++ b/server/routers/site/createSite.ts
@@ -263,7 +263,10 @@ export async function createSite(
             const { value: newClientAddress, release } =
                 await getNextAvailableClientSubnet(orgId);
             releaseSubnetLock = release;
-            updatedAddress = newClientAddress.split("/")[0];
+            const ipOnly = newClientAddress.split("/")[0];
+            updatedAddress = org.subnet
+                ? `${ipOnly}/${org.subnet.split("/")[1]}`
+                : ipOnly;
         }
 
         let newSite: Site | undefined;


### PR DESCRIPTION
Fixes #3523 where creating a Newt site via the Integration API (\PUT /v1/org/{orgId}/site\) stored the site address without the organization's CIDR subnet prefix (e.g., \100.90.128.2\ instead of \100.90.128.2/20\), causing Newt interface setup to fail during connectivity configuration.

### Changes
- Updated \createSite.ts\ to format auto-allocated IP addresses with the organization's CIDR subnet mask (\/\\).