### PR TITLE
fix(i18n): improve Accept-Language matching and fix zh-TW detection (#3480)

### DIFF
--- a/src/services/locale.ts
+++ b/src/services/locale.ts
@@ -10,6 +10,51 @@ import { authCookieHeader } from "@app/lib/api/cookies";
 const COOKIE_NAME = "NEXT_LOCALE";
 const COOKIE_MAX_AGE = 365 * 24 * 60 * 60; // 1 year in seconds
 
+function matchLocaleFromAcceptLanguage(
+    acceptLang: string | null | undefined
+): Locale | null {
+    if (!acceptLang) return null;
+
+    const parsedLanguages = acceptLang
+        .split(",")
+        .map((langStr) => {
+            const [rawTag, ...params] = langStr.trim().split(";");
+            const tag = rawTag.trim();
+            let q = 1.0;
+            for (const param of params) {
+                const [key, val] = param.trim().split("=");
+                if (key === "q" && val) {
+                    const parsedQ = parseFloat(val);
+                    if (!isNaN(parsedQ)) {
+                        q = parsedQ;
+                    }
+                }
+            }
+            return { tag, q };
+        })
+        .filter((item) => item.tag.length > 0 && item.q > 0)
+        .sort((a, b) => b.q - a.q);
+
+    for (const { tag } of parsedLanguages) {
+        const exactMatch = locales.find(
+            (locale: Locale) => locale.toLowerCase() === tag.toLowerCase()
+        );
+        if (exactMatch) {
+            return exactMatch;
+        }
+
+        const baseTag = tag.split("-")[0].toLowerCase();
+        const prefixMatch = locales.find(
+            (locale: Locale) => locale.split("-")[0].toLowerCase() === baseTag
+        );
+        if (prefixMatch) {
+            return prefixMatch;
+        }
+    }
+
+    return null;
+}
+
 export async function getUserLocale(): Promise<Locale> {
     const cookieLocale = (await cookies()).get(COOKIE_NAME)?.value;
 
@@ -46,16 +91,9 @@ export async function getUserLocale(): Promise<Locale> {
     const headerList = await headers();
     const acceptLang = headerList.get("accept-language");
 
-    if (acceptLang) {
-        const browserLang = acceptLang.split(",")[0];
-        const matched = locales.find((locale) =>
-            browserLang
-                .toLowerCase()
-                .startsWith(locale.split("-")[0].toLowerCase())
-        );
-        if (matched) {
-            return matched;
-        }
+    const matchedLocale = matchLocaleFromAcceptLanguage(acceptLang);
+    if (matchedLocale) {
+        return matchedLocale;
     }
 
     return defaultLocale;

--- a/src/services/locale.ts
+++ b/src/services/locale.ts
@@ -17,7 +17,7 @@ function matchLocaleFromAcceptLanguage(
 
     const parsedLanguages = acceptLang
         .split(",")
-        .map((langStr) => {
+        .map((langStr, index) => {
             const [rawTag, ...params] = langStr.trim().split(";");
             const tag = rawTag.trim();
             let q = 1.0;
@@ -30,10 +30,10 @@ function matchLocaleFromAcceptLanguage(
                     }
                 }
             }
-            return { tag, q };
+            return { tag, q, index };
         })
         .filter((item) => item.tag.length > 0 && item.q > 0)
-        .sort((a, b) => b.q - a.q);
+        .sort((a, b) => b.q - a.q || a.index - b.index);
 
     for (const { tag } of parsedLanguages) {
         const exactMatch = locales.find(


### PR DESCRIPTION
### Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited, perpetual license to use, modify, and redistribute these contributions under any license terms chosen by the project maintainers.

---

### Description
Fixes #3480.

When a user visits with an `Accept-Language` header containing regional locales like `zh-TW` (e.g. `zh-TW,zh;q=0.9,en-US;q=0.8,en;q=0.7,ja;q=0.6`), the previous implementation matched the first locale whose prefix matched (`zh-CN` comes earlier in the `locales` array).

This PR:
- Parses `Accept-Language` tags with quality factors (`q`) and sorts them by user preference.
- Sequentially matches each preferred tag: first looking for an exact locale match (e.g. `zh-TW` -> `zh-TW`), and falling back to a base language group match (e.g. `fr-CA` -> `fr-FR`).
- Falls back to `defaultLocale` (`en-US`) when no match is available.