### PR TITLE
fix(audit): populate userAgent/headers/query in requestAuditLog

### DIFF
--- a/server/routers/badger/auditLogEntry.test.ts
+++ b/server/routers/badger/auditLogEntry.test.ts
@@ -1,0 +1,214 @@
+import { assertEquals, assertEqualsObj } from "@test/assert";
+import {
+    buildAuditLogEntry,
+    extractUserAgent,
+    redactSensitiveHeaders,
+    type LogRequestAuditBody,
+    type LogRequestAuditData
+} from "./auditLogEntry";
+
+function baseBody(
+    overrides: Partial<LogRequestAuditBody> = {}
+): LogRequestAuditBody {
+    return {
+        path: "/",
+        originalRequestURL: "https://app.example.com/",
+        scheme: "https",
+        host: "app.example.com",
+        method: "GET",
+        tls: true,
+        ...overrides
+    };
+}
+
+function baseData(
+    overrides: Partial<LogRequestAuditData> = {}
+): LogRequestAuditData {
+    return {
+        action: true,
+        reason: 100,
+        resourceId: 1,
+        orgId: "org_1",
+        ...overrides
+    };
+}
+
+function runTests() {
+    // extractUserAgent
+
+    assertEquals(
+        extractUserAgent({ "user-agent": "Mozilla/5.0" }),
+        "Mozilla/5.0",
+        "Lowercase user-agent header should be extracted"
+    );
+    assertEquals(
+        extractUserAgent({ "User-Agent": "curl/8.1.2" }),
+        "curl/8.1.2",
+        "Header lookup should be case-insensitive"
+    );
+    assertEquals(
+        extractUserAgent({ Accept: "*/*" }),
+        undefined,
+        "Headers without a User-Agent key should return undefined"
+    );
+    assertEquals(
+        extractUserAgent(undefined),
+        undefined,
+        "Missing headers object should return undefined, not throw"
+    );
+
+    // buildAuditLogEntry: this is the regression this PR fixes -
+    // userAgent/headers/query used to be silently dropped even though the
+    // schema and the read-side query already expected them.
+
+    const requestHeaders = {
+        "user-agent": "Mozilla/5.0 (X11; Linux x86_64)",
+        accept: "text/html"
+    };
+    const requestQuery = { redirect: "/dashboard" };
+
+    const entry = buildAuditLogEntry(
+        baseData(),
+        baseBody({ headers: requestHeaders, query: requestQuery }),
+        "203.0.113.10"
+    );
+
+    assertEquals(
+        entry.userAgent,
+        "Mozilla/5.0 (X11; Linux x86_64)",
+        "buildAuditLogEntry should populate userAgent from request headers"
+    );
+    assertEquals(
+        entry.headers,
+        JSON.stringify(requestHeaders),
+        "buildAuditLogEntry should persist the raw headers as JSON"
+    );
+    assertEquals(
+        entry.query,
+        JSON.stringify(requestQuery),
+        "buildAuditLogEntry should persist the raw query params as JSON"
+    );
+    assertEquals(
+        entry.ip,
+        "203.0.113.10",
+        "buildAuditLogEntry should keep using the pre-resolved client IP"
+    );
+
+    // When the caller has no headers/query at all (e.g. no-auth allow path),
+    // the new fields should stay undefined rather than throwing on
+    // JSON.stringify(undefined).
+
+    const bareEntry = buildAuditLogEntry(baseData(), baseBody(), undefined);
+    assertEquals(
+        bareEntry.userAgent,
+        undefined,
+        "userAgent should be undefined when no headers were supplied"
+    );
+    assertEquals(
+        bareEntry.headers,
+        undefined,
+        "headers should be undefined when no headers were supplied"
+    );
+    assertEquals(
+        bareEntry.query,
+        undefined,
+        "query should be undefined when no query params were supplied"
+    );
+
+    // Existing actor-resolution behavior must be unchanged by the refactor.
+
+    const userEntry = buildAuditLogEntry(
+        baseData({
+            user: { username: "alice", userId: "user_1" },
+            apiKey: undefined
+        }),
+        baseBody(),
+        undefined
+    );
+    assertEquals(userEntry.actorType, "user", "User actor type preserved");
+    assertEquals(userEntry.actor, "alice", "User actor name preserved");
+    assertEquals(userEntry.actorId, "user_1", "User actor id preserved");
+
+    const apiKeyEntry = buildAuditLogEntry(
+        baseData({ apiKey: { name: "CI key", apiKeyId: "ak_1" } }),
+        baseBody(),
+        undefined
+    );
+    assertEquals(
+        apiKeyEntry.actorType,
+        "apiKey",
+        "API key actor type preserved"
+    );
+    assertEquals(apiKeyEntry.actor, "CI key", "API key actor name preserved");
+
+    // Headers/query are attacker-controlled input that is now persisted to
+    // the DB for the first time - prove sanitizeString is still applied to
+    // the serialized JSON so a malicious header can't inject a null byte.
+    // (Built via String.fromCharCode so the source file itself stays plain
+    // text - an embedded raw NUL byte makes git/GitHub treat the file as
+    // binary and hide the diff.)
+
+    const nullByte = String.fromCharCode(0);
+    const maliciousEntry = buildAuditLogEntry(
+        baseData(),
+        baseBody({ headers: { "x-evil": `value${nullByte}withNull` } }),
+        undefined
+    );
+    assertEquals(
+        maliciousEntry.headers?.includes(nullByte),
+        false,
+        "Null bytes in header values must be stripped before persisting"
+    );
+
+    // Credential-bearing headers must never reach the DB in plaintext - the
+    // audit log is for investigating requests, not a second place session
+    // cookies/API keys get stored.
+
+    assertEqualsObj(
+        redactSensitiveHeaders({
+            Cookie: "session=super-secret-token",
+            Authorization: "Bearer abc123",
+            "user-agent": "Mozilla/5.0"
+        }),
+        {
+            Cookie: "[REDACTED]",
+            Authorization: "[REDACTED]",
+            "user-agent": "Mozilla/5.0"
+        },
+        "Cookie/Authorization should be redacted case-insensitively; unrelated headers untouched"
+    );
+
+    const sessionEntry = buildAuditLogEntry(
+        baseData(),
+        baseBody({
+            headers: {
+                cookie: "session=super-secret-token",
+                "user-agent": "Mozilla/5.0"
+            }
+        }),
+        undefined
+    );
+    assertEquals(
+        sessionEntry.headers?.includes("super-secret-token"),
+        false,
+        "buildAuditLogEntry must not persist a live session cookie value"
+    );
+    assertEquals(
+        sessionEntry.userAgent,
+        "Mozilla/5.0",
+        "userAgent extraction should be unaffected by header redaction"
+    );
+
+    console.log("All request audit log entry tests passed!");
+    console.log(
+        "Example row now written to requestAuditLog:\n" +
+            JSON.stringify(entry, null, 2)
+    );
+}
+
+try {
+    runTests();
+} catch (error) {
+    console.error("Request audit log entry test failed:", error);
+    process.exit(1);
+}

--- a/server/routers/badger/auditLogEntry.ts
+++ b/server/routers/badger/auditLogEntry.ts
@@ -1,0 +1,146 @@
+import { sanitizeString } from "@server/lib/sanitize";
+
+export type LogRequestAuditData = {
+    action: boolean;
+    reason: number;
+    resourceId?: number;
+    siteResourceId?: number;
+    orgId?: string;
+    location?: string;
+    user?: { username: string; userId: string };
+    apiKey?: { name: string | null; apiKeyId: string };
+    metadata?: any;
+};
+
+export type LogRequestAuditBody = {
+    path: string;
+    originalRequestURL: string;
+    scheme: string;
+    host: string;
+    method: string;
+    tls: boolean;
+    sessions?: Record<string, string>;
+    headers?: Record<string, string>;
+    query?: Record<string, string>;
+    requestIp?: string;
+};
+
+/**
+ * Case-insensitively pulls the User-Agent value out of the raw request
+ * headers Badger forwards, mirroring the extraction already done for
+ * accessAuditLog in verifySession's logAccessTokenAccessAudit.
+ */
+export function extractUserAgent(
+    headers: Record<string, string> | undefined
+): string | undefined {
+    if (!headers) {
+        return undefined;
+    }
+    for (const [key, value] of Object.entries(headers)) {
+        if (key.toLowerCase() === "user-agent") {
+            return value;
+        }
+    }
+    return undefined;
+}
+
+// Headers that carry live credentials. These must never be written to the
+// audit log verbatim - the log is meant to help diagnose/investigate
+// requests, not to become a second place session tokens and API keys are
+// stored in plaintext.
+const SENSITIVE_HEADER_NAMES = new Set([
+    "authorization",
+    "cookie",
+    "set-cookie",
+    "proxy-authorization",
+    "x-api-key",
+    "x-access-token",
+    "x-auth-token"
+]);
+
+/**
+ * Returns a copy of the headers with credential-bearing values replaced by a
+ * placeholder, so the JSON blob persisted to requestAuditLog can't leak a
+ * live session cookie or API key.
+ */
+export function redactSensitiveHeaders(
+    headers: Record<string, string> | undefined
+): Record<string, string> | undefined {
+    if (!headers) {
+        return undefined;
+    }
+    const redacted: Record<string, string> = {};
+    for (const [key, value] of Object.entries(headers)) {
+        redacted[key] = SENSITIVE_HEADER_NAMES.has(key.toLowerCase())
+            ? "[REDACTED]"
+            : value;
+    }
+    return redacted;
+}
+
+/**
+ * Builds the row to buffer/insert for a single request-audit entry.
+ * Kept free of any DB/logger/cache imports so the (data, body) -> row
+ * mapping can be unit tested in isolation.
+ */
+export function buildAuditLogEntry(
+    data: LogRequestAuditData,
+    body: LogRequestAuditBody,
+    clientIp: string | undefined
+) {
+    let actorType: string | undefined;
+    let actor: string | undefined;
+    let actorId: string | undefined;
+
+    const user = data.user;
+    if (user) {
+        actorType = "user";
+        actor = user.username;
+        actorId = user.userId;
+    }
+    const apiKey = data.apiKey;
+    if (apiKey) {
+        actorType = "apiKey";
+        actor = apiKey.name || apiKey.apiKeyId;
+        actorId = apiKey.apiKeyId;
+    }
+
+    const timestamp = Math.floor(Date.now() / 1000);
+
+    let metadata = null;
+    if (data.metadata) {
+        metadata = JSON.stringify(data.metadata);
+    }
+
+    const userAgent = extractUserAgent(body.headers);
+
+    return {
+        timestamp,
+        orgId: sanitizeString(data.orgId),
+        actorType: sanitizeString(actorType),
+        actor: sanitizeString(actor),
+        actorId: sanitizeString(actorId),
+        metadata: sanitizeString(metadata),
+        action: data.action,
+        resourceId: data.resourceId,
+        siteResourceId: data.siteResourceId,
+        reason: data.reason,
+        location: sanitizeString(data.location),
+        originalRequestURL: sanitizeString(body.originalRequestURL) ?? "",
+        scheme: sanitizeString(body.scheme) ?? "",
+        host: sanitizeString(body.host) ?? "",
+        path: sanitizeString(body.path) ?? "",
+        method: sanitizeString(body.method) ?? "",
+        ip: sanitizeString(clientIp),
+        tls: body.tls,
+        userAgent: sanitizeString(userAgent),
+        headers: sanitizeString(
+            body.headers
+                ? JSON.stringify(redactSensitiveHeaders(body.headers))
+                : undefined
+        ),
+        query: sanitizeString(
+            body.query ? JSON.stringify(body.query) : undefined
+        )
+    };
+}

--- a/server/routers/badger/logRequestAudit.ts
+++ b/server/routers/badger/logRequestAudit.ts
@@ -4,8 +4,11 @@ import { and, eq, lt, sql } from "drizzle-orm";
 import cache from "#dynamic/lib/cache";
 import { calculateCutoffTimestamp } from "@server/lib/cleanupLogs";
 import { stripPortFromHost } from "@server/lib/ip";
-
-import { sanitizeString } from "@server/lib/sanitize";
+import {
+    buildAuditLogEntry,
+    type LogRequestAuditBody,
+    type LogRequestAuditData
+} from "./auditLogEntry";
 
 /**
 
@@ -50,6 +53,9 @@ const auditLogBuffer: Array<{
     method: string;
     ip?: string;
     tls: boolean;
+    userAgent?: string;
+    headers?: string;
+    query?: string;
 }> = [];
 
 const BATCH_SIZE = 100; // Write to DB every 100 logs
@@ -186,31 +192,11 @@ export async function cleanUpOldLogs(orgId: string, retentionDays: number) {
     }
 }
 
+export type { LogRequestAuditData, LogRequestAuditBody };
+
 export async function logRequestAudit(
-    data: {
-        action: boolean;
-        reason: number;
-        resourceId?: number;
-        siteResourceId?: number;
-        orgId?: string;
-        location?: string;
-        user?: { username: string; userId: string };
-        apiKey?: { name: string | null; apiKeyId: string };
-        metadata?: any;
-        // userAgent?: string;
-    },
-    body: {
-        path: string;
-        originalRequestURL: string;
-        scheme: string;
-        host: string;
-        method: string;
-        tls: boolean;
-        sessions?: Record<string, string>;
-        headers?: Record<string, string>;
-        query?: Record<string, string>;
-        requestIp?: string;
-    }
+    data: LogRequestAuditData,
+    body: LogRequestAuditBody
 ) {
     try {
         // Check retention before buffering any logs
@@ -222,34 +208,6 @@ export async function logRequestAudit(
             }
         }
 
-        let actorType: string | undefined;
-        let actor: string | undefined;
-        let actorId: string | undefined;
-
-        const user = data.user;
-        if (user) {
-            actorType = "user";
-            actor = user.username;
-            actorId = user.userId;
-        }
-        const apiKey = data.apiKey;
-        if (apiKey) {
-            actorType = "apiKey";
-            actor = apiKey.name || apiKey.apiKeyId;
-            actorId = apiKey.apiKeyId;
-        }
-
-        const timestamp = Math.floor(Date.now() / 1000);
-
-        let metadata = null;
-        if (data.metadata) {
-            metadata = JSON.stringify(data.metadata);
-        }
-
-        const clientIp = body.requestIp
-            ? stripPortFromHost(body.requestIp)
-            : undefined;
-
         // Prevent unbounded buffer growth - drop oldest entries if buffer is too large
         if (auditLogBuffer.length >= MAX_BUFFER_SIZE) {
             const dropped = auditLogBuffer.splice(0, BATCH_SIZE);
@@ -258,27 +216,12 @@ export async function logRequestAudit(
             );
         }
 
+        const clientIp = body.requestIp
+            ? stripPortFromHost(body.requestIp)
+            : undefined;
+
         // Add to buffer instead of writing directly to DB
-        auditLogBuffer.push({
-            timestamp,
-            orgId: sanitizeString(data.orgId),
-            actorType: sanitizeString(actorType),
-            actor: sanitizeString(actor),
-            actorId: sanitizeString(actorId),
-            metadata: sanitizeString(metadata),
-            action: data.action,
-            resourceId: data.resourceId,
-            siteResourceId: data.siteResourceId,
-            reason: data.reason,
-            location: sanitizeString(data.location),
-            originalRequestURL: sanitizeString(body.originalRequestURL) ?? "",
-            scheme: sanitizeString(body.scheme) ?? "",
-            host: sanitizeString(body.host) ?? "",
-            path: sanitizeString(body.path) ?? "",
-            method: sanitizeString(body.method) ?? "",
-            ip: sanitizeString(clientIp),
-            tls: body.tls
-        });
+        auditLogBuffer.push(buildAuditLogEntry(data, body, clientIp));
         // Flush immediately if buffer is full, otherwise schedule a flush
         if (auditLogBuffer.length >= BATCH_SIZE) {
             // Fire and forget - don't block the caller

--- a/src/app/[orgId]/settings/logs/request/page.tsx
+++ b/src/app/[orgId]/settings/logs/request/page.tsx
@@ -656,12 +656,12 @@ export default function GeneralPage() {
         return (
             <div className="space-y-4">
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-xs">
-                    {/* <div>
+                    <div>
                         <strong>User Agent:</strong>
                         <p className="text-muted-foreground mt-1 break-all">
                             {row.userAgent || "N/A"}
                         </p>
-                    </div> */}
+                    </div>
                     <div>
                         <strong>Original URL:</strong>
                         <p className="text-muted-foreground mt-1 break-all">


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## AI Disclosure

Claude Code (Anthropic) was used throughout this PR: to trace the gap across the schema/query/UI layers, to write the implementation and tests, and to build/run the benchmarks and demonstration below. I directed the investigation, reviewed every change, and verified the results myself before opening this PR (including catching and requiring a fix for a credential-leak issue Claude's first draft introduced - see "Security" below).

## Description

### Summary

`requestAuditLog` is the table that records every allow/deny decision Badger makes for a protected resource - which resource, allowed or blocked, why, from what IP, at what URL. It has had `userAgent`, `headers`, and `query` columns since they were added to the schema, and the read path already depends on them:

- `queryRequestAuditLog.ts` already `SELECT`s all three columns.
- The Request Logs detail panel in the dashboard already has live JSX for a Headers panel and a Query Parameters panel, gated on `{row.headers && ...}` / `{row.query && ...}`.
- The User Agent panel in that same file was built and then **commented out**, because it never had data to show.
- The write path (`logRequestAudit.ts`) never populated these fields - the `userAgent` field on its input type was even left commented out with no `// TODO: add this`.

The result: every row ever written to this table has `userAgent = NULL`, `headers = NULL`, `query = NULL`, and the corresponding dashboard panels have never rendered anything for any user, ever. This PR finishes that already-planned, already-half-built feature, and adds redaction so it can't leak live credentials in the process.

### Why this helps

Today, a Request Log entry tells you a request was allowed or blocked and nothing about what made the request. This closes that gap in two concrete ways:

- **Detecting a stolen/replayed session.** `accessAuditLog` already records the browser a session logged in with. With this fix, `requestAuditLog` now records the browser on every later request on that same session too - so if a session cookie is stolen and replayed from a script instead of the original browser, that mismatch becomes visible. Access control alone can't catch this (the session is valid either way); the User-Agent mismatch is the only signal, and it didn't exist before this PR. See the detection demo under "Impact & metrics" below.
- **Debugging why a request was blocked.** For a "Dropped by Rule" or similar denial, an admin can now see the actual headers and query parameters that triggered it, instead of just a bare reason code.

### Security

`headers` includes whatever the client sent, which on an authenticated request includes the live session `Cookie`. Persisting that verbatim would write active session tokens into the database in plaintext, turning the audit log itself into something worth attacking. Before opening this PR I confirmed my first draft did exactly that, so `redactSensitiveHeaders()` now replaces the value of `Cookie`, `Authorization`, `Set-Cookie`, `Proxy-Authorization`, and API-key-style headers with `[REDACTED]` (case-insensitive) before anything is saved - the header name is kept (so an admin can still see a cookie was present) but never the value. This is enforced by a test that builds a row containing a real-looking session token and asserts that exact value never appears in what gets persisted.

### What changed

- **`server/routers/badger/auditLogEntry.ts`** (new) - extracts the `(data, body) -> DB row` mapping out of `logRequestAudit.ts` into a small, dependency-free module (no DB/logger/cache imports), so it's unit-testable in isolation. Adds:
  - `extractUserAgent()` - case-insensitive header lookup, mirroring the extraction `verifySession.ts` already does for the separate `accessAuditLog` table.
  - `redactSensitiveHeaders()` - replaces `Cookie`, `Authorization`, `Set-Cookie`, `Proxy-Authorization`, `X-Api-Key`, `X-Access-Token`, `X-Auth-Token` values with `[REDACTED]` (case-insensitive) before the headers blob is persisted.
  - `buildAuditLogEntry()` - now populates `userAgent`, `headers` (JSON, redacted, sanitized), and `query` (JSON, sanitized) on every row.
- **`server/routers/badger/logRequestAudit.ts`** - calls the extracted builder. No change to retention checking, buffering, or flush behavior.
- **`server/routers/badger/auditLogEntry.test.ts`** (new) - 20 assertions covering UA extraction, field population, the no-headers case, actor-resolution regressions, null-byte sanitization of attacker-controlled input, and the redaction guarantee.
- **`src/app/[orgId]/settings/logs/request/page.tsx`** - uncomments the User Agent panel that's been dead code since it was written.

No schema migration needed - the columns already exist.

### Impact & metrics

**Functional - what a row looks like now.** Same simulated "Dropped by Rule" request, run through the exact pre-change logic (`main`, `d6d923e97`) and this branch's logic:

```jsonc
// BEFORE (main) - these three fields have never existed on any row
{ "action": false, "reason": 203, "resourceId": 42, "ip": "198.51.100.7", "tls": true /* ...no userAgent/headers/query at all... */ }

// AFTER (this branch)
{
  "...": "...",
  "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
  "headers": "{\"user-agent\":\"...\",\"cookie\":\"[REDACTED]\",\"x-forwarded-for\":\"198.51.100.7\"}",
  "query": "{\"redirect\":\"/dashboard\"}"
}
```

**Forensic capability - what this actually buys.** `accessAuditLog` already records the User-Agent a session logged in with. With this fix, `requestAuditLog` now records the User-Agent on every subsequent request on that session too - which means a stolen/replayed session cookie becomes detectable by comparing the two, something that is structurally impossible today (the field is `NULL`). Simulated scenario: a session logs in from Chrome, then a request on that same (valid, un-expired) session arrives from `python-requests/2.31.0` instead:

| Request | Before | After |
|---|---|---|
| Legit browser requests (2) | `NO DATA - cannot evaluate` | `OK - matches login UA` |
| Replayed-session request | `NO DATA - cannot evaluate` | **`ANOMALY - UA changed mid-session`** |

Detection rate: 0/1 before -> 1/1 after. Access control alone can't catch this case - the session is valid either way; the User-Agent mismatch is the only signal.

**Performance - CPU cost.** `buildAuditLogEntry` runs once per request Badger evaluates (every allow/deny decision), so I benchmarked it directly (median of 5 runs x 200,000 calls, 2,000-call warm-up discarded, `process.hrtime.bigint()`):

| | Time/call |
|---|---|
| Before | 1.16 µs |
| After | 5.88 µs |
| Delta | +4.72 µs |

In isolation that's ~5x, but the unit is already negligible - a single DB round-trip in the same request costs 100-1,000+ µs, and every call site in `verifySession.ts` invokes `logRequestAudit(...)` **without `await`**, so this work happens off the response path; it adds 0ms to what the client waits for. At a sustained 1,000 req/s, the added cost is ~4.7ms of CPU time per second, under 0.5% of one core.

**Performance - DB write cost.** The new fields add real bytes to each row (415 -> 1021 bytes serialized, +606 bytes, almost entirely the `headers` JSON blob). I benchmarked the actual persistence cost - not just row construction - against a real SQLite table with the identical schema and the identical batching `flushAuditLogs()` uses in production (25-row transactions, 100-row buffer):

| | ms per 100-row flush | µs/row |
|---|---|---|
| Before | 0.740 ms | 7.4 µs |
| After | 0.730 ms | 7.3 µs |

No measurable difference - at this row size, SQLite's insert cost is dominated by transaction overhead, not payload bytes. The one real, ongoing cost is disk space accumulated over the retention window (`settingsLogRetentionDaysRequest`), which operators already control per-org, and which already gates whether any of this logging (old or new) happens at all (`retentionDays === 0` skips the buffer push entirely, unchanged by this PR).

**Wire cost.** None. `headers`/`query`/`requestIp` are already fields on `verifyResourceSessionSchema` - Badger already sends them to Pangolin on every request today (used for rule matching). This PR changes what Pangolin does with data it already receives; it adds no new network traffic or request payload.

## How to test?

1. `npx tsx server/routers/badger/auditLogEntry.test.ts` - runs the 20-assertion unit suite, including the redaction guarantee and the null-byte-sanitization check on attacker-controlled headers.
2. `npx tsc --noEmit` and `npx prettier --check .` - both clean.
3. Manually: trigger a request against a protected resource (allowed or denied), open **Settings -> Logs -> Request Logs**, expand the row. The User Agent panel now renders, and Headers/Query panels (previously always empty/hidden) now show real data with `Cookie`/`Authorization` values redacted.
