### PR TITLE
fix: add Traefik routing rules for Integration API (/v1) endpoints (#3334)

### DIFF
--- a/config/traefik/dynamic_config.yml
+++ b/config/traefik/dynamic_config.yml
@@ -21,7 +21,7 @@ http:
 
     # Next.js router (handles everything except API and WebSocket paths)
     next-router:
-      rule: "Host(`{{.DashboardDomain}}`) && !PathPrefix(`/api/v1`)"
+      rule: "Host(`{{.DashboardDomain}}`) && !PathPrefix(`/api/v1`) && !PathPrefix(`/v1`)"
       service: next-service
       entryPoints:
         - websecure
@@ -41,6 +41,17 @@ http:
       tls:
         certResolver: letsencrypt
 
+    # Integration API router (handles /v1 paths)
+    integration-api-router:
+      rule: "Host(`{{.DashboardDomain}}`) && PathPrefix(`/v1`)"
+      service: integration-api-service
+      entryPoints:
+        - websecure
+      middlewares:
+        - badger
+      tls:
+        certResolver: letsencrypt
+
   services:
     next-service:
       loadBalancer:
@@ -51,6 +62,11 @@ http:
       loadBalancer:
         servers:
           - url: "http://pangolin:3000"  # API/WebSocket server
+
+    integration-api-service:
+      loadBalancer:
+        servers:
+          - url: "http://pangolin:3003"  # Integration API server
 
 tcp:
   serversTransports:

--- a/install/config/traefik/dynamic_config.yml
+++ b/install/config/traefik/dynamic_config.yml
@@ -21,7 +21,7 @@ http:
 
     # Next.js router (handles everything except API and WebSocket paths)
     next-router:
-      rule: "Host(`{{.DashboardDomain}}`) && !PathPrefix(`/api/v1`)"
+      rule: "Host(`{{.DashboardDomain}}`) && !PathPrefix(`/api/v1`) && !PathPrefix(`/v1`)"
       service: next-service
       entryPoints:
         - websecure
@@ -34,6 +34,17 @@ http:
     api-router:
       rule: "Host(`{{.DashboardDomain}}`) && PathPrefix(`/api/v1`)"
       service: api-service
+      entryPoints:
+        - websecure
+      middlewares:
+        - badger
+      tls:
+        certResolver: letsencrypt
+
+    # Integration API router (handles /v1 paths)
+    integration-api-router:
+      rule: "Host(`{{.DashboardDomain}}`) && PathPrefix(`/v1`)"
+      service: integration-api-service
       entryPoints:
         - websecure
       middlewares:
@@ -62,6 +73,11 @@ http:
       loadBalancer:
         servers:
           - url: "http://pangolin:3000"  # API/WebSocket server
+
+    integration-api-service:
+      loadBalancer:
+        servers:
+          - url: "http://pangolin:3003"  # Integration API server
 
 tcp:
   serversTransports:

--- a/server/private/lib/traefik/getTraefikConfig.ts
+++ b/server/private/lib/traefik/getTraefikConfig.ts
@@ -1599,5 +1599,38 @@ export async function getTraefikConfig(
         }
     }
 
+    if (config.getRawConfig().flags?.enable_integration_api) {
+        const intPort = config.getRawConfig().server.integration_port;
+        const intHost = config.getRawConfig().server.internal_hostname;
+
+        if (!config_output.http.services) {
+            config_output.http.services = {};
+        }
+        if (!config_output.http.routers) {
+            config_output.http.routers = {};
+        }
+
+        config_output.http.services["integration-api-service"] = {
+            loadBalancer: {
+                servers: [
+                    {
+                        url: `http://${intHost}:${intPort}`
+                    }
+                ]
+            }
+        };
+
+        config_output.http.routers["integration-api-router"] = {
+            entryPoints: [
+                config.getRawConfig().traefik.https_entrypoint,
+                config.getRawConfig().traefik.http_entrypoint
+            ],
+            middlewares: ["badger"],
+            service: "integration-api-service",
+            rule: `PathPrefix(\`/v1\`)`,
+            priority: 150
+        };
+    }
+
     return config_output;
 }


### PR DESCRIPTION
Fixes #3334 where enabling the Integration API (\enable_integration_api: true\) caused all \/v1/*\ endpoints (e.g. \/v1/docs\, \/v1/openapi.json\, \/v1/org/...\) to return 404 Not Found errors.

### Root Cause
1. Traefik lacked dynamic router and service definitions for the Integration API server (port 3003).
2. Traefik's \
ext-router\ rule only excluded \!PathPrefix('/api/v1')\, causing all \/v1/*\ requests to be routed to Next.js (\:3002\), which returned a 404.

### Changes
- Updated \getTraefikConfig.ts\ to dynamically inject \integration-api-service\ (\http://\:\\) and \integration-api-router\ (\PathPrefix('/v1')\) when \enable_integration_api\ flag is enabled.
- Updated default Traefik template configurations (\config/traefik/dynamic_config.yml\ & \install/config/traefik/dynamic_config.yml\) to exclude \!PathPrefix('/v1')\ from \
ext-router\ and include \integration-api-router\ and \integration-api-service\ for port 3003.