### PR TITLE
Crowdsec v1.7.1

### DIFF
--- a/install/config/crowdsec/traefik_config.yml
+++ b/install/config/crowdsec/traefik_config.yml
@@ -16,7 +16,7 @@ experimental:
       version: "{{.BadgerVersion}}"
     crowdsec: # CrowdSec plugin configuration added
       moduleName: "github.com/maxlerebourg/crowdsec-bouncer-traefik-plugin"
-      version: "v1.4.4"
+      version: "v1.7.8"
 
 log:
   level: "INFO"

--- a/install/config/crowdsec/traefik_config.yml
+++ b/install/config/crowdsec/traefik_config.yml
@@ -16,7 +16,7 @@ experimental:
       version: "{{.BadgerVersion}}"
     crowdsec: # CrowdSec plugin configuration added
       moduleName: "github.com/maxlerebourg/crowdsec-bouncer-traefik-plugin"
-      version: "v1.7.8"
+      version: "v1.7.1"
 
 log:
   level: "INFO"


### PR DESCRIPTION
Updated CrowdSec plugin version from v1.4.4 to v1.7.1

## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## AI Disclosure

> No AI used.

## Description
Bumped to [latest](https://github.com/maxlerebourg/crowdsec-bouncer-traefik-plugin/releases#release-v1.7.1) CrowdSec plugin version
Tested and confirmed working.
[Community docs](https://docs.pangolin.net/self-host/community-guides/crowdsec#custom-ban-page) also need updating because of depreciation:
BanHTMLFilePath become BanFilePath
CaptchaHTMLFilePath become CaptchaFilePath


## How to test?
Check logs `docker compose logs -f`
There should be 0 additional errors or warns
Wait or create a block and see metrics go up `docker compose exec crowdsec cscli metrics`
Confirm block and captcha works by already established test method from [docs](https://docs.pangolin.net/self-host/community-guides/crowdsec#testing)
Optionally test ban pages and captcha pages from community guides