### PR TITLE
fix(site): include org subnet prefix when auto-allocating site address (#3523)

### DIFF
--- a/server/routers/site/createSite.ts
+++ b/server/routers/site/createSite.ts
@@ -263,7 +263,7 @@ export async function createSite(
             const { value: newClientAddress, release } =
                 await getNextAvailableClientSubnet(orgId);
             releaseSubnetLock = release;
-            updatedAddress = newClientAddress.split("/")[0];
+            updatedAddress = `${newClientAddress.split("/")[0]}/${org.subnet ? org.subnet.split("/")[1] : "32"}`;
         }
 
         let newSite: Site | undefined;


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description
Fixes #3523.

When creating a site via the Integration API (`PUT /v1/org/{orgId}/site`) without specifying an address in the request body, `createSite.ts` allocated the next available address via `getNextAvailableClientSubnet()`, but truncated the subnet prefix (`newClientAddress.split("/")[0]`), storing only the bare IP (e.g. `100.90.128.2` instead of `100.90.128.2/20`).

This resulted in Newt failing to configure the WireGuard interface on connection with:
`Failed to ensure WireGuard interface: invalid IP address format: 100.90.128.2`

This change appends the organization's subnet prefix length when auto-allocating the site address in `createSite.ts`, matching the behavior in `registerNewt.ts`, `calculateUserClientsForOrgs.ts`, and manual address input.

## How to test?
1. Send a request to create a Newt site via the Integration API without specifying an `address`:
   ```http
   PUT /v1/org/{orgId}/site
   Content-Type: application/json

   {
     "name": "test-site",
     "type": "newt"
   }