### PR TITLE
Typo: Update verifyApiKeyAccess to use generated apiKey.apiKeyOrg?.orgId data

### DIFF
--- a/server/middlewares/verifyApiKeyAccess.ts
+++ b/server/middlewares/verifyApiKeyAccess.ts
@@ -70,13 +70,8 @@ export async function verifyApiKeyAccess(
             );
         }
 
-        if (!apiKeyOrg.orgId) {
-            return next(
-                createHttpError(
-                    HttpCode.INTERNAL_SERVER_ERROR,
-                    `API key with ID ${apiKeyId} does not have an organization ID`
-                )
-            );
+        if (!apiKey.apiKeyOrg?.orgId) {
+            return next(createHttpError(HttpCode.INTERNAL_SERVER_ERROR, `API key with ID ${apiKeyId} does not have an organization ID`));
         }
 
         if (!req.userOrg) {
@@ -86,7 +81,7 @@ export async function verifyApiKeyAccess(
                 .where(
                     and(
                         eq(userOrgs.userId, userId),
-                        eq(userOrgs.orgId, apiKeyOrg.orgId)
+                        eq(userOrgs.orgId, apiKey.apiKeyOrg.orgId)
                     )
                 )
                 .limit(1);


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description
verifyApiKeyAccess.ts references apiKeyOrg.orgId (the imported Drizzle schema table column) instead of apiKey.apiKeyOrg.orgId (the actual joined data).

## How to test?

