### PR TITLE
Add guard on resource policy change

### DIFF
--- a/server/routers/resource/updateResource.ts
+++ b/server/routers/resource/updateResource.ts
@@ -498,7 +498,8 @@ async function updateHttpResource(
     }
 
     // catch when the resource policy changes or gets cleared
-    if (resource.resourcePolicyId != updateData.resourcePolicyId) {
+    if (updateData.resourcePolicyId !== undefined && 
+        resource.resourcePolicyId !== updateData.resourcePolicyId) {
         await clearResourceSpecificSettings(
             resource.resourceId,
             resource.orgId,


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description
Using `!=` instead of `!==` for comparing resourcePolicyId causes the comparison `number != undefined` to return `true`, incorrectly triggering `clearResourceSpecificSettings`.

## How to test?

