### PR TITLE
Fix: Badger: Exchanging a request token fails to delete the request token from the database

### DIFF
--- a/server/routers/badger/exchangeSession.ts
+++ b/server/routers/badger/exchangeSession.ts
@@ -4,7 +4,7 @@ import createHttpError from "http-errors";
 import { z } from "zod";
 import { fromError } from "zod-validation-error";
 import logger from "@server/logger";
-import { resourceAccessToken, resources, sessions } from "@server/db";
+import { resourceAccessToken, resources, resourceSessions } from "@server/db";
 import { db } from "@server/db";
 import { and, eq, inArray, or, sql } from "drizzle-orm";
 import {
@@ -12,7 +12,6 @@ import {
     serializeResourceSessionCookie,
     validateResourceSessionToken
 } from "@server/auth/sessions/resource";
-import { resourceAccessToken, resources, resourceSessions } from "@server/db";
 import {
     generateSessionToken,
     SESSION_COOKIE_EXPIRES

--- a/server/routers/badger/exchangeSession.ts
+++ b/server/routers/badger/exchangeSession.ts
@@ -12,6 +12,7 @@ import {
     serializeResourceSessionCookie,
     validateResourceSessionToken
 } from "@server/auth/sessions/resource";
+import { resourceAccessToken, resources, resourceSessions } from "@server/db";
 import {
     generateSessionToken,
     SESSION_COOKIE_EXPIRES
@@ -128,7 +129,7 @@ export async function exchangeSession(
             );
         }
 
-        await db.delete(sessions).where(eq(sessions.sessionId, requestToken));
+        await db.delete(resourceSessions).where(eq(resourceSessions.sessionId, requestSession.sessionId));
 
         const token = generateSessionToken();
 


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description
Line 131 attempts to delete from the wrong table (sessions - user sessions) instead of resourceSessions, and uses the wrong identifier (raw token instead of hashed sessionId)

## How to test?

