### PR TITLE
Fix: ensuring only internal users can request password resets.

### DIFF
--- a/server/routers/auth/requestPasswordReset.ts
+++ b/server/routers/auth/requestPasswordReset.ts
@@ -6,7 +6,7 @@ import HttpCode from "@server/types/HttpCode";
 import { response } from "@server/lib/response";
 import { db } from "@server/db";
 import { passwordResetTokens, users } from "@server/db";
-import { eq } from "drizzle-orm";
+import { eq, and } from "drizzle-orm";
 import { alphabet, generateRandomString, sha256 } from "oslo/crypto";
 import { createDate } from "oslo";
 import logger from "@server/logger";

--- a/server/routers/auth/requestPasswordReset.ts
+++ b/server/routers/auth/requestPasswordReset.ts
@@ -49,7 +49,12 @@ export async function requestPasswordReset(
         const existingUser = await db
             .select()
             .from(users)
-            .where(eq(users.email, email));
+            .where(
+                and(
+                    eq(users.email, email),
+                    eq(users.type, UserType.Internal)
+                )
+            );
 
         if (!existingUser || !existingUser.length) {
             await randomDelay(2000);


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description
The user lookup queries by email without filtering by type, then only checks existingUser[0].type. When multiple users share the same email (OIDC + internal), the code checks the wrong user.

## How to test?

