### PR TITLE
feat: add passphrase support for encrypted SSH private keys (#3271)

### DIFF
--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -3794,6 +3794,8 @@
     "sshConnectionClosedCode": "Connection closed (code {code})",
     "sshPrivateKeyPlaceholder": "-----BEGIN OPENSSH PRIVATE KEY-----",
     "sshPrivateKeyRequired": "Private key is required",
+    "sshPassphraseOptional": "Key Passphrase (optional)",
+    "sshPassphrasePlaceholder": "Passphrase for encrypted private key",
     "vncTitle": "VNC",
     "vncSignInDescription": "Enter your VNC credentials to connect",
     "vncUsernameOptional": "Username (optional)",

--- a/src/app/ssh/SshClient.tsx
+++ b/src/app/ssh/SshClient.tsx
@@ -45,19 +45,22 @@ type SshCredentialsForm = {
     username: string;
     password: string;
     privateKey: string;
+    passphrase: string;
 };
 
 type ConnectCredentials = {
     username: string;
     password?: string;
     privateKey?: string;
+    passphrase?: string;
     certificate?: string;
 };
 
 const DEFAULT_SSH_CREDENTIALS: SshCredentialsForm = {
     username: "",
     password: "",
-    privateKey: ""
+    privateKey: "",
+    passphrase: ""
 };
 
 export default function SshClient({
@@ -245,6 +248,9 @@ export default function SshClient({
         const privateKey =
             override?.privateKey ??
             (authMethod === "privateKey" ? values.privateKey : "");
+        const passphrase =
+            override?.passphrase ??
+            (authMethod === "privateKey" ? values.passphrase : "");
         const certificate = override?.certificate;
 
         const proxyAddress = `${window.location.protocol === "https:" ? "wss" : "ws"}://${window.location.host}/gateway/ssh`;
@@ -283,7 +289,8 @@ export default function SshClient({
             ws.send(
                 JSON.stringify({
                     type: "auth",
-                    password,
+                    password: password || passphrase,
+                    passphrase,
                     privateKey,
                     certificate
                 })
@@ -657,6 +664,29 @@ export default function SshClient({
                                                             )}
                                                             rows={5}
                                                             className="font-mono text-xs"
+                                                        />
+                                                    </FormControl>
+                                                    <FormMessage />
+                                                </FormItem>
+                                            )}
+                                        />
+                                        <FormField
+                                            control={form.control}
+                                            name="passphrase"
+                                            render={({ field }) => (
+                                                <FormItem>
+                                                    <FormLabel>
+                                                        {t(
+                                                            "sshPassphraseOptional"
+                                                        )}
+                                                    </FormLabel>
+                                                    <FormControl>
+                                                        <Input
+                                                            type="password"
+                                                            {...field}
+                                                            placeholder={t(
+                                                                "sshPassphrasePlaceholder"
+                                                            )}
                                                         />
                                                     </FormControl>
                                                     <FormMessage />


### PR DESCRIPTION
Fixes #3271 by adding passphrase support for encrypted SSH private keys in the browser SSH client.

### Root Cause
Previously, the SSH client form (\SshClient.tsx\) lacked a passphrase input field in the Private Key tab, and the WebSocket authentication payload omitted the \passphrase\ property. As a result, authentication with passphrase-protected SSH private keys failed (\ssh: this private key is passphrase protected\).

### Changes
- Added an optional **Key Passphrase** field (\sshPassphraseOptional\) to the Private Key authentication tab in \SshClient.tsx\.
- Updated the WebSocket \uth\ message payload to send \passphrase\ (and fallback \password\ to \passphrase\ when no separate password is set).
- Added translation keys to \messages/en-US.json\.