### PR TITLE
security: fix OIDC post-authentication open redirect vulnerability (#3335)

### DIFF
--- a/server/lib/cleanRedirect.ts
+++ b/server/lib/cleanRedirect.ts
@@ -1,0 +1,93 @@
+type CleanRedirectOptions = {
+    fallback?: string;
+    maxRedirectDepth?: number;
+    allowAllQueryParams?: boolean;
+};
+
+const ALLOWED_QUERY_PARAMS = new Set([
+    "forceLogin",
+    "code",
+    "token",
+    "redirect"
+]);
+
+const DUMMY_BASE = "https://internal.local";
+
+export function cleanRedirect(
+    input: string,
+    options: CleanRedirectOptions = {}
+): string {
+    const {
+        fallback = "/",
+        maxRedirectDepth = 2,
+        allowAllQueryParams = false
+    } = options;
+
+    if (!input || typeof input !== "string") {
+        return fallback;
+    }
+
+    try {
+        return sanitizeUrl(input, fallback, maxRedirectDepth, allowAllQueryParams);
+    } catch {
+        return fallback;
+    }
+}
+
+function sanitizeUrl(
+    input: string,
+    fallback: string,
+    remainingRedirectDepth: number,
+    allowAllQueryParams: boolean = false
+): string {
+    if (
+        input.startsWith("javascript:") ||
+        input.startsWith("data:") ||
+        input.startsWith("//")
+    ) {
+        return fallback;
+    }
+
+    const url = new URL(input, DUMMY_BASE);
+
+    // Must be a relative/internal path
+    if (url.origin !== DUMMY_BASE) {
+        return fallback;
+    }
+
+    if (!url.pathname.startsWith("/")) {
+        return fallback;
+    }
+
+    const cleanParams = new URLSearchParams();
+
+    for (const [key, value] of url.searchParams.entries()) {
+        if (!allowAllQueryParams && !ALLOWED_QUERY_PARAMS.has(key)) {
+            continue;
+        }
+
+        if (key === "redirect") {
+            if (remainingRedirectDepth <= 0) {
+                continue;
+            }
+
+            const cleanedRedirect = sanitizeUrl(
+                value,
+                "",
+                remainingRedirectDepth - 1,
+                allowAllQueryParams
+            );
+
+            if (cleanedRedirect) {
+                cleanParams.set("redirect", cleanedRedirect);
+            }
+
+            continue;
+        }
+
+        cleanParams.set(key, value);
+    }
+
+    const queryString = cleanParams.toString();
+    return queryString ? `${url.pathname}?${queryString}` : url.pathname;
+}

--- a/server/routers/idp/generateOidcUrl.ts
+++ b/server/routers/idp/generateOidcUrl.ts
@@ -17,6 +17,8 @@ import { build } from "@server/build";
 import { isSubscribed } from "#dynamic/lib/isSubscribed";
 import { tierMatrix } from "@server/lib/billing/tierMatrix";
 
+import { cleanRedirect } from "@server/lib/cleanRedirect";
+
 const paramsSchema = z
     .object({
         idpId: z.coerce.number<number>()
@@ -170,9 +172,11 @@ export async function generateOidcUrl(
             parsedScopes
         );
 
+        const safePostAuthRedirectUrl = cleanRedirect(postAuthRedirectUrl);
+
         const stateJwt = jsonwebtoken.sign(
             {
-                redirectUrl: postAuthRedirectUrl, // TODO: validate that this is safe
+                redirectUrl: safePostAuthRedirectUrl,
                 state,
                 codeVerifier
             },

--- a/server/routers/idp/validateOidcCallback.ts
+++ b/server/routers/idp/validateOidcCallback.ts
@@ -23,6 +23,7 @@ import { generateOidcRedirectUrl } from "@server/lib/idp/generateRedirectUrl";
 import jmespath from "jmespath";
 import jsonwebtoken from "jsonwebtoken";
 import config from "@server/lib/config";
+import { cleanRedirect } from "@server/lib/cleanRedirect";
 import {
     createSession,
     generateId,
@@ -182,8 +183,9 @@ export async function validateOidcCallback(
         const {
             codeVerifier,
             state,
-            redirectUrl: postAuthRedirectUrl
+            redirectUrl: rawPostAuthRedirectUrl
         } = stateObj.data;
+        const postAuthRedirectUrl = cleanRedirect(rawPostAuthRedirectUrl);
 
         if (state !== expectedState) {
             logger.error("State mismatch", { expectedState, state });

--- a/src/components/ValidateOidcToken.tsx
+++ b/src/components/ValidateOidcToken.tsx
@@ -17,6 +17,7 @@ import { Loader2, CheckCircle2, AlertCircle } from "lucide-react";
 import { useLicenseStatusContext } from "@app/hooks/useLicenseStatusContext";
 import { useTranslations } from "next-intl";
 import { validateOidcUrlCallbackProxy } from "@app/actions/server";
+import { cleanRedirect } from "@app/lib/cleanRedirect";
 import { build } from "@server/build";
 
 type ValidateOidcTokenParams = {
@@ -129,9 +130,9 @@ export default function ValidateOidcToken(props: ValidateOidcTokenParams) {
                     return;
                 }
 
-                const redirectUrl = data.redirectUrl;
+                const safeRedirectUrl = cleanRedirect(data.redirectUrl);
 
-                if (!redirectUrl) {
+                if (!safeRedirectUrl) {
                     router.push(env.app.dashboardUrl);
                 }
 
@@ -141,10 +142,10 @@ export default function ValidateOidcToken(props: ValidateOidcTokenParams) {
                     await new Promise((resolve) => setTimeout(resolve, 100));
                 }
 
-                if (redirectUrl.startsWith("http")) {
-                    window.location.href = data.redirectUrl; // this is validated by the parent using this component
+                if (safeRedirectUrl.startsWith("http")) {
+                    window.location.href = safeRedirectUrl;
                 } else {
-                    router.push(data.redirectUrl);
+                    router.push(safeRedirectUrl);
                 }
             } catch (e: any) {
                 console.error(e);


### PR DESCRIPTION
Fixes #3335 where an unvalidated \edirectUrl\ passed to \POST /api/v1/auth/idp/:idpId/oidc/generate-url\ was stored in the \p_oidc_state\ JWT cookie and subsequently navigated to post-authentication, enabling open redirect attacks.

### Root Cause
1. \generateOidcUrl.ts\ stored \edirectUrl\ verbatim in the state JWT payload without validation (\// TODO: validate that this is safe\).
2. \ValidateOidcToken.tsx\ executed \window.location.href = data.redirectUrl\ directly for external HTTP URLs.

### Changes
- Created \server/lib/cleanRedirect.ts\ to validate and restrict redirect URLs to relative internal paths (sanitizing external hostnames, \javascript:\, \data:\, and \//\).
- Sanitized \postAuthRedirectUrl\ in \generateOidcUrl.ts\ before signing state JWT.
- Sanitized \postAuthRedirectUrl\ in \alidateOidcCallback.ts\.
- Sanitized \data.redirectUrl\ in \ValidateOidcToken.tsx\ before client navigation.