### PR TITLE
Fix: License.check can fail silently

### DIFF
--- a/server/private/license/license.ts
+++ b/server/private/license/license.ts
@@ -149,12 +149,8 @@ LQIDAQAB
         }
 
         // Count used sites and users for license comparison
-        const [siteCountRes] = await db
-            .select({ value: count() })
-            .from(sites);
-        const [userCountRes] = await db
-            .select({ value: count() })
-            .from(users);
+        const [siteCountRes] = await db.select({ value: count() }).from(sites);
+        const [userCountRes] = await db.select({ value: count() }).from(users);
 
         const status: LicenseStatus = {
             hostId: this.hostMeta.hostMetaId,
@@ -277,9 +273,7 @@ LQIDAQAB
                             `Allowing failure. Will retry one more time at next run interval.`
                         );
                         // return last known good status
-                        return this.statusCache.get(
-                            this.statusKey
-                        ) as LicenseStatus;
+                        return status;
                     } else {
                         // Subsequent failures: fail abruptly
                         throw e;
@@ -368,10 +362,7 @@ LQIDAQAB
                 }
 
                 // Only consider quantity if defined and >= 0 (quantity = users, quantity_2 = sites)
-                if (
-                    cached.quantity_2 !== undefined &&
-                    cached.quantity_2 >= 0
-                ) {
+                if (cached.quantity_2 !== undefined && cached.quantity_2 >= 0) {
                     status.maxSites =
                         (status.maxSites ?? 0) + cached.quantity_2;
                 }
@@ -561,7 +552,7 @@ LQIDAQAB
                     // Calculate exponential backoff delay
                     const retryDelay = Math.floor(
                         initialRetryDelay *
-                        Math.pow(exponentialFactor, attempt - 1)
+                            Math.pow(exponentialFactor, attempt - 1)
                     );
 
                     logger.debug(

--- a/server/private/license/license.ts
+++ b/server/private/license/license.ts
@@ -272,8 +272,13 @@ LQIDAQAB
                         logger.error(
                             `Allowing failure. Will retry one more time at next run interval.`
                         );
-                        // return last known good status
-                        return status;
+                        // Fall back to last known good status if we have
+                        // one cached; otherwise return the freshly built
+                        // status (with defaults) rather than undefined.
+                        const lastKnownStatus = this.statusCache.get(
+                            this.statusKey
+                        ) as LicenseStatus | undefined;
+                        return lastKnownStatus ?? status;
                     } else {
                         // Subsequent failures: fail abruptly
                         throw e;


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description
`License.check()` returns undefined instead of LicenseStatus if/when phone-home fails after `forceRecheck()` clears cache.

## How to test?

