### PR TITLE
Add Crowdsec bot detection

### DIFF
--- a/install/config/crowdsec/acquis.d/appsec.yaml
+++ b/install/config/crowdsec/acquis.d/appsec.yaml
@@ -1,5 +1,7 @@
 listen_addr: 0.0.0.0:7422
-appsec_config: crowdsecurity/appsec-default
+appsec_config:
+  - crowdsecurity/appsec-default
+  - crowdsecurity/appsec-bot-*
 name: myAppSecComponent
 source: appsec
 labels:

--- a/install/config/crowdsec/acquis.d/appsec.yaml
+++ b/install/config/crowdsec/acquis.d/appsec.yaml
@@ -1,5 +1,5 @@
 listen_addr: 0.0.0.0:7422
-appsec_config:
+appsec_configs:
   - crowdsecurity/appsec-default
   - crowdsecurity/appsec-bot-*
 name: myAppSecComponent

--- a/install/config/crowdsec/docker-compose.yml
+++ b/install/config/crowdsec/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     container_name: crowdsec
     environment:
       GID: "1000"
-      COLLECTIONS: crowdsecurity/traefik crowdsecurity/appsec-virtual-patching crowdsecurity/appsec-generic-rules
+      COLLECTIONS: crowdsecurity/traefik crowdsecurity/appsec-virtual-patching crowdsecurity/appsec-generic-rules crowdsecurity/appsec-bot-challenge
       ENROLL_INSTANCE_NAME: "pangolin-crowdsec"
       PARSERS: crowdsecurity/whitelists
       ENROLL_TAGS: docker


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## AI Disclosure

> AI was used to check if implementation is correct and to title file changes.

## Description
Crowdsec v1.8.0 added new [appsec](https://docs.crowdsec.net/docs/next/appsec/bot_detection/enable/) featuring bot detection. This PR adds and configures it.
PR on hold till PR [#343](https://github.com/maxlerebourg/crowdsec-bouncer-traefik-plugin/pull/343) on crowdsec-bouncer-traefik is merged and releases as stable.
It is also possible to choose a [treshold](https://docs.crowdsec.net/docs/next/appsec/bot_detection/enable/#choosing-a-threshold) for bot detection, using default as recommended by crowdsec.

## How to test?
Please use official crowdsec [recommendations](https://docs.crowdsec.net/docs/next/appsec/bot_detection/enable/#verification) for verification
