### PR TITLE
Fix TypeError: ensures more than 1 parts[] exists in signup page

### DIFF
--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -44,7 +44,7 @@ export default async function Page(props: {
     let inviteToken;
     if (searchParams.redirect && isInvite) {
         const parts = searchParams.redirect.split("token=");
-        if (parts.length) {
+        if (parts.length > 1) {
             const token = parts[1];
             const tokenParts = token.split("-");
             if (tokenParts.length === 2) {


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description
The page crashes with a TypeError instead of gracefully handling malformed redirect URLs.

## How to test?

Detected with a linter. no LLM. Fix by me.
