### PR TITLE
feat: per-site-resource opt-out from advertising the destination as a client route

### DIFF
--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -2895,6 +2895,8 @@
     "privateResourceAllowIcmpPing": "Allow ICMP Ping",
     "privateResourceNetworkAccess": "Network Access",
     "privateResourceNetworkAccessDescription": "Control TCP/UDP port access and whether ICMP ping is allowed for this resource.",
+    "privateResourceAdvertiseDestination": "Advertise Destination as a Client Route",
+    "privateResourceAdvertiseDestinationDescription": "Adds a route to the destination address on connected clients. Turn this off if clients already reach the destination another way; the resource stays reachable through its alias address.",
     "hostSettings": "Host",
     "cidrSettings": "CIDR",
     "createInternalResourceDialogResourceProperties": "Resource Properties",

--- a/server/db/pg/schema/schema.ts
+++ b/server/db/pg/schema/schema.ts
@@ -502,6 +502,12 @@ export const siteResources = pgTable(
             .notNull()
             .default("*"),
         disableIcmp: boolean("disableIcmp").notNull().default(false),
+        // When false, host/ssh resources are still reachable through their
+        // aliasAddress but their destination is not sent to clients as a
+        // route. Lets a client keep a pre-existing path to the destination.
+        advertiseDestination: boolean("advertiseDestination")
+            .notNull()
+            .default(true),
         authDaemonPort: integer("authDaemonPort").default(22123),
         pamMode: varchar("pamMode", { length: 32 })
             .$type<"passthrough" | "push">()

--- a/server/db/sqlite/schema/schema.ts
+++ b/server/db/sqlite/schema/schema.ts
@@ -492,6 +492,12 @@ export const siteResources = sqliteTable("siteResources", {
     disableIcmp: integer("disableIcmp", { mode: "boolean" })
         .notNull()
         .default(false),
+    // When false, host/ssh resources are still reachable through their
+    // aliasAddress but their destination is not sent to clients as a route.
+    // Lets a client keep a pre-existing path to the destination.
+    advertiseDestination: integer("advertiseDestination", { mode: "boolean" })
+        .notNull()
+        .default(true),
     authDaemonPort: integer("authDaemonPort").default(22123),
     pamMode: text("pamMode")
         .$type<"passthrough" | "push">()

--- a/server/lib/blueprints/privateResources.ts
+++ b/server/lib/blueprints/privateResources.ts
@@ -278,6 +278,8 @@ export async function updatePrivateResources(
                         (resourceData.mode == "http" || isInference
                             ? true
                             : false), // default to true for http/inference resources, otherwise false
+                    advertiseDestination:
+                        resourceData["advertise-destination"] ?? true,
                     tcpPortRangeString:
                         resourceData.mode == "http" || isInference
                             ? "443,80"
@@ -607,6 +609,8 @@ export async function updatePrivateResources(
                         (resourceData.mode == "http" || isInference
                             ? true
                             : false), // default to true for http/inference resources, otherwise false
+                    advertiseDestination:
+                        resourceData["advertise-destination"] ?? true,
                     tcpPortRangeString:
                         resourceData.mode == "http" || isInference
                             ? "443,80"

--- a/server/lib/blueprints/types.ts
+++ b/server/lib/blueprints/types.ts
@@ -572,6 +572,7 @@ export const PrivateResourceSchema = z
         "tcp-ports": portRangeStringSchema.optional().default("*"),
         "udp-ports": portRangeStringSchema.optional().default("*"),
         "disable-icmp": z.boolean().optional().default(false),
+        "advertise-destination": z.boolean().optional().default(true),
         "full-domain": z.string().optional(),
         ssl: z.boolean().optional(),
         scheme: z.enum(["http", "https"]).optional().nullable(),

--- a/server/lib/ip.test.ts
+++ b/server/lib/ip.test.ts
@@ -1,5 +1,13 @@
-import { cidrToRange, findNextAvailableCidr } from "./ip";
-import { assertEquals } from "@test/assert";
+// ./ip evaluates zod .openapi() schemas at module scope, so the extension
+// has to be registered before it is imported
+import "@server/extendZod";
+import {
+    cidrToRange,
+    findNextAvailableCidr,
+    generateRemoteSubnets
+} from "./ip";
+import type { SiteResource } from "@server/db";
+import { assertEquals, assertEqualsObj } from "@test/assert";
 
 // Test cases
 function testFindNextAvailableCidr() {
@@ -133,10 +141,90 @@ function testFindNextAvailableCidr() {
 //     console.log("All cidrToRange tests passed!");
 // }
 
+function makeSiteResource(overrides: Partial<SiteResource>): SiteResource {
+    return {
+        enabled: true,
+        mode: "host",
+        destination: "192.168.1.10",
+        ...overrides
+    } as SiteResource;
+}
+
+function testGenerateRemoteSubnets() {
+    console.log("Running generateRemoteSubnets tests...");
+
+    // Test 0: a host resource is advertised as a /32 by default
+    {
+        const result = generateRemoteSubnets([
+            makeSiteResource({ advertiseDestination: true })
+        ]);
+        assertEqualsObj(
+            result,
+            ["192.168.1.10/32"],
+            "Advertising host resource should produce a /32"
+        );
+    }
+
+    // Test 1: opting out withdraws the /32
+    {
+        const result = generateRemoteSubnets([
+            makeSiteResource({ advertiseDestination: false })
+        ]);
+        assertEqualsObj(
+            result,
+            [],
+            "Non-advertising host resource should produce no subnet"
+        );
+    }
+
+    // Test 2: the same holds for ssh resources
+    {
+        const result = generateRemoteSubnets([
+            makeSiteResource({ mode: "ssh", advertiseDestination: false })
+        ]);
+        assertEqualsObj(
+            result,
+            [],
+            "Non-advertising ssh resource should produce no subnet"
+        );
+    }
+
+    // Test 3: existing rows, which predate the column, keep advertising
+    {
+        const result = generateRemoteSubnets([
+            makeSiteResource({ advertiseDestination: undefined as never })
+        ]);
+        assertEqualsObj(
+            result,
+            ["192.168.1.10/32"],
+            "Resource without the flag set should still advertise"
+        );
+    }
+
+    // Test 4: only the opted-out resource is dropped
+    {
+        const result = generateRemoteSubnets([
+            makeSiteResource({ advertiseDestination: false }),
+            makeSiteResource({
+                destination: "192.168.1.11",
+                advertiseDestination: true
+            })
+        ]);
+        assertEqualsObj(
+            result,
+            ["192.168.1.11/32"],
+            "Only the non-advertising resource should be dropped"
+        );
+    }
+
+    console.log("All generateRemoteSubnets tests passed!");
+}
+
 // Run all tests
 try {
     // testCidrToRange();
     testFindNextAvailableCidr();
+    testGenerateRemoteSubnets();
     console.log("All tests passed successfully!");
 } catch (error) {
     console.error("Test failed:", error);

--- a/server/lib/ip.ts
+++ b/server/lib/ip.ts
@@ -507,6 +507,10 @@ export function generateRemoteSubnets(
                 return parseResult.success;
             }
             if (sr.mode === "host" || sr.mode === "ssh") {
+                // the resource is still served through its aliasAddress by
+                // generateSubnetProxyTargetV2, we just don't hand the client a
+                // route to the destination itself
+                if (sr.advertiseDestination === false) return false;
                 // check if its a valid IP using zod
                 const ipSchema = z.union([z.ipv4(), z.ipv6()]);
                 const parseResult = ipSchema.safeParse(sr.destination);

--- a/server/lib/rebuildClientAssociations.ts
+++ b/server/lib/rebuildClientAssociations.ts
@@ -1636,6 +1636,9 @@ export async function handleMessagingForUpdatedSiteResource(
                         siteResources.destination,
                         existingSiteResource.destination
                     ),
+                    // a sibling that doesn't advertise its destination isn't
+                    // keeping the route alive, so it must not block removal
+                    eq(siteResources.advertiseDestination, true),
                     ne(
                         siteResources.siteResourceId,
                         existingSiteResource.siteResourceId
@@ -1854,9 +1857,16 @@ export async function handleMessagingForUpdatedSiteResource(
     const enabledChanged =
         existingSiteResource &&
         existingSiteResource.enabled !== updatedSiteResource.enabled;
+    // Only affects what generateRemoteSubnets emits, so this drives the peer
+    // data (client route) update but not the newt targets, which are keyed off
+    // the alias address and are unchanged by it.
+    const advertiseDestinationChanged =
+        existingSiteResource &&
+        existingSiteResource.advertiseDestination !==
+            updatedSiteResource.advertiseDestination;
 
     logger.debug(
-        `handleMessagingForUpdatedSiteResource: change flags destinationChanged=${Boolean(destinationChanged)} destinationPortChanged=${Boolean(destinationPortChanged)} aliasChanged=${Boolean(aliasChanged)} fullDomainChanged=${Boolean(fullDomainChanged)} sslChanged=${Boolean(sslChanged)} portRangesChanged=${Boolean(portRangesChanged)} enabledChanged=${Boolean(enabledChanged)}`
+        `handleMessagingForUpdatedSiteResource: change flags destinationChanged=${Boolean(destinationChanged)} destinationPortChanged=${Boolean(destinationPortChanged)} aliasChanged=${Boolean(aliasChanged)} fullDomainChanged=${Boolean(fullDomainChanged)} sslChanged=${Boolean(sslChanged)} portRangesChanged=${Boolean(portRangesChanged)} enabledChanged=${Boolean(enabledChanged)} advertiseDestinationChanged=${Boolean(advertiseDestinationChanged)}`
     );
 
     // if the existingSiteResource is undefined (new resource) we don't need to do anything here, the rebuild above handled it all
@@ -1868,7 +1878,8 @@ export async function handleMessagingForUpdatedSiteResource(
         sslChanged ||
         portRangesChanged ||
         destinationPortChanged ||
-        enabledChanged
+        enabledChanged ||
+        advertiseDestinationChanged
     ) {
         const shouldUpdateTargets =
             destinationChanged ||
@@ -1953,7 +1964,9 @@ export async function handleMessagingForUpdatedSiteResource(
                     clientId: client.clientId,
                     siteId,
                     remoteSubnets:
-                        destinationChanged || enabledChanged
+                        destinationChanged ||
+                        enabledChanged ||
+                        advertiseDestinationChanged
                             ? {
                                   oldRemoteSubnets:
                                       !oldDestinationStillInUseBySite

--- a/server/routers/siteResource/createSiteResource.ts
+++ b/server/routers/siteResource/createSiteResource.ts
@@ -78,6 +78,11 @@ const createSiteResourceSchema = z
         tcpPortRangeString: portRangeStringSchema,
         udpPortRangeString: portRangeStringSchema,
         disableIcmp: z.boolean().optional(),
+        advertiseDestination: z.boolean().optional().openapi({
+            description:
+                "Only applies to host and ssh resources. When false the resource is still reachable through its alias address, but its destination is not installed as a route on the client. Defaults to true.",
+            example: true
+        }),
         authDaemonPort: z.int().positive().optional(),
         authDaemonMode: z.enum(["site", "remote", "native"]).optional(),
         pamMode: z.enum(["passthrough", "push"]).optional(),
@@ -331,6 +336,7 @@ export async function createSiteResource(
             tcpPortRangeString,
             udpPortRangeString,
             disableIcmp,
+            advertiseDestination,
             authDaemonPort,
             authDaemonMode,
             pamMode,
@@ -609,6 +615,9 @@ export async function createSiteResource(
                         (mode == "http" || mode == "ssh" || mode == "inference"
                             ? true
                             : false), // default to true for http resources, otherwise false
+                    ...(advertiseDestination !== undefined && {
+                        advertiseDestination
+                    }),
                     domainId,
                     subdomain: finalSubdomain,
                     fullDomain,

--- a/server/routers/siteResource/listAllSiteResourcesByOrg.ts
+++ b/server/routers/siteResource/listAllSiteResourcesByOrg.ts
@@ -205,6 +205,7 @@ function querySiteResourcesBase() {
             tcpPortRangeString: siteResources.tcpPortRangeString,
             udpPortRangeString: siteResources.udpPortRangeString,
             disableIcmp: siteResources.disableIcmp,
+            advertiseDestination: siteResources.advertiseDestination,
             authDaemonMode: siteResources.authDaemonMode,
             authDaemonPort: siteResources.authDaemonPort,
             pamMode: siteResources.pamMode,

--- a/server/routers/siteResource/updateSiteResource.ts
+++ b/server/routers/siteResource/updateSiteResource.ts
@@ -75,6 +75,11 @@ const updateSiteResourceSchema = z
         tcpPortRangeString: portRangeStringSchema,
         udpPortRangeString: portRangeStringSchema,
         disableIcmp: z.boolean().optional(),
+        advertiseDestination: z.boolean().optional().openapi({
+            description:
+                "Only applies to host and ssh resources. When false the resource is still reachable through its alias address, but its destination is not installed as a route on the client. Defaults to true.",
+            example: true
+        }),
         authDaemonPort: z.int().positive().nullish(),
         authDaemonMode: z.enum(["site", "remote", "native"]).optional(),
         pamMode: z.enum(["passthrough", "push"]).optional(),
@@ -329,6 +334,7 @@ export async function updateSiteResource(
             tcpPortRangeString,
             udpPortRangeString,
             disableIcmp,
+            advertiseDestination,
             authDaemonPort,
             authDaemonMode,
             pamMode,
@@ -575,6 +581,7 @@ export async function updateSiteResource(
                                   ? true
                                   : false)
                             : disableIcmp,
+                    advertiseDestination,
                     domainId,
                     subdomain: finalSubdomain,
                     fullDomain,

--- a/src/app/[orgId]/settings/resources/private/[niceId]/host/page.tsx
+++ b/src/app/[orgId]/settings/resources/private/[niceId]/host/page.tsx
@@ -21,7 +21,10 @@ import { useActionState, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { PrivateResourceSitesField } from "@app/components/PrivateResourceSitesField";
-import { PrivateResourceHostDestinationFields } from "@app/components/PrivateResourceDestinationFields";
+import {
+    PrivateResourceAdvertiseDestinationField,
+    PrivateResourceHostDestinationFields
+} from "@app/components/PrivateResourceDestinationFields";
 import { PrivateResourcePortRanges } from "@app/components/PrivateResourcePortRanges";
 import { useSaveSiteResource } from "@app/hooks/useSaveSiteResource";
 import {
@@ -51,6 +54,7 @@ export default function PrivateResourceHostPage() {
             tcpPortRangeString: siteResource.tcpPortRangeString ?? "*",
             udpPortRangeString: siteResource.udpPortRangeString ?? "*",
             disableIcmp: siteResource.disableIcmp ?? false,
+            advertiseDestination: siteResource.advertiseDestination ?? true,
             authDaemonMode: siteResource.authDaemonMode ?? "site",
             authDaemonPort: siteResource.authDaemonPort ?? null
         }
@@ -69,6 +73,7 @@ export default function PrivateResourceHostPage() {
             tcpPortRangeString: data.tcpPortRangeString,
             udpPortRangeString: data.udpPortRangeString,
             disableIcmp: data.disableIcmp,
+            advertiseDestination: data.advertiseDestination,
             authDaemonMode: data.authDaemonMode,
             authDaemonPort: data.authDaemonPort
         });
@@ -109,6 +114,12 @@ export default function PrivateResourceHostPage() {
                                         <PrivateResourceHostDestinationFields
                                             control={asAnyControl(form.control)}
                                             watch={asAnyWatch(form.watch)}
+                                        />
+                                    </SettingsFormCell>
+
+                                    <SettingsFormCell span="full">
+                                        <PrivateResourceAdvertiseDestinationField
+                                            control={asAnyControl(form.control)}
                                         />
                                     </SettingsFormCell>
 

--- a/src/app/[orgId]/settings/resources/private/[niceId]/ssh/page.tsx
+++ b/src/app/[orgId]/settings/resources/private/[niceId]/ssh/page.tsx
@@ -9,6 +9,7 @@ import {
     SettingsSectionForm,
     SettingsSectionHeader,
     SettingsSectionTitle,
+    SettingsFormCell,
     SettingsFormGrid
 } from "@app/components/Settings";
 import { SshServerSettingsFields } from "@app/components/SshServerSettingsFields";
@@ -24,6 +25,7 @@ import { useActionState, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { PrivateResourceSshFields } from "@app/components/PrivateResourceSshFields";
+import { PrivateResourceAdvertiseDestinationField } from "@app/components/PrivateResourceDestinationFields";
 import type { Selectedsite } from "@app/components/site-selector";
 import { useSaveSiteResource } from "@app/hooks/useSaveSiteResource";
 import {
@@ -69,7 +71,8 @@ export default function PrivateResourceSshPage() {
                   : "site",
             authDaemonPort: siteResource.authDaemonPort
                 ? String(siteResource.authDaemonPort)
-                : "22123"
+                : "22123",
+            advertiseDestination: siteResource.advertiseDestination ?? true
         }
     });
 
@@ -139,7 +142,8 @@ export default function PrivateResourceSshPage() {
             destinationPort: isNative ? null : data.destinationPort,
             authDaemonMode: effectiveAuthDaemonMode,
             authDaemonPort: effectiveAuthDaemonPort,
-            pamMode: data.pamMode
+            pamMode: data.pamMode,
+            advertiseDestination: data.advertiseDestination
         });
     }, null);
 
@@ -193,6 +197,14 @@ export default function PrivateResourceSshPage() {
                                     embedInParentGrid
                                     isNativeSsh={isNative}
                                 />
+                                {!isNative && (
+                                    <SettingsFormCell span="full">
+                                        <PrivateResourceAdvertiseDestinationField
+                                            control={asAnyControl(form.control)}
+                                            id="private-ssh-edit-advertise-destination"
+                                        />
+                                    </SettingsFormCell>
+                                )}
                             </SettingsFormGrid>
                         </SettingsSectionForm>
                     </SettingsSectionBody>

--- a/src/app/[orgId]/settings/resources/private/create/page.tsx
+++ b/src/app/[orgId]/settings/resources/private/create/page.tsx
@@ -53,6 +53,7 @@ import { PrivateResourceHttpFields } from "@app/components/PrivateResourceHttpFi
 import { PrivateResourceSshFields } from "@app/components/PrivateResourceSshFields";
 import { PrivateResourcePortRanges } from "@app/components/PrivateResourcePortRanges";
 import {
+    PrivateResourceAdvertiseDestinationField,
     PrivateResourceAliasField,
     PrivateResourceCidrDestinationField,
     PrivateResourceHostDestinationFields
@@ -112,7 +113,8 @@ export default function CreatePrivateResourcePage() {
             tcpPortRangeString: "*",
             udpPortRangeString: "*",
             disableIcmp: false,
-            providerIds: []
+            providerIds: [],
+            advertiseDestination: true
         }
     });
 
@@ -450,6 +452,18 @@ export default function CreatePrivateResourcePage() {
                                                 )}
                                                 watch={asAnyWatch(form.watch)}
                                                 labelPrefix="create"
+                                            />
+                                        </SettingsFormCell>
+                                    )}
+
+                                    {(mode === "host" ||
+                                        (mode === "ssh" && !isNativeSsh)) && (
+                                        <SettingsFormCell span="full">
+                                            <PrivateResourceAdvertiseDestinationField
+                                                control={asAnyControl(
+                                                    form.control
+                                                )}
+                                                id="create-private-resource-advertise-destination"
                                             />
                                         </SettingsFormCell>
                                     )}

--- a/src/app/[orgId]/settings/resources/private/page.tsx
+++ b/src/app/[orgId]/settings/resources/private/page.tsx
@@ -91,6 +91,7 @@ export default async function ClientResourcesPage(
                 tcpPortRangeString: siteResource.tcpPortRangeString || null,
                 udpPortRangeString: siteResource.udpPortRangeString || null,
                 disableIcmp: siteResource.disableIcmp || false,
+                advertiseDestination: siteResource.advertiseDestination ?? true,
                 authDaemonMode: siteResource.authDaemonMode ?? null,
                 authDaemonPort: siteResource.authDaemonPort ?? null,
                 pamMode: siteResource.pamMode ?? null,

--- a/src/components/PrivateResourceDestinationFields.tsx
+++ b/src/components/PrivateResourceDestinationFields.tsx
@@ -10,8 +10,42 @@ import {
     FormMessage
 } from "@app/components/ui/form";
 import { Input } from "@app/components/ui/input";
+import { SwitchInput } from "@app/components/SwitchInput";
 import { useTranslations } from "next-intl";
 import type { Control, UseFormWatch } from "react-hook-form";
+
+export function PrivateResourceAdvertiseDestinationField({
+    control,
+    id = "private-resource-advertise-destination"
+}: {
+    control: Control<any>;
+    id?: string;
+}) {
+    const t = useTranslations();
+
+    return (
+        <FormField
+            control={control}
+            name="advertiseDestination"
+            render={({ field }) => (
+                <FormItem>
+                    <FormControl>
+                        <SwitchInput
+                            id={id}
+                            label={t("privateResourceAdvertiseDestination")}
+                            description={t(
+                                "privateResourceAdvertiseDestinationDescription"
+                            )}
+                            checked={field.value ?? true}
+                            onCheckedChange={field.onChange}
+                        />
+                    </FormControl>
+                    <FormMessage />
+                </FormItem>
+            )}
+        />
+    );
+}
 
 type PrivateResourceAliasFieldProps = {
     control: Control<any>;

--- a/src/components/PrivateResourcesTable.tsx
+++ b/src/components/PrivateResourcesTable.tsx
@@ -97,6 +97,7 @@ export type PrivateResourceRow = {
     tcpPortRangeString: string | null;
     udpPortRangeString: string | null;
     disableIcmp: boolean;
+    advertiseDestination: boolean;
     authDaemonMode?: "site" | "remote" | "native" | null;
     authDaemonPort?: number | null;
     pamMode?: "passthrough" | "push" | null;

--- a/src/hooks/useSaveSiteResource.ts
+++ b/src/hooks/useSaveSiteResource.ts
@@ -62,6 +62,7 @@ export function useSaveSiteResource() {
                 tcpPortRangeString: merged.tcpPortRangeString ?? null,
                 udpPortRangeString: merged.udpPortRangeString ?? null,
                 disableIcmp: merged.disableIcmp ?? false,
+                advertiseDestination: merged.advertiseDestination ?? true,
                 authDaemonMode: merged.authDaemonMode ?? null,
                 authDaemonPort: merged.authDaemonPort ?? null,
                 pamMode: merged.pamMode ?? null

--- a/src/lib/fetchSiteResourceByNiceId.ts
+++ b/src/lib/fetchSiteResourceByNiceId.ts
@@ -46,6 +46,7 @@ export async function fetchSiteResourceByNiceId(
         tcpPortRangeString: match.tcpPortRangeString || null,
         udpPortRangeString: match.udpPortRangeString || null,
         disableIcmp: match.disableIcmp || false,
+        advertiseDestination: match.advertiseDestination ?? true,
         authDaemonMode: match.authDaemonMode ?? null,
         authDaemonPort: match.authDaemonPort ?? null,
         pamMode: match.pamMode ?? null,

--- a/src/lib/privateResourceForm.ts
+++ b/src/lib/privateResourceForm.ts
@@ -30,6 +30,7 @@ export type PrivateResourceFormValues = {
     tcpPortRangeString?: string | null;
     udpPortRangeString?: string | null;
     disableIcmp?: boolean;
+    advertiseDestination?: boolean;
     authDaemonMode?: "site" | "remote" | "native" | null;
     authDaemonPort?: number | null;
     pamMode?: "passthrough" | "push" | null;
@@ -232,6 +233,9 @@ export function buildCreateSiteResourcePayload(
             udpPortRangeString: data.udpPortRangeString,
             disableIcmp: data.disableIcmp ?? false
         }),
+        ...((data.mode === "host" || data.mode === "ssh") && {
+            advertiseDestination: data.advertiseDestination ?? true
+        }),
         roleIds: data.roles ? data.roles.map((r) => parseInt(r.id)) : [],
         userIds: data.users ? data.users.map((u) => u.id) : [],
         clientIds: data.clients ? data.clients.map((c) => c.clientId) : []
@@ -319,6 +323,9 @@ export function buildUpdateSiteResourcePayload(
             udpPortRangeString: data.udpPortRangeString,
             disableIcmp: data.disableIcmp ?? false
         }),
+        ...((data.mode === "host" || data.mode === "ssh") && {
+            advertiseDestination: data.advertiseDestination ?? true
+        }),
         roleIds: access.roleIds,
         userIds: access.userIds,
         clientIds: access.clientIds
@@ -354,6 +361,7 @@ export function siteResourceToFormValues(
         tcpPortRangeString: resource.tcpPortRangeString ?? "*",
         udpPortRangeString: resource.udpPortRangeString ?? "*",
         disableIcmp: resource.disableIcmp ?? false,
+        advertiseDestination: resource.advertiseDestination ?? true,
         authDaemonMode:
             resource.authDaemonMode === "native"
                 ? "native"
@@ -449,7 +457,8 @@ export function createCreateFormSchema(t: TranslateFn) {
             tcpPortRangeString: createPortRangeStringSchema(t),
             udpPortRangeString: createPortRangeStringSchema(t),
             disableIcmp: z.boolean().optional(),
-            providerIds: z.array(z.number().int().positive()).optional()
+            providerIds: z.array(z.number().int().positive()).optional(),
+            advertiseDestination: z.boolean().optional()
         })
         .superRefine((data, ctx) => {
             const isNativeSsh =
@@ -604,6 +613,7 @@ export function createHostFormSchema(t: TranslateFn) {
             tcpPortRangeString: createPortRangeStringSchema(t),
             udpPortRangeString: createPortRangeStringSchema(t),
             disableIcmp: z.boolean().optional(),
+            advertiseDestination: z.boolean().optional(),
             authDaemonMode: z
                 .enum(["site", "remote", "native"])
                 .optional()
@@ -688,7 +698,8 @@ export function createSshFormSchema(
                 .nullable(),
             pamMode: z.enum(["passthrough", "push"]),
             standardDaemonLocation: z.enum(["site", "remote"]),
-            authDaemonPort: z.string()
+            authDaemonPort: z.string(),
+            advertiseDestination: z.boolean().optional()
         })
         .superRefine((data, ctx) => {
             destinationRefine(


### PR DESCRIPTION
```
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.
```

@AstralDestiny asked me to say whether AI was involved, so up front: yes. Claude (Claude Code) wrote the code, the commit messages and this description. I drove it and read every line, and the verification below is stuff that was actually run, not asserted.

This implements #3548. It replaces #3567, which closed on 13 Aug — not because I withdrew it, but because I deleted the fork it was branched from and GitHub closes a PR when its head repository goes away. Sorry for the silence that followed; nothing about the change was in doubt. The branch is rebased and re-pushed here.

## What it changes

`siteResources.advertiseDestination`, boolean, not null, default true. When false, `generateRemoteSubnets()` skips the resource, so a `host` or `ssh` resource with a bare-IP destination no longer becomes a `/32` in the client's route table. The resource stays reachable through its alias, because `generateSubnetProxyTargetV2()` and `generateAliasConfig()` are untouched. Defaulting to true makes this a no-op for existing deployments.

The motivation, briefly: those `/32`s win route selection by longest prefix before any metric is consulted, so a client that already reaches the destination LAN another way has that path pre-empted, including when the tunnel half-dies.

Three things beyond the one-line filter, each separable if you'd rather not take them:

- `handleMessagingForUpdatedSiteResource()` diffs the flag, so toggling it withdraws or adds the route on already-connected clients instead of waiting for a reconnect. It deliberately doesn't set `shouldUpdateTargets` — the newt targets key off the alias address and don't change.
- The "is this destination still in use by a sibling resource?" query now requires the sibling to be advertising, otherwise a non-advertising sibling blocks withdrawal of a route it isn't keeping alive.
- Exposed on create/update, in blueprints as `advertise-destination`, and as a switch on the host and ssh settings pages and the create wizard, shown under the same condition as the alias field.

No migration script — the convention looks like feature commits touch the schema files and the release migration collects the ALTERs, so I followed that. Tell me which version to name one after and I'll add it.

## Verification

`tsc --noEmit` is clean under oss+sqlite, enterprise+pg and saas+pg, and `prettier --check` passes on every changed file.

The second commit adds unit tests to `server/lib/ip.test.ts` covering the default, the opt-out, the ssh case, and a row with the flag unset still advertising. Deleting the one-line filter from `generateRemoteSubnets()` makes them fail, so they're testing the thing they claim to.

That commit also adds `import "@server/extendZod"` to the top of `ip.test.ts`. On current `main` that file throws on import — `ip.ts` evaluates zod `.openapi()` schemas at module scope, so without the extension registered the existing `findNextAvailableCidr` tests don't run either. It's unrelated to this feature and easy to take separately or drop.

The limits, plainly: the runtime checks I reported on #3567 — the flag round-tripping through the API and dashboard, toggling pushing the change, re-sending the same value no-opping — were run against the older base and I have not re-run them since rebasing over ~360 commits. The static checks and the new tests are the evidence for this revision. One thing the rebase changed: the ssh page's license-gated `fieldset` is gone from `main`, so the switch there no longer takes a `disabled` prop and now matches its siblings.

## Two questions

It's based on `main` rather than `dev`, where #3567 sat, because `dev` is currently ~360 commits behind `main` and branching from it would have made an unreadable diff. Happy to rebase onto whichever you prefer.

The flag is only honoured for `host` and `ssh`, the modes that produce a `/32`. A `cidr` resource with `advertise-destination: false` in a blueprint is silently ignored today. I kept the change to what #3548 described, but if you'd rather it applied there too, or was rejected outright, that's small and I'll do it.
