### PR TITLE
fix: coerce null email and name properties to empty strings in user retrieval endpoints (#3238)

### DIFF
--- a/server/routers/user/adminGetUser.ts
+++ b/server/routers/user/adminGetUser.ts
@@ -59,7 +59,14 @@ async function queryUser(userId: string) {
         .leftJoin(idp, eq(users.idpId, idp.idpId))
         .where(eq(users.userId, userId))
         .limit(1);
-    return user;
+
+    if (!user) return undefined;
+
+    return {
+        ...user,
+        email: user.email ?? "",
+        name: user.name ?? ""
+    };
 }
 
 export type AdminGetUserResponse = NonNullable<

--- a/server/routers/user/getOrgUser.ts
+++ b/server/routers/user/getOrgUser.ts
@@ -54,6 +54,8 @@ export async function queryUser(orgId: string, userId: string) {
 
     return {
         ...userRow,
+        email: userRow.email ?? "",
+        name: userRow.name ?? "",
         isAdmin,
         roleIds: roleRows.map((r) => r.roleId),
         roles: roleRows.map((r) => ({

--- a/server/routers/user/getUser.ts
+++ b/server/routers/user/getUser.ts
@@ -28,7 +28,14 @@ async function queryUser(userId: string) {
         .leftJoin(idp, eq(users.idpId, idp.idpId))
         .where(eq(users.userId, userId))
         .limit(1);
-    return user;
+
+    if (!user) return undefined;
+
+    return {
+        ...user,
+        email: user.email ?? "",
+        name: user.name ?? ""
+    };
 }
 
 export type GetUserResponse = NonNullable<

--- a/server/routers/user/myDevice.ts
+++ b/server/routers/user/myDevice.ts
@@ -111,9 +111,15 @@ export async function myDevice(
             roleId: roleByOrg.get(row.orgId) ?? 0
         }));
 
+        const formattedUser = {
+            ...user,
+            email: user.email ?? "",
+            name: user.name ?? ""
+        };
+
         return response<MyDeviceResponse>(res, {
             data: {
-                user,
+                user: formattedUser,
                 orgs: userOrganizations,
                 olm
             },


### PR DESCRIPTION
Fixes #3238 where mobile clients using strict JSON parsing fail with unexpected JSON token when polling user endpoints for accounts with null email. Changes: Normalized email and name to empty string when null in getUser, getOrgUser, adminGetUser, and myDevice.