### PR TITLE
perf(auth): make path-rule matching linear-time, fix deep-path rejection

### DIFF
--- a/server/lib/pathMatch.ts
+++ b/server/lib/pathMatch.ts
@@ -45,9 +45,14 @@ function decodeAndResolvePath(p: string): string[] {
     return resolved;
 }
 
-// Matches a request path against a rule pattern, segment by segment, where a
-// `*` segment matches zero or more path segments and a segment containing `*`
-// or `?` is matched as a per-segment glob (see `getSegmentRegex`).
+// Matches a request path against a rule pattern, segment by segment. A bare
+// `*` segment matches zero or more path segments. A segment that contains a
+// `*` (but isn't a bare `*`) is matched as a per-segment glob via
+// `getSegmentRegex`, where within that segment `*` matches any run of
+// characters and `?` matches a single character. A segment with no `*` is
+// compared literally, so a lone `?` is a literal `?` — this matches the
+// previous implementation's behavior exactly and is deliberate: making `?`
+// wildcard-match on its own would widen which paths an access rule covers.
 //
 // This is the classic "wildcard matching" problem. The previous
 // implementation expressed it as a doubly-recursive descent: on every `*`

--- a/server/lib/pathMatch.ts
+++ b/server/lib/pathMatch.ts
@@ -1,5 +1,3 @@
-const MAX_RECURSION_DEPTH = 100;
-
 const segmentRegexCache = new Map<string, RegExp>();
 
 function getSegmentRegex(patternPart: string): RegExp {
@@ -47,59 +45,76 @@ function decodeAndResolvePath(p: string): string[] {
     return resolved;
 }
 
+// Matches a request path against a rule pattern, segment by segment, where a
+// `*` segment matches zero or more path segments and a segment containing `*`
+// or `?` is matched as a per-segment glob (see `getSegmentRegex`).
+//
+// This is the classic "wildcard matching" problem. The previous
+// implementation expressed it as a doubly-recursive descent: on every `*`
+// segment it branched into "the star consumes this path segment" and "the
+// star matches nothing here" without remembering states it had already
+// visited. Because those branches overlap, a pattern with k `*` segments
+// against an n-segment path re-explored the same (patternIndex, pathIndex)
+// states an exponential number of times — O(2^n) in the worst case — and a
+// hard `MAX_RECURSION_DEPTH = 100` guard was needed just to stop it running
+// away, at the cost of silently rejecting any path deeper than 100 segments.
+//
+// Reframed as dynamic programming, `match(i, j)` = "can patternParts[i..]
+// match pathParts[j..]?" has only (patternParts.length + 1) x
+// (pathParts.length + 1) distinct states, so filling them bottom-up solves the
+// same problem in O(pattern x path) time with no recursion and no depth cap.
+// We keep only two rows at a time (row i depends solely on row i+1 and on the
+// already-computed column j+1 of row i), so memory is O(pathParts.length) —
+// itself bounded by the upstream URL parser — with no large per-request
+// allocation. Behavior is otherwise identical to the recursive version
+// (verified by fuzzing the two against each other over 500k random
+// pattern/path pairs), except that legitimately deep paths are no longer
+// wrongly rejected.
 export function isPathAllowed(pattern: string, path: string): boolean {
     const patternParts = pattern.split("/").filter(Boolean);
     const pathParts = decodeAndResolvePath(path);
 
-    function matchSegments(
-        patternIndex: number,
-        pathIndex: number,
-        depth: number = 0
-    ): boolean {
-        if (depth > MAX_RECURSION_DEPTH) {
-            return false;
-        }
+    const patternLen = patternParts.length;
+    const pathLen = pathParts.length;
 
-        const currentPatternPart = patternParts[patternIndex];
-        const currentPathPart = pathParts[pathIndex];
+    // `next[j]` holds match(i + 1, j); `curr[j]` is filled with match(i, j).
+    // Index `pathLen` is the "path fully consumed" column.
+    let next = new Array<boolean>(pathLen + 1).fill(false);
+    let curr = new Array<boolean>(pathLen + 1).fill(false);
 
-        if (patternIndex >= patternParts.length) {
-            return pathIndex >= pathParts.length;
-        }
+    // Base row (i === patternLen, pattern fully consumed): a match only when
+    // the path is also fully consumed.
+    next[pathLen] = true;
 
-        if (pathIndex >= pathParts.length) {
-            return patternParts.slice(patternIndex).every((p) => p === "*");
-        }
+    for (let i = patternLen - 1; i >= 0; i--) {
+        const patternPart = patternParts[i];
+        const isStar = patternPart === "*";
+        const isGlob = !isStar && patternPart.includes("*");
+        const segmentRegex = isGlob ? getSegmentRegex(patternPart) : null;
 
-        if (currentPatternPart === "*") {
-            if (matchSegments(patternIndex + 1, pathIndex, depth + 1)) {
-                return true;
+        // Path fully consumed but pattern is not: matches only if this and
+        // every remaining pattern segment is `*` (each may match zero).
+        curr[pathLen] = isStar && next[pathLen];
+
+        for (let j = pathLen - 1; j >= 0; j--) {
+            if (isStar) {
+                // `*` either matches nothing here (advance the pattern,
+                // next[j]) or consumes this path segment (advance the path,
+                // curr[j + 1]).
+                curr[j] = next[j] || curr[j + 1];
+            } else if (isGlob) {
+                curr[j] = segmentRegex!.test(pathParts[j]) && next[j + 1];
+            } else {
+                curr[j] = patternPart === pathParts[j] && next[j + 1];
             }
-            if (matchSegments(patternIndex, pathIndex + 1, depth + 1)) {
-                return true;
-            }
-            return false;
         }
 
-        if (currentPatternPart.includes("*")) {
-            const regex = getSegmentRegex(currentPatternPart);
-
-            if (regex.test(currentPathPart)) {
-                return matchSegments(
-                    patternIndex + 1,
-                    pathIndex + 1,
-                    depth + 1
-                );
-            }
-            return false;
-        }
-
-        if (currentPatternPart !== currentPathPart) {
-            return false;
-        }
-
-        return matchSegments(patternIndex + 1, pathIndex + 1, depth + 1);
+        // Row i becomes the "next" row for row i - 1; reuse the old buffer.
+        const swap = next;
+        next = curr;
+        curr = swap;
     }
 
-    return matchSegments(0, 0, 0);
+    // After the final swap, `next` holds row 0.
+    return next[0];
 }

--- a/server/routers/badger/verifySession.test.ts
+++ b/server/routers/badger/verifySession.test.ts
@@ -415,6 +415,21 @@ function runSpecialCharacterTests() {
         "Question mark should still act as a single-character wildcard"
     );
 
+    // A `?` only acts as a wildcard inside a segment that also contains `*`.
+    // On its own it is a literal `?`, matching the original implementation.
+    // This is deliberate: treating a lone `?` as a wildcard would widen which
+    // paths an access rule matches (e.g. `secret?` would match `secrets`).
+    assertEquals(
+        isPathAllowed("file?", "fileX"),
+        false,
+        "A lone ? (no * in the segment) is literal, not a single-char wildcard"
+    );
+    assertEquals(
+        isPathAllowed("file?", "file?"),
+        true,
+        "A lone ? matches a literal ? in the path"
+    );
+
     assertEquals(
         isPathAllowed("api/*", "api/" + "x/".repeat(50)),
         true,

--- a/server/routers/badger/verifySession.test.ts
+++ b/server/routers/badger/verifySession.test.ts
@@ -268,6 +268,44 @@ function runTests() {
         "Single-dot segments are a no-op and should not affect matching"
     );
 
+    // Multiple consecutive `*` segments: the matcher must still be correct
+    // (these are the patterns that previously triggered exponential-time
+    // backtracking before the switch to dynamic programming).
+    assertEquals(
+        isPathAllowed("*/*/*", "a/b/c"),
+        true,
+        "Three star segments should match a three-segment path"
+    );
+    assertEquals(
+        isPathAllowed("*/*/*/end", "a/b/c/d/e/end"),
+        true,
+        "Leading star segments should absorb extra path segments before a literal tail"
+    );
+    assertEquals(
+        isPathAllowed("*/*/*/*/*/ZZZ", "a/b/c/d/e/f/g"),
+        false,
+        "A many-star pattern must still reject a path missing its literal tail"
+    );
+    assertEquals(
+        isPathAllowed("a/*/*/b", "a/x/b"),
+        true,
+        "Interior star segments may each match zero path segments"
+    );
+
+    // Paths deeper than the old MAX_RECURSION_DEPTH (100) must now match
+    // correctly instead of being silently rejected by the recursion guard.
+    const deepTail = Array.from({ length: 150 }, (_, i) => `s${i}`).join("/");
+    assertEquals(
+        isPathAllowed("api/*", `api/${deepTail}`),
+        true,
+        "A legitimately deep path (>100 segments) under a wildcard should match"
+    );
+    assertEquals(
+        isPathAllowed("api/*/x", `api/${deepTail}/x`),
+        true,
+        "Deep paths should also match patterns with a literal tail after the star"
+    );
+
     console.log("All path matching tests passed!");
 }
 


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## AI Disclosure

Claude Code (Anthropic) was used throughout: to analyze the matcher, write the dynamic-programming rewrite and the new tests, and build/run the equivalence fuzzer and the before/after benchmark below. I directed the work and verified every result myself — including fuzzing the new implementation against the old one over 500k random inputs to confirm identical behavior before committing.

## Description

### Summary

`isPathAllowed` in `server/lib/pathMatch.ts` decides whether a request path matches a resource's path rule. It runs on the badger authorization path (`server/routers/badger/verifySession.ts` → `checkRules`), i.e. for **every proxied HTTP request** that has path rules configured.

It matched patterns with a doubly-recursive descent. On each `*` segment it branched two ways — "the star consumes this path segment" and "the star matches nothing here" — **without memoizing** which `(patternIndex, pathIndex)` states it had already visited. Those branches overlap, so a pattern with *k* wildcard segments against an *n*-segment path re-explores the same states an exponential number of times — **O(2ⁿ)** in the worst case.

A `MAX_RECURSION_DEPTH = 100` guard existed only to stop that runaway recursion. As a side effect it **silently rejected any path deeper than 100 segments**, even when the path legitimately matched the rule.

### What changed

Reframed the matcher as the standard wildcard-matching **dynamic program**: `match(i, j)` = "can `patternParts[i..]` match `pathParts[j..]`?". There are only `(pattern+1) × (path+1)` distinct states, so filling them bottom-up is **O(pattern × path)** with no recursion and no depth cap.

- Only **two rows** are kept at a time (row *i* depends solely on row *i+1* and the already-computed column *j+1* of row *i*), so memory is **O(path length)** — itself bounded by the upstream URL parser — with no large per-request allocation.
- The `MAX_RECURSION_DEPTH` guard is removed. It's no longer needed to bound work, and removing it fixes the deep-path false rejection.
- Behavior is otherwise **identical** to the previous implementation (see verification).

Only `server/lib/pathMatch.ts` (logic) and `server/routers/badger/verifySession.test.ts` (added assertions) change.

### Why this helps

1. **Removes an exponential-time path on the request hot path.** The pattern comes from admin config, but the path comes from the request, so an admin rule with several consecutive `*` segments could make an ordinary request cost tens of milliseconds of synchronous CPU on the single Node event loop — stalling *every* concurrent request, not just that one. After this change the cost is linear and flat.
2. **Fixes a real correctness bug.** Paths deeper than 100 segments under a wildcard rule were wrongly rejected. They now match correctly.
3. **No regression for normal rules.** Realistic patterns (`api/*`, `assets/*.png`, exact literals) are unchanged to slightly faster.

### How this was verified

**Behavioral equivalence — 500,000 random inputs, zero differences.** I kept a verbatim copy of the old implementation and fuzzed it against the new one over 500k random `(pattern, path)` pairs (drawn from literals, `*`, mid-segment globs like `x*`/`*y`, `?`, `.`/`..` traversal, `%2F` encoded slashes, and regex-metacharacter segments), within the depth-cap range where the two must agree exactly:

```
=== 1. EQUIVALENCE FUZZ (500k random inputs, depth < cap) ===
  checked=500000  mismatches=0  IDENTICAL
```

All existing `isPathAllowed` assertions in `verifySession.test.ts` continue to pass unchanged.

### Before / after (measured on my machine, best-of-5 median)

**Pathological case** — pattern `*/*/*/*/*/ZZZ` (5 wildcard segments), against an N-segment request path that never matches:

| path segments | before | after | speedup |
|---|---|---|---|
| 10 | 0.24 ms | 0.006 ms | ~41× |
| 15 | 1.14 ms | 0.011 ms | ~100× |
| 20 | 2.40 ms | 0.016 ms | ~153× |
| 25 | 10.3 ms | 0.019 ms | ~533× |
| 30 | 21.4 ms | 0.017 ms | **~1280×** |

The "before" column is the exponential blowup; "after" is flat (linear), as expected.

**No regression** — realistic rules and paths (100k iterations each):

| case | before | after |
|---|---|---|
| exact literal (`api/v1/users`) | 0.0035 ms | 0.0022 ms |
| single trailing `*` (`api/*`, 20 seg) | 0.0142 ms | 0.0126 ms |
| deep single `*` (`api/*`, 80 seg) | 0.0354 ms | 0.0200 ms |
| mid glob segment (`assets/*.png`) | 0.0012 ms | 0.0009 ms |
| literal miss, early (`admin/panel` vs `public/home`) | 0.0011 ms | 0.0019 ms |
| two wildcards (`api/*/settings`) | 0.0035 ms | 0.0027 ms |

Every realistic case is unchanged or faster except an early literal mismatch, which is ~0.8 µs slower because the DP fills its (tiny) table rather than early-returning on the first mismatched segment — negligible on a path already dominated by DB work, and far outweighed by removing the exponential case.

**Correctness — deep path that the old code wrongly rejected:**

```
pattern="api/*", path="api/<150 segments>"
  before (depth-capped) => false   (wrongly rejected)
  after  (dp, no cap)   => true    (correct)
```

## How to test?

1. `npx tsx server/routers/badger/verifySession.test.ts` — the full existing suite plus the new assertions (multi-wildcard patterns and >100-segment paths) pass.
2. `npx tsc --noEmit` and `npx eslint server/lib/pathMatch.ts` — both clean.
3. To see the blowup for yourself on `main`: call `isPathAllowed("*/*/*/*/*/ZZZ", "s0/s1/…/s29")` (30 segments) in a loop and time it — it takes ~20 ms/call before this change, ~0.02 ms after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
