### PR TITLE
Fix: SSH settings page silently deletes extra SSH targets when resource is in push+site mode

### DIFF
--- a/server/routers/target/createTarget.ts
+++ b/server/routers/target/createTarget.ts
@@ -200,6 +200,28 @@ export async function createTarget(
             );
         }
 
+        if (resource.mode === "ssh") {
+            const isSingleSiteMode =
+                resource.authDaemonMode === "native" ||
+                (resource.pamMode === "push" && resource.authDaemonMode === "site");
+
+            if (isSingleSiteMode) {
+                const existingTargets = await db
+                    .select()
+                    .from(targets)
+                    .where(eq(targets.resourceId, resourceId));
+                
+                if (existingTargets.length > 0) {
+                    return next(
+                        createHttpError(
+                            HttpCode.BAD_REQUEST,
+                            "Only one target is allowed for SSH resources in push+site or native mode"
+                        )
+                    );
+                }
+            }
+        }
+
         const siteId = targetData.siteId;
 
         const [site] = await db

--- a/src/app/[orgId]/settings/resources/public/[niceId]/ssh/page.tsx
+++ b/src/app/[orgId]/settings/resources/public/[niceId]/ssh/page.tsx
@@ -159,7 +159,7 @@ function SshServerForm({
                 ? String((resource as { authDaemonPort?: number }).authDaemonPort)
                 : "22123",
             selectedSites:
-                isNativeInitially || useSingleSiteOnLoad
+                isNativeInitially
                     ? []
                     : targets.map((target) => ({
                           siteId: target.siteId,
@@ -170,9 +170,7 @@ function SshServerForm({
                 useSingleSiteOnLoad && firstTarget
                     ? {
                           siteId: firstTarget.siteId,
-                          name:
-                              firstTarget.siteName ??
-                              String(firstTarget.siteId),
+                          name: firstTarget.siteName ?? String(firstTarget.siteId),
                           type: "newt" as const
                       }
                     : null,


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description
When useSingleSiteOnLoad=true, the form initializes selectedSites=[] and selectedSite=firstTarget, discarding all other targets from form state. On save, these targets are deleted without any user warning.

## How to test?

