### PR TITLE
Allow COUNTRY_IS_NOT rules to be created via Blueprints

### DIFF
--- a/server/lib/blueprints/types.ts
+++ b/server/lib/blueprints/types.ts
@@ -101,7 +101,7 @@ export const AuthSchema = z.object({
 export const RuleSchema = z
     .object({
         action: z.enum(["allow", "deny", "pass"]),
-        match: z.enum(["cidr", "path", "ip", "country", "asn", "region"]),
+        match: z.enum(["cidr", "path", "ip", "country", "country_is_not", "asn", "region"]),
         value: z.coerce.string(),
         priority: z.int().optional(),
         enabled: z.boolean().optional().default(true)
@@ -136,7 +136,7 @@ export const RuleSchema = z
     )
     .refine(
         (rule) => {
-            if (rule.match === "country") {
+            if (rule.match === "country" || rule.match === "country_is_not") {
                 if (!hasMaxmindCountryDb) {
                     return false;
                 }


### PR DESCRIPTION
Updates RuleSchema to include "country_is_not" so the blueprint upload from newt can create the same rules as are available in the web UI.

## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## AI Disclosure

I ran into the bug on my own, I used AI to locate where in the codebase the validation error was coming from. I updated it myself.

## Description

Pangolin web UI allows creation of COUNTRY and COUNTRY_IS_NOT rules. Uploaded Blueprints from Newt only pass validation for COUNTRY rules. This is due to an out of date RuleSchema that excludes COUNTRY_IS_NOT. This fixes that.


## How to test?

Add a COUNTRY_IS_NOT rule in a blueprint and upload from newt and see it reflected in the webUI:

```
public-resources:
  my_resource:
    name: MyResource
    ...
    rules:
      - action: allow
         match: country_is_not
         value: US
```
