### PR TITLE
feat: add per-site-resource opt-out for client route advertising (#3548)

### DIFF
--- a/server/db/pg/schema/schema.ts
+++ b/server/db/pg/schema/schema.ts
@@ -444,6 +444,9 @@ export const siteResources = pgTable(
             .notNull()
             .default("*"),
         disableIcmp: boolean("disableIcmp").notNull().default(false),
+        advertiseDestination: boolean("advertiseDestination")
+            .notNull()
+            .default(true),
         authDaemonPort: integer("authDaemonPort").default(22123),
         pamMode: varchar("pamMode", { length: 32 })
             .$type<"passthrough" | "push">()

--- a/server/db/sqlite/schema/schema.ts
+++ b/server/db/sqlite/schema/schema.ts
@@ -438,6 +438,9 @@ export const siteResources = sqliteTable("siteResources", {
     disableIcmp: integer("disableIcmp", { mode: "boolean" })
         .notNull()
         .default(false),
+    advertiseDestination: integer("advertiseDestination", { mode: "boolean" })
+        .notNull()
+        .default(true),
     authDaemonPort: integer("authDaemonPort").default(22123),
     pamMode: text("pamMode")
         .$type<"passthrough" | "push">()

--- a/server/lib/ip.ts
+++ b/server/lib/ip.ts
@@ -499,6 +499,7 @@ export function generateRemoteSubnets(
         .filter((sr) => {
             if (!sr.enabled) return false;
             if (!sr.destination) return false;
+            if (sr.advertiseDestination === false) return false;
 
             if (sr.mode === "cidr") {
                 // check if its a valid CIDR using zod

--- a/server/routers/siteResource/createSiteResource.ts
+++ b/server/routers/siteResource/createSiteResource.ts
@@ -74,6 +74,7 @@ const createSiteResourceSchema = z
         tcpPortRangeString: portRangeStringSchema,
         udpPortRangeString: portRangeStringSchema,
         disableIcmp: z.boolean().optional(),
+        advertiseDestination: z.boolean().optional(),
         authDaemonPort: z.int().positive().optional(),
         authDaemonMode: z.enum(["site", "remote", "native"]).optional(),
         pamMode: z.enum(["passthrough", "push"]).optional(),
@@ -315,6 +316,7 @@ export async function createSiteResource(
             tcpPortRangeString,
             udpPortRangeString,
             disableIcmp,
+            advertiseDestination,
             authDaemonPort,
             authDaemonMode,
             pamMode,
@@ -580,6 +582,9 @@ export async function createSiteResource(
                     disableIcmp:
                         disableIcmp ||
                         (mode == "http" || mode == "ssh" ? true : false), // default to true for http resources, otherwise false
+                    ...(advertiseDestination !== undefined && {
+                        advertiseDestination
+                    }),
                     domainId,
                     subdomain: finalSubdomain,
                     fullDomain

--- a/server/routers/siteResource/updateSiteResource.ts
+++ b/server/routers/siteResource/updateSiteResource.ts
@@ -74,6 +74,7 @@ const updateSiteResourceSchema = z
         tcpPortRangeString: portRangeStringSchema,
         udpPortRangeString: portRangeStringSchema,
         disableIcmp: z.boolean().optional(),
+        advertiseDestination: z.boolean().optional(),
         authDaemonPort: z.int().positive().nullish(),
         authDaemonMode: z.enum(["site", "remote", "native"]).optional(),
         pamMode: z.enum(["passthrough", "push"]).optional(),
@@ -322,6 +323,7 @@ export async function updateSiteResource(
             tcpPortRangeString,
             udpPortRangeString,
             disableIcmp,
+            advertiseDestination,
             authDaemonPort,
             authDaemonMode,
             pamMode,
@@ -583,6 +585,9 @@ export async function updateSiteResource(
                                   ? true
                                   : false)
                             : disableIcmp,
+                    ...(advertiseDestination !== undefined && {
+                        advertiseDestination
+                    }),
                     domainId,
                     subdomain: finalSubdomain,
                     fullDomain,


### PR DESCRIPTION
Fixes #3548 by adding a per-site-resource setting (\dvertiseDestination\, default \	rue\) that allows resources to opt out of advertising their destination as a \/32\ client route in \emoteSubnets\.

### Changes
- Added \dvertiseDestination\ boolean column (default \	rue\) to \siteResources\ table schema in both SQLite and PostgreSQL schemas.
- Updated \generateRemoteSubnets()\ in \server/lib/ip.ts\ to exclude resources where \dvertiseDestination === false\.
- Updated site resource creation (\createSiteResource.ts\) and update (\updateSiteResource.ts\) API schemas and endpoints to accept optional \dvertiseDestination\.