### PR TITLE
feat: per-site-resource opt-out from advertising the destination as a client route

### DIFF
--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -2424,6 +2424,8 @@
     "privateResourceAllowIcmpPing": "Allow ICMP Ping",
     "privateResourceNetworkAccess": "Network Access",
     "privateResourceNetworkAccessDescription": "Control TCP/UDP port access and whether ICMP ping is allowed for this resource.",
+    "privateResourceAdvertiseDestination": "Advertise Destination as a Client Route",
+    "privateResourceAdvertiseDestinationDescription": "Adds a route to the destination address on connected clients. Turn this off if clients already reach the destination another way; the resource stays reachable through its alias address.",
     "hostSettings": "Host Settings",
     "cidrSettings": "CIDR Settings",
     "createInternalResourceDialogResourceProperties": "Resource Properties",

--- a/server/db/pg/schema/schema.ts
+++ b/server/db/pg/schema/schema.ts
@@ -444,6 +444,12 @@ export const siteResources = pgTable(
             .notNull()
             .default("*"),
         disableIcmp: boolean("disableIcmp").notNull().default(false),
+        // When false, host/ssh resources are still reachable through their
+        // aliasAddress but their destination is not sent to clients as a
+        // route. Lets a client keep a pre-existing path to the destination.
+        advertiseDestination: boolean("advertiseDestination")
+            .notNull()
+            .default(true),
         authDaemonPort: integer("authDaemonPort").default(22123),
         pamMode: varchar("pamMode", { length: 32 })
             .$type<"passthrough" | "push">()

--- a/server/db/sqlite/schema/schema.ts
+++ b/server/db/sqlite/schema/schema.ts
@@ -438,6 +438,12 @@ export const siteResources = sqliteTable("siteResources", {
     disableIcmp: integer("disableIcmp", { mode: "boolean" })
         .notNull()
         .default(false),
+    // When false, host/ssh resources are still reachable through their
+    // aliasAddress but their destination is not sent to clients as a route.
+    // Lets a client keep a pre-existing path to the destination.
+    advertiseDestination: integer("advertiseDestination", { mode: "boolean" })
+        .notNull()
+        .default(true),
     authDaemonPort: integer("authDaemonPort").default(22123),
     pamMode: text("pamMode")
         .$type<"passthrough" | "push">()

--- a/server/lib/blueprints/privateResources.ts
+++ b/server/lib/blueprints/privateResources.ts
@@ -279,6 +279,8 @@ export async function updatePrivateResources(
                     disableIcmp:
                         resourceData["disable-icmp"] ||
                         (resourceData.mode == "http" ? true : false), // default to true for http resources, otherwise false
+                    advertiseDestination:
+                        resourceData["advertise-destination"] ?? true,
                     tcpPortRangeString:
                         resourceData.mode == "http"
                             ? "443,80"
@@ -554,6 +556,8 @@ export async function updatePrivateResources(
                     disableIcmp:
                         resourceData["disable-icmp"] ||
                         (resourceData.mode == "http" ? true : false), // default to true for http resources, otherwise false
+                    advertiseDestination:
+                        resourceData["advertise-destination"] ?? true,
                     tcpPortRangeString:
                         resourceData.mode == "http"
                             ? "443,80"

--- a/server/lib/blueprints/types.ts
+++ b/server/lib/blueprints/types.ts
@@ -474,6 +474,7 @@ export const PrivateResourceSchema = z
         "tcp-ports": portRangeStringSchema.optional().default("*"),
         "udp-ports": portRangeStringSchema.optional().default("*"),
         "disable-icmp": z.boolean().optional().default(false),
+        "advertise-destination": z.boolean().optional().default(true),
         "full-domain": z.string().optional(),
         ssl: z.boolean().optional(),
         scheme: z.enum(["http", "https"]).optional().nullable(),

--- a/server/lib/ip.ts
+++ b/server/lib/ip.ts
@@ -507,6 +507,10 @@ export function generateRemoteSubnets(
                 return parseResult.success;
             }
             if (sr.mode === "host" || sr.mode === "ssh") {
+                // the resource is still served through its aliasAddress by
+                // generateSubnetProxyTargetV2, we just don't hand the client a
+                // route to the destination itself
+                if (sr.advertiseDestination === false) return false;
                 // check if its a valid IP using zod
                 const ipSchema = z.union([z.ipv4(), z.ipv6()]);
                 const parseResult = ipSchema.safeParse(sr.destination);

--- a/server/lib/rebuildClientAssociations.ts
+++ b/server/lib/rebuildClientAssociations.ts
@@ -1353,6 +1353,9 @@ export async function handleMessagingForUpdatedSiteResource(
                         siteResources.destination,
                         existingSiteResource.destination
                     ),
+                    // a sibling that doesn't advertise its destination isn't
+                    // keeping the route alive, so it must not block removal
+                    eq(siteResources.advertiseDestination, true),
                     ne(
                         siteResources.siteResourceId,
                         existingSiteResource.siteResourceId
@@ -1571,9 +1574,16 @@ export async function handleMessagingForUpdatedSiteResource(
     const enabledChanged =
         existingSiteResource &&
         existingSiteResource.enabled !== updatedSiteResource.enabled;
+    // Only affects what generateRemoteSubnets emits, so this drives the peer
+    // data (client route) update but not the newt targets, which are keyed off
+    // the alias address and are unchanged by it.
+    const advertiseDestinationChanged =
+        existingSiteResource &&
+        existingSiteResource.advertiseDestination !==
+            updatedSiteResource.advertiseDestination;
 
     logger.debug(
-        `handleMessagingForUpdatedSiteResource: change flags destinationChanged=${Boolean(destinationChanged)} destinationPortChanged=${Boolean(destinationPortChanged)} aliasChanged=${Boolean(aliasChanged)} fullDomainChanged=${Boolean(fullDomainChanged)} sslChanged=${Boolean(sslChanged)} portRangesChanged=${Boolean(portRangesChanged)} enabledChanged=${Boolean(enabledChanged)}`
+        `handleMessagingForUpdatedSiteResource: change flags destinationChanged=${Boolean(destinationChanged)} destinationPortChanged=${Boolean(destinationPortChanged)} aliasChanged=${Boolean(aliasChanged)} fullDomainChanged=${Boolean(fullDomainChanged)} sslChanged=${Boolean(sslChanged)} portRangesChanged=${Boolean(portRangesChanged)} enabledChanged=${Boolean(enabledChanged)} advertiseDestinationChanged=${Boolean(advertiseDestinationChanged)}`
     );
 
     // if the existingSiteResource is undefined (new resource) we don't need to do anything here, the rebuild above handled it all
@@ -1585,7 +1595,8 @@ export async function handleMessagingForUpdatedSiteResource(
         sslChanged ||
         portRangesChanged ||
         destinationPortChanged ||
-        enabledChanged
+        enabledChanged ||
+        advertiseDestinationChanged
     ) {
         const shouldUpdateTargets =
             destinationChanged ||
@@ -1670,7 +1681,9 @@ export async function handleMessagingForUpdatedSiteResource(
                     clientId: client.clientId,
                     siteId,
                     remoteSubnets:
-                        destinationChanged || enabledChanged
+                        destinationChanged ||
+                        enabledChanged ||
+                        advertiseDestinationChanged
                             ? {
                                   oldRemoteSubnets:
                                       !oldDestinationStillInUseBySite

--- a/server/routers/siteResource/createSiteResource.ts
+++ b/server/routers/siteResource/createSiteResource.ts
@@ -74,6 +74,11 @@ const createSiteResourceSchema = z
         tcpPortRangeString: portRangeStringSchema,
         udpPortRangeString: portRangeStringSchema,
         disableIcmp: z.boolean().optional(),
+        advertiseDestination: z.boolean().optional().openapi({
+            description:
+                "Only applies to host and ssh resources. When false the resource is still reachable through its alias address, but its destination is not installed as a route on the client. Defaults to true.",
+            example: true
+        }),
         authDaemonPort: z.int().positive().optional(),
         authDaemonMode: z.enum(["site", "remote", "native"]).optional(),
         pamMode: z.enum(["passthrough", "push"]).optional(),
@@ -315,6 +320,7 @@ export async function createSiteResource(
             tcpPortRangeString,
             udpPortRangeString,
             disableIcmp,
+            advertiseDestination,
             authDaemonPort,
             authDaemonMode,
             pamMode,
@@ -580,6 +586,9 @@ export async function createSiteResource(
                     disableIcmp:
                         disableIcmp ||
                         (mode == "http" || mode == "ssh" ? true : false), // default to true for http resources, otherwise false
+                    ...(advertiseDestination !== undefined && {
+                        advertiseDestination
+                    }),
                     domainId,
                     subdomain: finalSubdomain,
                     fullDomain

--- a/server/routers/siteResource/listAllSiteResourcesByOrg.ts
+++ b/server/routers/siteResource/listAllSiteResourcesByOrg.ts
@@ -205,6 +205,7 @@ function querySiteResourcesBase() {
             tcpPortRangeString: siteResources.tcpPortRangeString,
             udpPortRangeString: siteResources.udpPortRangeString,
             disableIcmp: siteResources.disableIcmp,
+            advertiseDestination: siteResources.advertiseDestination,
             authDaemonMode: siteResources.authDaemonMode,
             authDaemonPort: siteResources.authDaemonPort,
             pamMode: siteResources.pamMode,

--- a/server/routers/siteResource/updateSiteResource.ts
+++ b/server/routers/siteResource/updateSiteResource.ts
@@ -74,6 +74,11 @@ const updateSiteResourceSchema = z
         tcpPortRangeString: portRangeStringSchema,
         udpPortRangeString: portRangeStringSchema,
         disableIcmp: z.boolean().optional(),
+        advertiseDestination: z.boolean().optional().openapi({
+            description:
+                "Only applies to host and ssh resources. When false the resource is still reachable through its alias address, but its destination is not installed as a route on the client. Defaults to true.",
+            example: true
+        }),
         authDaemonPort: z.int().positive().nullish(),
         authDaemonMode: z.enum(["site", "remote", "native"]).optional(),
         pamMode: z.enum(["passthrough", "push"]).optional(),
@@ -322,6 +327,7 @@ export async function updateSiteResource(
             tcpPortRangeString,
             udpPortRangeString,
             disableIcmp,
+            advertiseDestination,
             authDaemonPort,
             authDaemonMode,
             pamMode,
@@ -583,6 +589,7 @@ export async function updateSiteResource(
                                   ? true
                                   : false)
                             : disableIcmp,
+                    advertiseDestination,
                     domainId,
                     subdomain: finalSubdomain,
                     fullDomain,

--- a/src/app/[orgId]/settings/resources/private/[niceId]/host/page.tsx
+++ b/src/app/[orgId]/settings/resources/private/[niceId]/host/page.tsx
@@ -21,7 +21,10 @@ import { useActionState, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { PrivateResourceSitesField } from "@app/components/PrivateResourceSitesField";
-import { PrivateResourceHostDestinationFields } from "@app/components/PrivateResourceDestinationFields";
+import {
+    PrivateResourceAdvertiseDestinationField,
+    PrivateResourceHostDestinationFields
+} from "@app/components/PrivateResourceDestinationFields";
 import { PrivateResourcePortRanges } from "@app/components/PrivateResourcePortRanges";
 import { useSaveSiteResource } from "@app/hooks/useSaveSiteResource";
 import {
@@ -51,6 +54,7 @@ export default function PrivateResourceHostPage() {
             tcpPortRangeString: siteResource.tcpPortRangeString ?? "*",
             udpPortRangeString: siteResource.udpPortRangeString ?? "*",
             disableIcmp: siteResource.disableIcmp ?? false,
+            advertiseDestination: siteResource.advertiseDestination ?? true,
             authDaemonMode: siteResource.authDaemonMode ?? "site",
             authDaemonPort: siteResource.authDaemonPort ?? null
         }
@@ -69,6 +73,7 @@ export default function PrivateResourceHostPage() {
             tcpPortRangeString: data.tcpPortRangeString,
             udpPortRangeString: data.udpPortRangeString,
             disableIcmp: data.disableIcmp,
+            advertiseDestination: data.advertiseDestination,
             authDaemonMode: data.authDaemonMode,
             authDaemonPort: data.authDaemonPort
         });
@@ -109,6 +114,12 @@ export default function PrivateResourceHostPage() {
                                         <PrivateResourceHostDestinationFields
                                             control={asAnyControl(form.control)}
                                             watch={asAnyWatch(form.watch)}
+                                        />
+                                    </SettingsFormCell>
+
+                                    <SettingsFormCell span="full">
+                                        <PrivateResourceAdvertiseDestinationField
+                                            control={asAnyControl(form.control)}
                                         />
                                     </SettingsFormCell>
 

--- a/src/app/[orgId]/settings/resources/private/[niceId]/ssh/page.tsx
+++ b/src/app/[orgId]/settings/resources/private/[niceId]/ssh/page.tsx
@@ -9,6 +9,7 @@ import {
     SettingsSectionForm,
     SettingsSectionHeader,
     SettingsSectionTitle,
+    SettingsFormCell,
     SettingsFormGrid
 } from "@app/components/Settings";
 import { SshServerSettingsFields } from "@app/components/SshServerSettingsFields";
@@ -27,6 +28,7 @@ import { useActionState, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { PrivateResourceSshFields } from "@app/components/PrivateResourceSshFields";
+import { PrivateResourceAdvertiseDestinationField } from "@app/components/PrivateResourceDestinationFields";
 import type { Selectedsite } from "@app/components/site-selector";
 import { useSaveSiteResource } from "@app/hooks/useSaveSiteResource";
 import {
@@ -74,7 +76,8 @@ export default function PrivateResourceSshPage() {
                   : "site",
             authDaemonPort: siteResource.authDaemonPort
                 ? String(siteResource.authDaemonPort)
-                : "22123"
+                : "22123",
+            advertiseDestination: siteResource.advertiseDestination ?? true
         }
     });
 
@@ -144,7 +147,8 @@ export default function PrivateResourceSshPage() {
             destinationPort: isNative ? null : data.destinationPort,
             authDaemonMode: effectiveAuthDaemonMode,
             authDaemonPort: effectiveAuthDaemonPort,
-            pamMode: data.pamMode
+            pamMode: data.pamMode,
+            advertiseDestination: data.advertiseDestination
         });
     }, null);
 
@@ -210,6 +214,16 @@ export default function PrivateResourceSshPage() {
                                         showPaidFeaturesAlert={false}
                                         isNativeSsh={isNative}
                                     />
+                                    {!isNative && (
+                                        <SettingsFormCell span="full">
+                                            <PrivateResourceAdvertiseDestinationField
+                                                control={asAnyControl(
+                                                    form.control
+                                                )}
+                                                id="private-ssh-edit-advertise-destination"
+                                            />
+                                        </SettingsFormCell>
+                                    )}
                                 </SettingsFormGrid>
                             </SettingsSectionForm>
                         </SettingsSectionBody>

--- a/src/app/[orgId]/settings/resources/private/create/page.tsx
+++ b/src/app/[orgId]/settings/resources/private/create/page.tsx
@@ -55,6 +55,7 @@ import { PrivateResourceHttpFields } from "@app/components/PrivateResourceHttpFi
 import { PrivateResourceSshFields } from "@app/components/PrivateResourceSshFields";
 import { PrivateResourcePortRanges } from "@app/components/PrivateResourcePortRanges";
 import {
+    PrivateResourceAdvertiseDestinationField,
     PrivateResourceAliasField,
     PrivateResourceCidrDestinationField,
     PrivateResourceHostDestinationFields
@@ -112,7 +113,8 @@ export default function CreatePrivateResourcePage() {
             pamMode: "passthrough",
             tcpPortRangeString: "*",
             udpPortRangeString: "*",
-            disableIcmp: false
+            disableIcmp: false,
+            advertiseDestination: true
         }
     });
 
@@ -385,6 +387,22 @@ export default function CreatePrivateResourcePage() {
                                                 )}
                                                 watch={asAnyWatch(form.watch)}
                                                 labelPrefix="create"
+                                                disabled={
+                                                    mode === "ssh" &&
+                                                    sshSectionDisabled
+                                                }
+                                            />
+                                        </SettingsFormCell>
+                                    )}
+
+                                    {(mode === "host" ||
+                                        (mode === "ssh" && !isNativeSsh)) && (
+                                        <SettingsFormCell span="full">
+                                            <PrivateResourceAdvertiseDestinationField
+                                                control={asAnyControl(
+                                                    form.control
+                                                )}
+                                                id="create-private-resource-advertise-destination"
                                                 disabled={
                                                     mode === "ssh" &&
                                                     sshSectionDisabled

--- a/src/app/[orgId]/settings/resources/private/page.tsx
+++ b/src/app/[orgId]/settings/resources/private/page.tsx
@@ -91,6 +91,7 @@ export default async function ClientResourcesPage(
                 tcpPortRangeString: siteResource.tcpPortRangeString || null,
                 udpPortRangeString: siteResource.udpPortRangeString || null,
                 disableIcmp: siteResource.disableIcmp || false,
+                advertiseDestination: siteResource.advertiseDestination ?? true,
                 authDaemonMode: siteResource.authDaemonMode ?? null,
                 authDaemonPort: siteResource.authDaemonPort ?? null,
                 pamMode: siteResource.pamMode ?? null,

--- a/src/components/PrivateResourceDestinationFields.tsx
+++ b/src/components/PrivateResourceDestinationFields.tsx
@@ -10,8 +10,45 @@ import {
     FormMessage
 } from "@app/components/ui/form";
 import { Input } from "@app/components/ui/input";
+import { SwitchInput } from "@app/components/SwitchInput";
 import { useTranslations } from "next-intl";
 import type { Control, UseFormWatch } from "react-hook-form";
+
+export function PrivateResourceAdvertiseDestinationField({
+    control,
+    id = "private-resource-advertise-destination",
+    disabled = false
+}: {
+    control: Control<any>;
+    id?: string;
+    disabled?: boolean;
+}) {
+    const t = useTranslations();
+
+    return (
+        <FormField
+            control={control}
+            name="advertiseDestination"
+            render={({ field }) => (
+                <FormItem>
+                    <FormControl>
+                        <SwitchInput
+                            id={id}
+                            label={t("privateResourceAdvertiseDestination")}
+                            description={t(
+                                "privateResourceAdvertiseDestinationDescription"
+                            )}
+                            checked={field.value ?? true}
+                            onCheckedChange={field.onChange}
+                            disabled={disabled}
+                        />
+                    </FormControl>
+                    <FormMessage />
+                </FormItem>
+            )}
+        />
+    );
+}
 
 type PrivateResourceAliasFieldProps = {
     control: Control<any>;

--- a/src/components/PrivateResourcesTable.tsx
+++ b/src/components/PrivateResourcesTable.tsx
@@ -96,6 +96,7 @@ export type InternalResourceRow = {
     tcpPortRangeString: string | null;
     udpPortRangeString: string | null;
     disableIcmp: boolean;
+    advertiseDestination: boolean;
     authDaemonMode?: "site" | "remote" | "native" | null;
     authDaemonPort?: number | null;
     pamMode?: "passthrough" | "push" | null;

--- a/src/hooks/useSaveSiteResource.ts
+++ b/src/hooks/useSaveSiteResource.ts
@@ -62,6 +62,7 @@ export function useSaveSiteResource() {
                 tcpPortRangeString: merged.tcpPortRangeString ?? null,
                 udpPortRangeString: merged.udpPortRangeString ?? null,
                 disableIcmp: merged.disableIcmp ?? false,
+                advertiseDestination: merged.advertiseDestination ?? true,
                 authDaemonMode: merged.authDaemonMode ?? null,
                 authDaemonPort: merged.authDaemonPort ?? null,
                 pamMode: merged.pamMode ?? null

--- a/src/lib/fetchSiteResourceByNiceId.ts
+++ b/src/lib/fetchSiteResourceByNiceId.ts
@@ -46,6 +46,7 @@ export async function fetchSiteResourceByNiceId(
         tcpPortRangeString: match.tcpPortRangeString || null,
         udpPortRangeString: match.udpPortRangeString || null,
         disableIcmp: match.disableIcmp || false,
+        advertiseDestination: match.advertiseDestination ?? true,
         authDaemonMode: match.authDaemonMode ?? null,
         authDaemonPort: match.authDaemonPort ?? null,
         pamMode: match.pamMode ?? null,

--- a/src/lib/privateResourceForm.ts
+++ b/src/lib/privateResourceForm.ts
@@ -29,6 +29,7 @@ export type PrivateResourceFormValues = {
     tcpPortRangeString?: string | null;
     udpPortRangeString?: string | null;
     disableIcmp?: boolean;
+    advertiseDestination?: boolean;
     authDaemonMode?: "site" | "remote" | "native" | null;
     authDaemonPort?: number | null;
     pamMode?: "passthrough" | "push" | null;
@@ -215,6 +216,9 @@ export function buildCreateSiteResourcePayload(
             udpPortRangeString: data.udpPortRangeString,
             disableIcmp: data.disableIcmp ?? false
         }),
+        ...((data.mode === "host" || data.mode === "ssh") && {
+            advertiseDestination: data.advertiseDestination ?? true
+        }),
         roleIds: data.roles ? data.roles.map((r) => parseInt(r.id)) : [],
         userIds: data.users ? data.users.map((u) => u.id) : [],
         clientIds: data.clients ? data.clients.map((c) => c.clientId) : []
@@ -285,6 +289,9 @@ export function buildUpdateSiteResourcePayload(
             udpPortRangeString: data.udpPortRangeString,
             disableIcmp: data.disableIcmp ?? false
         }),
+        ...((data.mode === "host" || data.mode === "ssh") && {
+            advertiseDestination: data.advertiseDestination ?? true
+        }),
         roleIds: access.roleIds,
         userIds: access.userIds,
         clientIds: access.clientIds
@@ -320,6 +327,7 @@ export function siteResourceToFormValues(
         tcpPortRangeString: resource.tcpPortRangeString ?? "*",
         udpPortRangeString: resource.udpPortRangeString ?? "*",
         disableIcmp: resource.disableIcmp ?? false,
+        advertiseDestination: resource.advertiseDestination ?? true,
         authDaemonMode:
             resource.authDaemonMode === "native"
                 ? "native"
@@ -402,7 +410,8 @@ export function createCreateFormSchema(t: TranslateFn) {
             pamMode: z.enum(["passthrough", "push"]).optional().nullable(),
             tcpPortRangeString: createPortRangeStringSchema(t),
             udpPortRangeString: createPortRangeStringSchema(t),
-            disableIcmp: z.boolean().optional()
+            disableIcmp: z.boolean().optional(),
+            advertiseDestination: z.boolean().optional()
         })
         .superRefine((data, ctx) => {
             const isNativeSsh =
@@ -545,6 +554,7 @@ export function createHostFormSchema(t: TranslateFn) {
             tcpPortRangeString: createPortRangeStringSchema(t),
             udpPortRangeString: createPortRangeStringSchema(t),
             disableIcmp: z.boolean().optional(),
+            advertiseDestination: z.boolean().optional(),
             authDaemonMode: z
                 .enum(["site", "remote", "native"])
                 .optional()
@@ -610,7 +620,8 @@ export function createSshFormSchema(
                 .nullable(),
             pamMode: z.enum(["passthrough", "push"]),
             standardDaemonLocation: z.enum(["site", "remote"]),
-            authDaemonPort: z.string()
+            authDaemonPort: z.string(),
+            advertiseDestination: z.boolean().optional()
         })
         .superRefine((data, ctx) => {
             destinationRefine(


### PR DESCRIPTION
Closes #3548.

```
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.
```

## AI disclosure

@AstralDestiny asked for this up front, so: **I used Claude (Claude Code) to write this PR** — the code, the commit message and this description. I drove it, read every line, and did the verification below myself against a running instance. Anything wrong in here is mine, not the tool's.

## What this adds

A per-site-resource boolean, `advertiseDestination`, default `true`.

When it's `false`, `generateRemoteSubnets()` skips the resource, so a `host`/`ssh` resource with a bare-IP destination no longer becomes a `/32` in the client's route table. The resource stays fully reachable through its `aliasAddress` — `generateSubnetProxyTargetV2()` and `generateAliasConfig()` are untouched.

The whole change is one line of actual behaviour:

```js
if (sr.mode === "host" || sr.mode === "ssh") {
    if (sr.advertiseDestination === false) return false;
    const parseResult = ipSchema.safeParse(sr.destination);
    return parseResult.success;
}
```

Defaulting to `true` makes it a no-op for every existing deployment.

## Why

Long version is in #3548; the short one:

olm installs one `/32` per site resource. On macOS the route table picks by longest prefix **before** metric is consulted, so each of those `/32`s beats any less-specific route the machine already had for the same LAN. On our workstations that's 158 `/32`s sitting on top of a healthy SD-WAN route and a Tailscale route to the same hosts. While the tunnel is up nobody notices; when it half-dies the `/32`s stay installed and blackhole the estate with a working path underneath. `--prefer-local-routes` can't help — it adjusts metric, and metric is never reached when prefix lengths differ.

Those `/32`s are pure downside for us, because we reach everything by alias anyway (`pangolin ssh` never uses the LAN IP). This flag lets a resource say "advertise the alias, don't route the destination". It's essentially letting a non-JIT client opt into the shape `jitMode` already has, per resource.

## Beyond the one-liner

Three things the filter change alone wouldn't cover:

- **`handleMessagingForUpdatedSiteResource()`** now diffs the flag, so toggling it pushes the route add/withdraw to already-connected clients instead of waiting for a reconnect. It deliberately does **not** set `shouldUpdateTargets` — the newt targets key off the alias address and don't change.
- **The "is this destination still in use by a sibling resource?" query** now requires the sibling to be advertising. Without that, a non-advertising sibling with the same destination would block withdrawal of a route it isn't keeping alive.
- **`advertiseDestination` is passed through** create/update, blueprints (`advertise-destination`), and the dashboard.

In the UI it's a switch shown under exactly the same condition as the alias field (host, or ssh when not native) — which felt right, since the flag only makes sense when there's an alias to fall back to.

## Migration

I did **not** add a `server/setup/scripts{Pg,Sqlite}/` script, because the convention in this repo looks like feature commits touch the schema files and the release migration collects the ALTERs (1.21.0 batches `resources.status`, `siteResources.status`, `sites.localEndpoints` that way). Flagging it loudly so it doesn't get lost — happy to add a versioned script if you'd rather, just tell me which version to name it. The statements are:

```sql
-- pg
ALTER TABLE "siteResources" ADD COLUMN "advertiseDestination" boolean DEFAULT true NOT NULL;
```
```sql
-- sqlite
ALTER TABLE 'siteResources' ADD 'advertiseDestination' integer NOT NULL DEFAULT true;
```

## Verification

Ran against a local instance (`oss` + sqlite, dev server), not just typechecked:

- **Schema** — `drizzle-kit generate` emits `advertiseDestination integer DEFAULT true NOT NULL`; `db:push` applies clean.
- **Create** — resource created with `advertiseDestination: false` via the API round-trips; `aliasAddress` is still allocated.
- **The actual output** — with three host resources (one advertising, two not), `generateRemoteSubnets()` returns only the advertising one's `/32`, while `generateAliasConfig()` still returns all three aliases. That's the property that matters: opted-out resources lose the route and keep the alias.
- **Update, both directions** — flipping the flag on and off through the API changes the emitted subnet set each time.
- **Change detection** — toggling logs `advertiseDestinationChanged=true` and enters the update path; re-sending the *same* value logs `advertiseDestinationChanged=false` and correctly no-ops, so there's no spurious client churn.
- **Dashboard** — drove it in a real browser: the switch reflects the stored value both ways, saving from the host settings page persists and the `/32` disappears from `generateRemoteSubnets()`, and creating a resource from the wizard with the switch off sends `advertiseDestination: false`.
- **ssh mode** — the create endpoint is license-gated, so on an OSS dev build I inserted an `ssh`-mode resource directly into the database instead. With the flag on, its `/32` appears in `generateRemoteSubnets()`; with it off, the `/32` is gone and the alias is still returned by `generateAliasConfig()`. Same single branch as `host`, now actually exercised rather than assumed. The ssh settings page renders the switch bound to the stored value in both states (greyed out along with the rest of the Enterprise-gated fieldset, as expected).
- **Typecheck** — `tsc --noEmit` passes under all three of `oss`+sqlite, `enterprise`+pg and `saas`+pg.

Two gaps left, both narrow. **Saving from the ssh settings page** needs a license, since the whole ssh fieldset is disabled without one — the save path is the same `useSaveSiteResource` → `buildUpdateSiteResourcePayload` the host page proves live, with `ssh` in the same spread, but I haven't watched that specific button work. And I have no olm build handy to watch the routes actually leave the client's table, though that follows from `remoteSubnets` being what the client installs.

One note on formatting: `server/lib/ip.ts` and `server/routers/siteResource/updateSiteResource.ts` were already failing `prettier --check` on `dev` before this branch. I left that alone rather than sweep unrelated reformatting into the diff — the lines this PR adds are prettier-clean.

Happy to rename the column, change where the UI switch lives, or split the messaging/query changes out if you'd rather take them separately.
