### PR TITLE
Performance: Handle badger cache invalidation and extend TTLs

### DIFF
--- a/server/lib/badgerCacheInvalidation.ts
+++ b/server/lib/badgerCacheInvalidation.ts
@@ -1,0 +1,68 @@
+import { localCache } from "#dynamic/lib/cache";
+import logger from "@server/logger";
+
+/**
+ * Invalidates the badger resource cache for a given domain.
+ * Call this when resource settings, policies, or auth methods change.
+ */
+export function invalidateResourceCache(fullDomain: string | null | undefined) {
+    if (!fullDomain) return;
+    const key = `resource:${fullDomain}`;
+    localCache.del(key);
+    logger.debug(`Invalidated badger resource cache: ${key}`);
+}
+
+/**
+ * Invalidates the badger rules cache for a given resource.
+ * Call this when resource rules are created, updated, or deleted.
+ */
+export function invalidateRulesCache(resourceId: number) {
+    const key = `rules:${resourceId}`;
+    localCache.del(key);
+    logger.debug(`Invalidated badger rules cache: ${key}`);
+}
+
+/**
+ * Invalidates all badger header auth cache entries for a resource.
+ * Call this when header auth settings change for a resource.
+ */
+export function invalidateHeaderAuthCache(resourceId: number) {
+    const prefix = `headerAuth:${resourceId}:`;
+    const allKeys = localCache.keys();
+    const matching = allKeys.filter((k) => k.startsWith(prefix));
+    if (matching.length > 0) {
+        localCache.del(matching);
+        logger.debug(
+            `Invalidated ${matching.length} badger headerAuth cache entries for resource ${resourceId}`
+        );
+    }
+}
+
+/**
+ * Invalidates a specific resource session from the cache.
+ * Call this when a resource session is explicitly deleted or invalidated.
+ */
+export function invalidateResourceSessionCache(sessionToken: string) {
+    const key = `session:${sessionToken}`;
+    localCache.del(key);
+    logger.debug(`Invalidated badger session cache: ${key}`);
+}
+
+/**
+ * Invalidates all user access cache entries for a given resource.
+ * Call this when role/user access permissions change for a resource.
+ */
+export function invalidateUserAccessCache(resourceId: number) {
+    const prefix = `userAccess:`;
+    const suffix = `:${resourceId}`;
+    const allKeys = localCache.keys();
+    const matching = allKeys.filter(
+        (k) => k.startsWith(prefix) && k.endsWith(suffix)
+    );
+    if (matching.length > 0) {
+        localCache.del(matching);
+        logger.debug(
+            `Invalidated ${matching.length} badger userAccess cache entries for resource ${resourceId}`
+        );
+    }
+}

--- a/server/routers/badger/verifySession.ts
+++ b/server/routers/badger/verifySession.ts
@@ -189,7 +189,7 @@ export async function verifyResourceSession(
             }
 
             resourceData = result;
-            localCache.set(resourceCacheKey, resourceData, 5);
+            localCache.set(resourceCacheKey, resourceData, 3600);
         }
 
         const {
@@ -451,7 +451,7 @@ export async function verifyResourceSession(
                     headerAuth.headerAuthHash
                 )
             ) {
-                localCache.set(clientHeaderAuthKey, clientHeaderAuth, 5);
+                localCache.set(clientHeaderAuthKey, clientHeaderAuth, 3600);
                 logger.debug("Resource allowed because header auth is valid");
 
                 logRequestAudit(
@@ -553,7 +553,7 @@ export async function verifyResourceSession(
                 );
 
                 resourceSession = result?.resourceSession;
-                localCache.set(sessionCacheKey, resourceSession, 5);
+                localCache.set(sessionCacheKey, resourceSession, 60);
             }
 
             if (resourceSession?.isRequestToken) {
@@ -956,7 +956,7 @@ async function allowAccessToken(
                 resource.resourceId
             );
             resourceSession = result?.resourceSession;
-            localCache.set(sessionCacheKey, resourceSession, 5);
+            localCache.set(sessionCacheKey, resourceSession, 60);
         }
 
         if (
@@ -1024,7 +1024,7 @@ async function getAccessTokenUserData(
         .limit(1);
 
     if (!user) {
-        localCache.set(cacheKey, null, 5);
+        localCache.set(cacheKey, null, 3600);
         return undefined;
     }
 
@@ -1268,7 +1268,7 @@ async function checkRules(
 
     if (!rules) {
         rules = await getResourceRules(resourceId);
-        localCache.set(ruleCacheKey, rules, 5);
+        localCache.set(ruleCacheKey, rules, 3600);
     }
 
     if (rules.length === 0) {

--- a/server/routers/badger/verifySession.ts
+++ b/server/routers/badger/verifySession.ts
@@ -189,7 +189,7 @@ export async function verifyResourceSession(
             }
 
             resourceData = result;
-            localCache.set(resourceCacheKey, resourceData, 3600);
+            localCache.set(resourceCacheKey, resourceData, 60);
         }
 
         const {
@@ -451,7 +451,7 @@ export async function verifyResourceSession(
                     headerAuth.headerAuthHash
                 )
             ) {
-                localCache.set(clientHeaderAuthKey, clientHeaderAuth, 3600);
+                localCache.set(clientHeaderAuthKey, clientHeaderAuth, 60);
                 logger.debug("Resource allowed because header auth is valid");
 
                 logRequestAudit(
@@ -1024,7 +1024,7 @@ async function getAccessTokenUserData(
         .limit(1);
 
     if (!user) {
-        localCache.set(cacheKey, null, 3600);
+        localCache.set(cacheKey, null, 60);
         return undefined;
     }
 
@@ -1268,7 +1268,7 @@ async function checkRules(
 
     if (!rules) {
         rules = await getResourceRules(resourceId);
-        localCache.set(ruleCacheKey, rules, 3600);
+        localCache.set(ruleCacheKey, rules, 60);
     }
 
     if (rules.length === 0) {

--- a/server/routers/resource/createResourceRule.ts
+++ b/server/routers/resource/createResourceRule.ts
@@ -13,6 +13,7 @@ import {
     getResourceRuleValueValidationError
 } from "@server/lib/validators";
 import { OpenAPITags, registry } from "@server/openApi";
+import { invalidateRulesCache } from "@server/lib/badgerCacheInvalidation";
 
 const createResourceRuleSchema = z.strictObject({
     action: z.enum(["ACCEPT", "DROP", "PASS"]),
@@ -199,6 +200,8 @@ export async function createResourceRule(
                 enabled
             })
             .returning();
+
+        invalidateRulesCache(resourceId);
 
         return response(res, {
             data: newRule,

--- a/server/routers/resource/deleteResource.ts
+++ b/server/routers/resource/deleteResource.ts
@@ -112,9 +112,8 @@ export async function deleteResource(
             );
         }
 
-        await runResourceDeleteSideEffects(deleteResult);
-
         invalidateResourceCache(deleteResult?.deletedResource?.fullDomain);
+        await runResourceDeleteSideEffects(deleteResult);
 
         return response(res, {
             data: null,

--- a/server/routers/resource/deleteResource.ts
+++ b/server/routers/resource/deleteResource.ts
@@ -13,6 +13,7 @@ import {
 } from "@server/lib/deleteResource";
 import { LimitId } from "@server/lib/billing";
 import { usageService } from "@server/lib/billing/usageService";
+import { invalidateResourceCache } from "@server/lib/badgerCacheInvalidation";
 
 const deleteResourceSchema = z.strictObject({
     resourceId: z.coerce.number().int().positive()
@@ -112,6 +113,8 @@ export async function deleteResource(
         }
 
         await runResourceDeleteSideEffects(deleteResult);
+
+        invalidateResourceCache(deleteResult?.deletedResource?.fullDomain);
 
         return response(res, {
             data: null,

--- a/server/routers/resource/deleteResource.ts
+++ b/server/routers/resource/deleteResource.ts
@@ -89,18 +89,17 @@ export async function deleteResource(
 
         const { resourceId } = parsedParams.data;
 
-        let deleteResult = null;
-
-        await db.transaction(async (trx) => {
-            deleteResult = await performDeleteResource(resourceId, trx);
-            if (deleteResult?.deletedResource?.orgId) {
+        const deleteResult = await db.transaction(async (trx) => {
+            const result = await performDeleteResource(resourceId, trx);
+            if (result?.deletedResource?.orgId) {
                 await usageService.add(
-                    deleteResult?.deletedResource?.orgId,
+                    result.deletedResource.orgId,
                     LimitId.PUBLIC_RESOURCES,
                     -1,
                     trx
                 );
             }
+            return result;
         });
 
         if (!deleteResult) {
@@ -113,7 +112,7 @@ export async function deleteResource(
         }
 
         await runResourceDeleteSideEffects(deleteResult);
-        invalidateResourceCache(deleteResult?.deletedResource?.fullDomain);
+        invalidateResourceCache(deleteResult.deletedResource?.fullDomain);
 
         return response(res, {
             data: null,

--- a/server/routers/resource/deleteResource.ts
+++ b/server/routers/resource/deleteResource.ts
@@ -112,8 +112,8 @@ export async function deleteResource(
             );
         }
 
-        invalidateResourceCache(deleteResult?.deletedResource?.fullDomain);
         await runResourceDeleteSideEffects(deleteResult);
+        invalidateResourceCache(deleteResult?.deletedResource?.fullDomain);
 
         return response(res, {
             data: null,

--- a/server/routers/resource/deleteResourceRule.ts
+++ b/server/routers/resource/deleteResourceRule.ts
@@ -9,6 +9,7 @@ import createHttpError from "http-errors";
 import logger from "@server/logger";
 import { fromError } from "zod-validation-error";
 import { OpenAPITags, registry } from "@server/openApi";
+import { invalidateRulesCache } from "@server/lib/badgerCacheInvalidation";
 
 const deleteResourceRuleSchema = z.strictObject({
     ruleId: z.coerce.number().int().positive(),
@@ -118,6 +119,8 @@ export async function deleteResourceRule(
                 );
             }
 
+            invalidateRulesCache(resourceId);
+
             return response(res, {
                 data: null,
                 success: true,
@@ -141,6 +144,8 @@ export async function deleteResourceRule(
                 )
             );
         }
+
+        invalidateRulesCache(resourceId);
 
         return response(res, {
             data: null,

--- a/server/routers/resource/updateResource.ts
+++ b/server/routers/resource/updateResource.ts
@@ -48,6 +48,11 @@ import { isLicensedOrSubscribed } from "#dynamic/lib/isLicencedOrSubscribed";
 import { tierMatrix } from "@server/lib/billing/tierMatrix";
 import { isSubscribed } from "#dynamic/lib/isSubscribed";
 import { applyInlinePolicyFields } from "./inlinePolicyFields";
+import {
+    invalidateResourceCache,
+    invalidateHeaderAuthCache,
+    invalidateUserAccessCache
+} from "@server/lib/badgerCacheInvalidation";
 
 const updateResourceParamsSchema = z.strictObject({
     resourceId: z.coerce.number().int().positive()
@@ -740,6 +745,10 @@ async function updateHttpResource(
             );
         }
 
+        invalidateResourceCache(resource.fullDomain);
+        invalidateHeaderAuthCache(resource.resourceId);
+        invalidateUserAccessCache(resource.resourceId);
+
         return response(res, {
             data: applyInlinePolicyFields(updatedResource[0], inlinePolicy),
             success: true,
@@ -763,6 +772,10 @@ async function updateHttpResource(
             )
         );
     }
+
+    invalidateResourceCache(resource.fullDomain);
+    invalidateHeaderAuthCache(resource.resourceId);
+    invalidateUserAccessCache(resource.resourceId);
 
     return response(res, {
         data: updatedResource[0],

--- a/server/routers/resource/updateResourceRule.ts
+++ b/server/routers/resource/updateResourceRule.ts
@@ -13,6 +13,7 @@ import {
     getResourceRuleValueValidationError,
     ResourceRuleMatchType
 } from "@server/lib/validators";
+import { invalidateRulesCache } from "@server/lib/badgerCacheInvalidation";
 import { OpenAPITags, registry } from "@server/openApi";
 
 // Define Zod schema for request parameters validation
@@ -284,6 +285,8 @@ export async function updateResourceRule(
                       )
                   )
                   .returning();
+
+        invalidateRulesCache(resourceId);
 
         return response(res, {
             data: updatedRule,


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description
Cache invalidation is immediate for the same process. This eliminates stale data for the common admin operations (updating resource settings, toggling rules) while dramatically reducing DB load on the hot request path.

- Create badgerCacheInvalidation module with helpers to invalidate specific cache entries
- Wire invalidation into updateResource and deleteResource (clears resource, headerAuth, userAccess caches)
- Wire invalidation into createResourceRule, updateResourceRule, deleteResourceRule
- Increase resource/rules/headerAuth cache TTLs

## How to test?

