### PR TITLE
Fix: Use variant instead of type only for the Org login IDPs

### DIFF
--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -100,7 +100,7 @@ export default async function Page(props: {
             loginIdps = idpsRes.data.data.idps.map((idp) => ({
                 idpId: idp.idpId,
                 name: idp.name,
-                variant: idp.type
+                variant: idp.variant ?? idp.type
             })) as LoginFormIDP[];
         }
     } else {


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Summary

fix  #3631

This was fixed for last used login but it seems to be affecting normal the normal idp buttons.

