### PR TITLE
fix(auth): render auth pages on legacy iOS

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "scripts": {
         "dev": "NODE_ENV=development ENVIRONMENT=dev tsx watch server/index.ts",
         "dev:check": "npx tsc --noEmit && npm run format:check",
+        "test:ios14-compat": "tsx --test src/lib/legacyIosStylesheet.test.ts",
         "dev:setup": "cp config/config.example.yml config/config.yml && npm run set:oss && npm run set:sqlite && npm run db:sqlite:generate && npm run db:sqlite:push",
         "db:generate": "drizzle-kit generate --config=./drizzle.config.ts",
         "db:push": "npx tsx server/db/migrate.ts",
@@ -23,8 +24,8 @@
         "set:enterprise": "echo 'export const build = \"enterprise\" as \"saas\" | \"enterprise\" | \"oss\";' > server/build.ts && cp tsconfig.enterprise.json tsconfig.json",
         "set:sqlite": "echo 'export * from \"./sqlite\";\nexport const driver: \"pg\" | \"sqlite\" = \"sqlite\";' > server/db/index.ts && cp drizzle.sqlite.config.ts drizzle.config.ts && cp server/setup/migrationsSqlite.ts server/setup/migrations.ts",
         "set:pg": "echo 'export * from \"./pg\";\nexport const driver: \"pg\" | \"sqlite\" = \"pg\";' > server/db/index.ts && cp drizzle.pg.config.ts drizzle.config.ts && cp server/setup/migrationsPg.ts server/setup/migrations.ts",
-        "build:next": "next build",
-        "build": "mkdir -p dist && next build && node esbuild.mjs -e server/index.ts -o dist/server.mjs && node esbuild.mjs -e server/setup/migrations.ts -o dist/migrations.mjs",
+        "build:next": "next build && node scripts/compat-ios14.mjs",
+        "build": "mkdir -p dist && next build && node scripts/compat-ios14.mjs && node esbuild.mjs -e server/index.ts -o dist/server.mjs && node esbuild.mjs -e server/setup/migrations.ts -o dist/migrations.mjs",
         "start": "ENVIRONMENT=prod node dist/migrations.mjs && ENVIRONMENT=prod NODE_ENV=development node --enable-source-maps dist/server.mjs",
         "email": "email dev --dir server/emails/templates --port 3005",
         "build:cli": "node esbuild.mjs -e cli/index.ts -o dist/cli.mjs",
@@ -182,5 +183,12 @@
         "esbuild": "0.28.1",
         "dompurify": "3.4.0",
         "postcss": "8.5.15"
-    }
+    },
+    "browserslist": [
+        "chrome 111",
+        "edge 111",
+        "firefox 111",
+        "safari 14",
+        "ios_saf 14.0-14.4"
+    ]
 }

--- a/scripts/compat-ios14.mjs
+++ b/scripts/compat-ios14.mjs
@@ -1,0 +1,102 @@
+import crypto from "crypto";
+import fs from "fs";
+import path from "path";
+import postcss from "postcss";
+
+const rootDir = process.cwd();
+const nextDir = path.join(rootDir, ".next");
+const staticChunksDir = path.join(nextDir, "static", "chunks");
+const legacyCssDir = path.join(nextDir, "static", "legacy-ios14");
+const legacyManifestPath = path.join(legacyCssDir, "manifest.json");
+
+function walkFiles(dir, predicate, files = []) {
+    if (!fs.existsSync(dir)) {
+        return files;
+    }
+
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const fullPath = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+            walkFiles(fullPath, predicate, files);
+        } else if (predicate(fullPath)) {
+            files.push(fullPath);
+        }
+    }
+
+    return files;
+}
+
+function stripLayerAtRules(css) {
+    const root = postcss.parse(css);
+
+    root.walkAtRules("layer", (atRule) => {
+        if (atRule.nodes?.length) {
+            atRule.replaceWith(...atRule.nodes);
+        } else {
+            atRule.remove();
+        }
+    });
+
+    return root.toString();
+}
+
+function transformCssChunks() {
+    const cssFiles = walkFiles(staticChunksDir, (file) =>
+        file.endsWith(".css")
+    ).sort();
+    const layeredCssFiles = cssFiles.filter((file) =>
+        fs.readFileSync(file, "utf8").includes("@layer")
+    );
+
+    fs.rmSync(legacyCssDir, { recursive: true, force: true });
+
+    if (layeredCssFiles.length !== 1) {
+        throw new Error(
+            `Expected exactly one layered CSS bundle, found ${layeredCssFiles.length}. ` +
+                "Review the auth route CSS order before updating the compatibility build."
+        );
+    }
+
+    const source = fs.readFileSync(layeredCssFiles[0], "utf8");
+    const output = stripLayerAtRules(source);
+    if (!output || output.includes("@layer")) {
+        throw new Error(
+            "Legacy CSS generation did not remove all @layer rules."
+        );
+    }
+
+    const contentHash = crypto
+        .createHash("sha256")
+        .update(output)
+        .digest("hex")
+        .slice(0, 16);
+    const legacyCssName = `auth-ios14.${contentHash}.css`;
+    const legacyCssHref = `/_next/static/legacy-ios14/${legacyCssName}`;
+
+    fs.mkdirSync(legacyCssDir, { recursive: true });
+    fs.writeFileSync(path.join(legacyCssDir, legacyCssName), output);
+    fs.writeFileSync(
+        legacyManifestPath,
+        JSON.stringify({ stylesheets: [legacyCssHref] })
+    );
+
+    return {
+        stylesheets: 1,
+        colorMixDeclarations: (output.match(/color-mix\(/g) || []).length,
+        unsupportedHasSelectors: (output.match(/:has\(/g) || []).length
+    };
+}
+
+if (!fs.existsSync(nextDir)) {
+    throw new Error(
+        ".next does not exist. Run next build before compat-ios14."
+    );
+}
+
+const result = transformCssChunks();
+
+console.log(
+    `compat-ios14 complete: generated ${result.stylesheets} legacy CSS bundle; ` +
+        `${result.colorMixDeclarations} color-mix declarations and ` +
+        `${result.unsupportedHasSelectors} :has selectors remain as progressive enhancements`
+);

--- a/src/app/auth/layout.tsx
+++ b/src/app/auth/layout.tsx
@@ -1,6 +1,11 @@
 import ThemeSwitcher from "@app/components/ThemeSwitcher";
 import AuthFooter from "@app/components/AuthFooter";
+import {
+    getLegacyIosStylesheetHrefs,
+    isLegacyIosUserAgent
+} from "@app/lib/legacyIosStylesheet";
 import { Metadata } from "next";
+import { headers } from "next/headers";
 
 export const metadata: Metadata = {
     title: {
@@ -15,17 +20,33 @@ type AuthLayoutProps = {
 };
 
 export default async function AuthLayout({ children }: AuthLayoutProps) {
+    const requestHeaders = await headers();
+    const userAgent = requestHeaders.get("user-agent") || "";
+    const legacyIosStylesheets = isLegacyIosUserAgent(userAgent)
+        ? getLegacyIosStylesheetHrefs()
+        : [];
+
     return (
-        <div className="h-full flex flex-col">
-            <div className="hidden md:flex justify-end items-center p-3 space-x-2">
-                <ThemeSwitcher />
-            </div>
+        <>
+            {legacyIosStylesheets.map((href) => (
+                <link
+                    key={href}
+                    rel="stylesheet"
+                    href={href}
+                    precedence="legacy-ios14"
+                />
+            ))}
+            <div className="h-full flex flex-col">
+                <div className="hidden md:flex justify-end items-center p-3 space-x-2">
+                    <ThemeSwitcher />
+                </div>
 
-            <div className="flex-1 flex md:items-center justify-center">
-                <div className="w-full max-w-md p-3">{children}</div>
-            </div>
+                <div className="flex-1 flex md:items-center justify-center">
+                    <div className="w-full max-w-md p-3">{children}</div>
+                </div>
 
-            <AuthFooter />
-        </div>
+                <AuthFooter />
+            </div>
+        </>
     );
 }

--- a/src/lib/legacyIosStylesheet.test.ts
+++ b/src/lib/legacyIosStylesheet.test.ts
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { isLegacyIosUserAgent } from "./legacyIosStylesheet";
+
+const cases: Array<{
+    name: string;
+    userAgent: string;
+    expected: boolean;
+}> = [
+    {
+        name: "iPhone iOS 14 WeCom",
+        userAgent:
+            "Mozilla/5.0 (iPhone; CPU iPhone OS 14_1 like Mac OS X) " +
+            "AppleWebKit/605.1.15 Mobile/15E148 wxwork/4.1.0",
+        expected: true
+    },
+    {
+        name: "iPad iOS 13 mobile mode",
+        userAgent:
+            "Mozilla/5.0 (iPad; CPU OS 13_7 like Mac OS X) " +
+            "AppleWebKit/605.1.15 Mobile/15E148 Safari/604.1",
+        expected: true
+    },
+    {
+        name: "iPadOS 14 desktop mode",
+        userAgent:
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15) " +
+            "AppleWebKit/605.1.15 Version/14.0 Mobile/15E148 Safari/604.1",
+        expected: true
+    },
+    {
+        name: "iPadOS 18 desktop mode",
+        userAgent:
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15) " +
+            "AppleWebKit/605.1.15 Version/18.0 Mobile/15E148 Safari/604.1",
+        expected: false
+    },
+    {
+        name: "iPhone 13-class iOS 15.0",
+        userAgent:
+            "Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X) " +
+            "AppleWebKit/605.1.15 Mobile/15E148 Safari/604.1",
+        expected: true
+    },
+    {
+        name: "iPhone iOS 15.3",
+        userAgent:
+            "Mozilla/5.0 (iPhone; CPU iPhone OS 15_3 like Mac OS X) " +
+            "AppleWebKit/605.1.15 Mobile/15E148 Safari/604.1",
+        expected: true
+    },
+    {
+        name: "iPhone iOS 15.4",
+        userAgent:
+            "Mozilla/5.0 (iPhone; CPU iPhone OS 15_4 like Mac OS X) " +
+            "AppleWebKit/605.1.15 Mobile/15E148 Safari/604.1",
+        expected: false
+    },
+    {
+        name: "macOS Safari 14",
+        userAgent:
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) " +
+            "AppleWebKit/605.1.15 Version/14.0 Safari/605.1.15",
+        expected: false
+    },
+    {
+        name: "Android Chrome",
+        userAgent:
+            "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 " +
+            "Chrome/126.0.0.0 Mobile Safari/537.36",
+        expected: false
+    },
+    {
+        name: "unknown mobile user agent",
+        userAgent: "CustomMobileClient/1.0",
+        expected: false
+    }
+];
+
+for (const entry of cases) {
+    test(entry.name, () => {
+        assert.equal(isLegacyIosUserAgent(entry.userAgent), entry.expected);
+    });
+}

--- a/src/lib/legacyIosStylesheet.ts
+++ b/src/lib/legacyIosStylesheet.ts
@@ -1,0 +1,77 @@
+import fs from "fs";
+import path from "path";
+
+const IOS_CASCADE_LAYERS_MIN_VERSION = [15, 4] as const;
+const LEGACY_CSS_DIRECTORY = path.join(
+    process.cwd(),
+    ".next",
+    "static",
+    "legacy-ios14"
+);
+const LEGACY_CSS_MANIFEST = path.join(LEGACY_CSS_DIRECTORY, "manifest.json");
+let cachedStylesheetHrefs: string[] | undefined;
+
+export function isLegacyIosUserAgent(userAgent: string): boolean {
+    if (/\b(?:iPhone|iPad|iPod)\b/i.test(userAgent)) {
+        const versionMatch = userAgent.match(
+            /\b(?:CPU (?:iPhone )?OS|iPhone OS) (\d+)(?:[_.](\d+))?/i
+        );
+        return !!versionMatch && isBeforeCascadeLayers(versionMatch);
+    }
+
+    if (/\bMacintosh\b.*\bMobile\//i.test(userAgent)) {
+        const safariVersion = userAgent.match(/\bVersion\/(\d+)(?:\.(\d+))?/i);
+        return !!safariVersion && isBeforeCascadeLayers(safariVersion);
+    }
+
+    return false;
+}
+
+function isBeforeCascadeLayers(versionMatch: RegExpMatchArray): boolean {
+    const major = Number(versionMatch[1]);
+    const minor = Number(versionMatch[2] || 0);
+    const [minimumMajor, minimumMinor] = IOS_CASCADE_LAYERS_MIN_VERSION;
+
+    return (
+        major < minimumMajor || (major === minimumMajor && minor < minimumMinor)
+    );
+}
+
+export function getLegacyIosStylesheetHrefs(): string[] {
+    if (cachedStylesheetHrefs) {
+        return cachedStylesheetHrefs;
+    }
+
+    try {
+        const manifest = JSON.parse(
+            fs.readFileSync(LEGACY_CSS_MANIFEST, "utf8")
+        ) as { stylesheets?: unknown };
+        if (
+            !Array.isArray(manifest.stylesheets) ||
+            !manifest.stylesheets.every(
+                (href) =>
+                    typeof href === "string" &&
+                    href.startsWith("/_next/static/legacy-ios14/") &&
+                    href.endsWith(".css")
+            )
+        ) {
+            throw new Error("Invalid legacy iOS stylesheet manifest.");
+        }
+
+        cachedStylesheetHrefs = manifest.stylesheets;
+    } catch (error) {
+        if (
+            !(error instanceof Error) ||
+            !("code" in error) ||
+            error.code !== "ENOENT"
+        ) {
+            console.error(
+                "Failed to load legacy iOS stylesheet manifest",
+                error
+            );
+        }
+        cachedStylesheetHrefs = [];
+    }
+
+    return cachedStylesheetHrefs;
+}


### PR DESCRIPTION
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description

Auth pages can render without their layout styles on iOS versions before 15.4, including embedded WeCom webviews. These WebKit versions do not support CSS cascade layers, so they discard the contents of the generated layered Tailwind stylesheet.

This change adds a targeted compatibility path:

- compile client assets for Safari/iOS 14 through the project Browserslist targets;
- generate a content-hashed fallback stylesheet after each Next.js build by unwrapping `@layer` blocks;
- serve that fallback only from the auth layout and only to iOS/iPadOS versions before 15.4;
- fail the build if the generated CSS bundle shape changes, so the fallback cannot silently become incomplete;
- cover iPhone, iPad, desktop-mode iPadOS, boundary-version, and non-iOS user agents with tests.

Modern browsers continue receiving the original stylesheet only.

## How to test?

```bash
npm run test:ios14-compat
npx eslint scripts/compat-ios14.mjs src/lib/legacyIosStylesheet.ts src/lib/legacyIosStylesheet.test.ts src/app/auth/layout.tsx --ext .js,.jsx,.ts,.tsx
npx tsc --noEmit
npm run build:next
```

The production build generates `.next/static/legacy-ios14/manifest.json` and one content-hashed CSS file with no remaining `@layer` rules. The deployed auth route was also checked with iOS 14.1, iOS 15.3, and iOS 15.4 user agents: only versions before 15.4 received the fallback stylesheet. A Chromium mobile-viewport visual check confirmed the fallback page layout; final WebKit behavior still requires testing on an affected iOS device.
