### PR TITLE
fix: return explicit HTTPS verification url in startDeviceWebAuth to prevent Android cleartext policy errors (#3430)

### DIFF
--- a/server/routers/auth/startDeviceWebAuth.ts
+++ b/server/routers/auth/startDeviceWebAuth.ts
@@ -26,6 +26,7 @@ export type StartDeviceWebAuthBody = z.infer<typeof bodySchema>;
 export type StartDeviceWebAuthResponse = {
     code: string;
     expiresInSeconds: number;
+    url: string;
 };
 
 // Helper function to generate device code in format A1AJ-N5JD
@@ -111,10 +112,18 @@ export async function startDeviceWebAuth(
         // calculate relative expiration in seconds
         const expiresInSeconds = Math.floor((expiresAt - Date.now()) / 1000);
 
+        // Construct explicit HTTPS verification URL for clients
+        const host = req.get("host") || "";
+        const isHttpLocal =
+            host.startsWith("localhost") || host.startsWith("127.0.0.1");
+        const protocol = isHttpLocal ? req.protocol : "https";
+        const url = `${protocol}://${host}/device-auth?code=${code}`;
+
         return response<StartDeviceWebAuthResponse>(res, {
             data: {
                 code,
-                expiresInSeconds
+                expiresInSeconds,
+                url
             },
             success: true,
             error: false,


### PR DESCRIPTION
Fixes #3430 where mobile clients (e.g. Android app) throw \Failed to start sign in: CLEARTEXT communication to pangolin.example.com not permitted by network security policy\ during device sign-in.

### Root Cause
Android 9+ enforces cleartext traffic restrictions by default. When starting device web auth (\POST /api/v1/auth/device-web-auth/start\), the server returned \{ code, expiresInSeconds }\ without an explicit HTTPS verification URL, causing clients to construct or fall back to \http://\ URLs which Android OS rejects.

### Changes
- Updated \StartDeviceWebAuthResponse\ in \startDeviceWebAuth.ts\ to include \url: string\.
- Computes and returns an explicit \https://\System.Management.Automation.Internal.Host.InternalHost/device-auth?code=\\ URL in \startDeviceWebAuth()\.