### PR TITLE
Fix access token deletion for root API keys

### DIFF
--- a/server/middlewares/integration/verifyAccessTokenAccess.ts
+++ b/server/middlewares/integration/verifyAccessTokenAccess.ts
@@ -68,6 +68,11 @@ export async function verifyApiKeyAccessTokenAccess(
             );
         }
 
+        if (apiKey.isRoot) {
+            // Root keys can access any access token in any org
+            return next();
+        }
+
         if (!resource.orgId) {
             return next(
                 createHttpError(


### PR DESCRIPTION
By creating this pull request, I grant the project maintainers an unlimited, perpetual license to use, modify, and redistribute these contributions under any terms they choose, including both the AGPLv3 and the Fossorial Commercial license terms. I represent that I have the right to grant this license for all contributed content.

## What does this PR do?

This PR adds a root API key bypass to `verifyApiKeyAccessTokenAccess`, making its behaviour consistent with the other integration middleware functions, including `verifyApiKeyResourceAccess` and `verifyApiKeyOrgAccess`.

The bypass is applied only after confirming that the access token and its associated resource exist, so the existing `404` behaviour remains unchanged.

## Why is this change needed?

Fixes #3638.

Root API keys are not associated with organisations through `apiKeyOrg`. As a result, the organisation membership lookup always returns an empty result for root keys, causing `DELETE /v1/access-token/{id}` to return `403 Forbidden`.

Creating and listing access tokens already work with root API keys because their middleware explicitly checks `isRoot`. This change brings the delete operation in line with that existing behaviour.

## Additional notes

The behaviour of `GET /v1/resource/{id}/access-tokens` mentioned in the issue appears to be a separate problem and is not addressed by this PR.
