### PR TITLE
Fix maintenance page not taking over when a resource has no usable targets

### DIFF
--- a/server/lib/traefik/browserGateway.ts
+++ b/server/lib/traefik/browserGateway.ts
@@ -280,6 +280,16 @@ export function buildBrowserGatewayConfig(params: {
                 ...(bgResource.ssl ? { tls } : {})
             };
 
+            // The HTTP -> HTTPS redirect router above points at the UI
+            // service, which we skip building below. Point it at the
+            // maintenance service so it does not reference a service that
+            // does not exist.
+            if (bgResource.ssl) {
+                config_output.http.routers![
+                    `bg-r${bgResource.resourceId}-redirect`
+                ].service = bgMaintenanceServiceName;
+            }
+
             continue;
         }
 

--- a/server/private/lib/traefik/getTraefikConfig.ts
+++ b/server/private/lib/traefik/getTraefikConfig.ts
@@ -568,7 +568,7 @@ export async function getTraefikConfig(
             const loadBalancerServers = buildHttpLoadBalancerServers(targets);
 
             // A Traefik loadBalancer with an empty servers list answers every
-            // request with a 500, so "nothing left to route to" has to count
+            // request with a 503, so "nothing left to route to" has to count
             // as unhealthy when deciding whether to show the maintenance
             // page. availableServers on its own is not enough: it and the
             // load balancer apply different filters, so a target can survive
@@ -692,7 +692,7 @@ export async function getTraefikConfig(
             if (showMaintenancePage) {
                 // Maintenance mode is on but there is no UI to send the
                 // request to. Falling through would build a service with an
-                // empty servers list, which Traefik answers with a 500, so
+                // empty servers list, which Traefik answers with a 503, so
                 // skip the resource and make the misconfiguration visible.
                 logger.warn(
                     `Resource ${resource.name} (${fullDomain}) is in maintenance mode but no maintenance page URL is configured, skipping Traefik config`

--- a/server/private/lib/traefik/getTraefikConfig.ts
+++ b/server/private/lib/traefik/getTraefikConfig.ts
@@ -565,7 +565,17 @@ export async function getTraefikConfig(
                 return true;
             });
 
-            const hasHealthyServers = availableServers.length > 0;
+            const loadBalancerServers = buildHttpLoadBalancerServers(targets);
+
+            // A Traefik loadBalancer with an empty servers list answers every
+            // request with a 500, so "nothing left to route to" has to count
+            // as unhealthy when deciding whether to show the maintenance
+            // page. availableServers on its own is not enough: it and the
+            // load balancer apply different filters, so a target can survive
+            // this one and still be dropped there for missing connection
+            // details.
+            const hasHealthyServers =
+                availableServers.length > 0 && loadBalancerServers.length > 0;
 
             let showMaintenancePage = false;
             if (resource.maintenanceModeEnabled) {
@@ -662,8 +672,36 @@ export async function getTraefikConfig(
                         ...(resource.ssl ? { tls } : {})
                     };
 
+                // The HTTP -> HTTPS redirect router was registered above
+                // pointing at the resource's normal service, but we skip
+                // building that service below, which leaves the router
+                // referencing a service that does not exist. Point it at the
+                // maintenance service instead; the redirect middleware runs
+                // before the service is ever reached.
+                if (resource.ssl) {
+                    config_output.http.routers![
+                        routerName + "-redirect"
+                    ].service = maintenanceServiceName;
+                }
+
                 // logger.info(`Maintenance mode active for ${fullDomain}`);
 
+                continue;
+            }
+
+            if (showMaintenancePage) {
+                // Maintenance mode is on but there is no UI to send the
+                // request to. Falling through would build a service with an
+                // empty servers list, which Traefik answers with a 500, so
+                // skip the resource and make the misconfiguration visible.
+                logger.warn(
+                    `Resource ${resource.name} (${fullDomain}) is in maintenance mode but no maintenance page URL is configured, skipping Traefik config`
+                );
+                if (resource.ssl) {
+                    delete config_output.http.routers![
+                        routerName + "-redirect"
+                    ];
+                }
                 continue;
             }
 
@@ -710,7 +748,7 @@ export async function getTraefikConfig(
 
             config_output.http.services![serviceName] = {
                 loadBalancer: {
-                    servers: buildHttpLoadBalancerServers(targets),
+                    servers: loadBalancerServers,
                     ...(resource.stickySession
                         ? buildStickySessionCookie(resource.ssl)
                         : {})


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## AI Disclosure

> Please disclose how AI was used in this pull request. The use of AI does not preclude this from being merged, but is an important factor in how we review your request.

It was used to run the tests
## Description

Refs #3666.

When a resource has maintenance mode enabled but no usable targets, the maintenance
page does not take over — Traefik serves an error instead.

I measured the actual behaviour against Traefik v3.7 (the version we ship) using a
dynamic config that reproduces each condition:

| Condition | Status |
|---|---|
| service with `servers: []` | 503 |
| router → nonexistent service | 404 |
| router → nonexistent middleware | 404 |
| control (real server) | 301 |

Three paths in `getTraefikConfig` land in one of those states while in maintenance mode
is on:

1. **`hasHealthyServers` disagreed with the load balancer.** It was derived from
   `availableServers`, which applies a different filter than
   `buildHttpLoadBalancerServers`. A target could pass the first and be dropped by the
   second, so `automatic` mode saw a healthy backend, skipped the maintenance branch,
   and emitted a service with no servers → **503**.

2. **A dangling HTTP → HTTPS redirect router.** The `-redirect` router is registered
   before the maintenance branch, which `continue`s before the resource's normal
   service is defined, leaving the router pointing at a service that does not
   exist → **404** on the HTTP entrypoint.

3. **Silent fall-through with no maintenance page URL.** With maintenance mode on but
   `maintenancePageUiUrl` null, the resource fell through to the empty service, and
   nothing was logged.

### Changes

- Derive `hasHealthyServers` from the load balancer output as well, closing the gap
  between the two filters.
- Point the redirect router at the maintenance service when maintenance takes over.
- Skip the resource with a warning when maintenance is requested but there is no
  maintenance page to route to, so the misconfiguration is visible instead of silent.
- The browser gateway had the same dangling redirect router
  (`server/lib/traefik/browserGateway.ts`), so it is fixed there too.

### On the reported 500

I could not reproduce the 500 from #3666, and neither could @AstralDestiny. None of the
conditions above returns a 500 on Traefik v3.7, so the reported status likely comes from
something outside the file-provider config — a middleware such as crowdsec or badger is
a plausible candidate. Marked `Refs` rather than `Fixes` for that reason.

`maintenanceEstimatedTime` is also not the trigger: it is only stored and rendered,
never branched on, and the maintenance screen guards its block with
`{estimatedTime && ...}`, so a null value renders strictly less markup than a set one.
The screen itself returns 200 with a null time.

## How to test?

Enterprise build required — maintenance mode for HTTP resources only exists in
`server/private`. Note that `updateResource` silently discards maintenance fields when
unlicensed, so set them via SQL rather than the UI.

Seed an exit node, then create an org, a `local` site, an HTTP resource
(`test.localhost`, SSL on) and one target at `127.0.0.1:8080`.

`GET localhost:3001/api/v1/traefik-config` returns the generated config. Check it for a
router whose `service` is absent from `http.services`, and for any service whose
`loadBalancer.servers` is `[]`.

**Automatic mode with a target the load balancer drops** — nulling `method` keeps the
target past the health filter but drops it from the load balancer, which is the gap
being fixed:

```sql
UPDATE resources SET maintenanceModeEnabled=1, maintenanceModeType='automatic' WHERE resourceId=1;
UPDATE sites SET online=1 WHERE siteId=1;
UPDATE targets SET method=NULL WHERE resourceId=1;
```

Before: `1-Test-service` has `servers: []` and there are no maintenance routers.
After: `1-maintenance-router` and `1-maintenance-router-assets` are present.

**Forced mode:**

```sql
UPDATE resources SET maintenanceModeEnabled=1, maintenanceModeType='forced' WHERE resourceId=1;
UPDATE targets SET method='http' WHERE resourceId=1;
```

Before: `1-Test-router-redirect` points at `1-Test-service`, which is not in
`http.services`. After: it points at `1-maintenance-service`, which exists.

**Regression:** with maintenance off and a healthy target, the generated config is
byte-identical before and after the change.
